### PR TITLE
fix exception when feeding terminal number to terminal

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1538,7 +1538,7 @@ class Terminal(Gtk.VBox):
 
     def feed(self, text):
         """Feed the supplied text to VTE"""
-        self.vte.feed_child(text, len(text))
+        self.vte.feed_child_binary(text.encode(self.vte.get_encoding()))
 
     def zoom_in(self):
         """Increase the font size"""


### PR DESCRIPTION
It's a weird feature that I've never heard of but in the titlebar menu in the top left corner there's two menu items "Insert terminal number" and "Insert padded terminal number".  These were not previously working and would just put the following to stdout.  This PR fixes this issue.

```
Traceback (most recent call last):
  File "/home/mattrose/Code/terminator/terminatorlib/terminator.py", line 642, in do_enumerate
    term.feed(numstr % (idx + 1))
  File "/home/mattrose/Code/terminator/terminatorlib/terminal.py", line 1541, in feed
    self.vte.feed_child(text, len(text))
TypeError: Vte.Terminal.feed_child() takes exactly 2 arguments (3 given)
```