### PR TITLE
Only import GdkX11 when available

### DIFF
--- a/terminatorlib/keybindings.py
+++ b/terminatorlib/keybindings.py
@@ -40,7 +40,7 @@ class Keybindings:
         'alt':      Gdk.ModifierType.MOD1_MASK,
         'super':    Gdk.ModifierType.SUPER_MASK,
         'hyper':    Gdk.ModifierType.HYPER_MASK,
-	'mod2':	    Gdk.ModifierType.MOD2_MASK
+        'mod2':	    Gdk.ModifierType.MOD2_MASK
     }
 
     empty = {}

--- a/terminatorlib/keybindings.py
+++ b/terminatorlib/keybindings.py
@@ -40,6 +40,7 @@ class Keybindings:
         'alt':      Gdk.ModifierType.MOD1_MASK,
         'super':    Gdk.ModifierType.SUPER_MASK,
         'hyper':    Gdk.ModifierType.HYPER_MASK,
+	'mod2':	    Gdk.ModifierType.MOD2_MASK
     }
 
     empty = {}

--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -6,7 +6,7 @@ import copy
 import os
 import gi
 gi.require_version('Vte', '2.91')
-from gi.repository import Gtk, Gdk, Vte, GdkX11
+from gi.repository import Gtk, Gdk, Vte
 from gi.repository.GLib import GError
 
 from . import borg
@@ -17,6 +17,12 @@ from .util import dbg, err, enumerate_descendants
 from .factory import Factory
 from .cwd import get_pid_cwd
 from .version import APP_NAME, APP_VERSION
+
+try:
+    from gi.repository import GdkX11
+except ImportError:
+    dbg("could not import X11 gir module")
+
 
 def eventkey2gdkevent(eventkey):  # FIXME FOR GTK3: is there a simpler way of casting from specific EventKey to generic (union) GdkEvent?
     gdkevent = Gdk.Event.new(eventkey.type)

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -7,16 +7,22 @@ import time
 import uuid
 import gi
 from gi.repository import GObject
-from gi.repository import Gtk, Gdk, GdkX11
+from gi.repository import Gtk, Gdk
 
 from .util import dbg, err, make_uuid, display_manager
+
+try:
+    from gi.repository import GdkX11
+except ImportError:
+    dbg("could not import X11 gir module")
+
+
 from . import util
 from .translation import _
 from .version import APP_NAME
 from .container import Container
 from .factory import Factory
 from .terminator import Terminator
-
 if display_manager() == 'X11':
     try:
         gi.require_version('Keybinder', '3.0')


### PR DESCRIPTION
This is so that terminator will run natively on MacOS using the quartz backend, rather than requiring the X11 backend. 
