### PR TITLE
Remove obsolete terminator.wrapper

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include AUTHORS CHANGELOG* COPYING INSTALL README* remotinator setup.py terminator terminator.wrapper run_tests
+include AUTHORS CHANGELOG* COPYING INSTALL README* remotinator setup.py terminator run_tests
 recursive-include data *
 recursive-include doc *
 recursive-include po *

--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,6 @@ setup(name=APP_NAME,
       license='GNU GPL v2',
       scripts=['terminator', 'remotinator'],
       data_files=[
-                  ('bin', ['terminator.wrapper']),
                   ('share/appdata', ['data/terminator.appdata.xml']),
                   ('share/applications', ['data/terminator.desktop']),
                   (os.path.join(man_dir, 'man1'), ['doc/terminator.1']),

--- a/terminator.wrapper
+++ b/terminator.wrapper
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-terminator $@
-


### PR DESCRIPTION
We don't really need this file, if one needs to wrap the binary they could use `$HOME/bin/terminator`

Anyone thoughts on this?