### PR TITLE
#38: Add option for configuring bold-is-bright setting of VTE

### DIFF
--- a/doc/terminator_config.5
+++ b/doc/terminator_config.5
@@ -370,6 +370,10 @@ Default value: \fBFalse\fR
 If true, ignore the configured colours and use values from the theme instead.
 Default value: \fBFalse\fR
 .TP
+.B bold_is_bright
+If true, show bold text with increased brightness. If false, then text boldness can be controlled by applications independently from the text brightness.
+Default value: \fBFalse\fR
+.TP
 .B background_color
 Default colour of terminal background, as a colour specification (can be HTML-style hex digits, or a colour name such as "red"). \fBNote:\fR You may need to set \fBuse_theme_colors=False\fR to force this setting to take effect.
 Default value: \fB'#000000'\fR

--- a/po/af.po
+++ b/po/af.po
@@ -1027,6 +1027,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -1024,6 +1024,10 @@ msgstr "_لوح الألوان:"
 msgid "Colors"
 msgstr "اﻷلوان"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "لون _جامد"

--- a/po/ast.po
+++ b/po/ast.po
@@ -1028,6 +1028,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/az.po
+++ b/po/az.po
@@ -1026,6 +1026,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -1023,6 +1023,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -1031,6 +1031,10 @@ msgstr "_Цветова палитра:"
 msgid "Colors"
 msgstr "Цветове"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Плътен цвят"

--- a/po/bn.po
+++ b/po/bn.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/bs.po
+++ b/po/bs.po
@@ -1044,6 +1044,10 @@ msgstr "Paleta boja:"
 msgid "Colors"
 msgstr "Boje"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "Neprozirno"

--- a/po/ca.po
+++ b/po/ca.po
@@ -1051,6 +1051,10 @@ msgstr "_Paleta de colors:"
 msgid "Colors"
 msgstr "Colors"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "Color _sòlid"

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -1029,6 +1029,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -1050,7 +1050,7 @@ msgstr "Barvy"
 
 #: ../terminatorlib/preferences.glade.h:114
 msgid "Show b_old text in bright colors"
-msgstr ""
+msgstr "Z_obrazovat tučný text jasnými barvami"
 
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1048,6 +1048,10 @@ msgstr "P_aleta barev:"
 msgid "Colors"
 msgstr "Barvy"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Jednolitá barva"

--- a/po/da.po
+++ b/po/da.po
@@ -1041,6 +1041,10 @@ msgstr "Farvep_alet:"
 msgid "Colors"
 msgstr "Farver"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Ensfarvet"

--- a/po/de.po
+++ b/po/de.po
@@ -1057,6 +1057,10 @@ msgstr "Farb_palette:"
 msgid "Colors"
 msgstr "Farben"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Einfarbig"

--- a/po/el.po
+++ b/po/el.po
@@ -1040,6 +1040,10 @@ msgstr "Πα_λέτα χρωμάτων:"
 msgid "Colors"
 msgstr "Χρώματα"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Συμπαγές χρώμα"

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -1039,6 +1039,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -1026,6 +1026,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1043,6 +1043,10 @@ msgstr "Colour p_alette:"
 msgid "Colors"
 msgstr "Colours"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Solid colour"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1045,7 +1045,7 @@ msgstr "Colours"
 
 #: ../terminatorlib/preferences.glade.h:114
 msgid "Show b_old text in bright colors"
-msgstr ""
+msgstr "Show b_old text in bright colours"
 
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"

--- a/po/eo.po
+++ b/po/eo.po
@@ -1024,6 +1024,10 @@ msgstr "Kolorp_aletro:"
 msgid "Colors"
 msgstr "Koloroj"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -1056,6 +1056,10 @@ msgstr "P_aleta de colores:"
 msgid "Colors"
 msgstr "Colores"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "Color _sólido"

--- a/po/et.po
+++ b/po/et.po
@@ -1026,6 +1026,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -1030,6 +1030,10 @@ msgstr "Kolore-_paleta:"
 msgid "Colors"
 msgstr "Koloreak"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Kolore solidoa"

--- a/po/fa.po
+++ b/po/fa.po
@@ -1029,6 +1029,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -1030,6 +1030,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/fo.po
+++ b/po/fo.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -1056,6 +1056,10 @@ msgstr "P_alette de couleurs :"
 msgid "Colors"
 msgstr "Couleurs"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "Couleur _unie"

--- a/po/fy.po
+++ b/po/fy.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -1027,6 +1027,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -1028,6 +1028,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -1031,6 +1031,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/hy.po
+++ b/po/hy.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ia.po
+++ b/po/ia.po
@@ -1026,6 +1026,10 @@ msgstr ""
 msgid "Colors"
 msgstr "Colores"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -1041,6 +1041,10 @@ msgstr "P_alet warna:"
 msgid "Colors"
 msgstr "Warna"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "warna _Solid"

--- a/po/is.po
+++ b/po/is.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -1035,6 +1035,10 @@ msgstr "Tavolo_zza dei colori:"
 msgid "Colors"
 msgstr "Colori"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Tinta unita"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1024,6 +1024,10 @@ msgstr "カラーパレット(_a):"
 msgid "Colors"
 msgstr "色"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "単色(_S)"

--- a/po/jv.po
+++ b/po/jv.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -1026,6 +1026,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/kk.po
+++ b/po/kk.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -1024,6 +1024,10 @@ msgstr "색상표(_A)"
 msgid "Colors"
 msgstr "색상"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "단색(_S)"

--- a/po/ku.po
+++ b/po/ku.po
@@ -1023,6 +1023,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/la.po
+++ b/po/la.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -1027,6 +1027,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/mk.po
+++ b/po/mk.po
@@ -1026,6 +1026,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ml.po
+++ b/po/ml.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ms.po
+++ b/po/ms.po
@@ -1042,6 +1042,10 @@ msgstr "Warna p_alet:"
 msgid "Colors"
 msgstr "Warna"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "Warna _tegar"

--- a/po/nb.po
+++ b/po/nb.po
@@ -1031,6 +1031,10 @@ msgstr "Fargep_alett:"
 msgid "Colors"
 msgstr "Farger"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Helfylt farge"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1045,6 +1045,10 @@ msgstr "Kleuren_palet:"
 msgid "Colors"
 msgstr "Kleuren"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Effen kleur"

--- a/po/nn.po
+++ b/po/nn.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/oc.po
+++ b/po/oc.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -1048,6 +1048,10 @@ msgstr "Paleta _kolorów:"
 msgid "Colors"
 msgstr "Kolory"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Jednolity kolor"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1045,6 +1045,10 @@ msgstr "P_aleta de cores:"
 msgid "Colors"
 msgstr "Cores"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "Cor _sólida"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1044,6 +1044,10 @@ msgstr "_Paleta de cores:"
 msgid "Colors"
 msgstr "Cores"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Cor Sólida"

--- a/po/ro.po
+++ b/po/ro.po
@@ -1039,6 +1039,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -1050,6 +1050,10 @@ msgstr "Цветовая _палитра:"
 msgid "Colors"
 msgstr "Цвета"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Сплошной цвет"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -1044,6 +1044,10 @@ msgstr "Paleta _farieb:"
 msgid "Colors"
 msgstr "Farby"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Plná farba"

--- a/po/sl.po
+++ b/po/sl.po
@@ -1028,6 +1028,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -1027,6 +1027,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/su.po
+++ b/po/su.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -1040,6 +1040,10 @@ msgstr "Färgp_alett:"
 msgid "Colors"
 msgstr "Färger"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "_Enfärgad"

--- a/po/sw.po
+++ b/po/sw.po
@@ -1028,6 +1028,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -1033,6 +1033,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/terminator.pot
+++ b/po/terminator.pot
@@ -1023,6 +1023,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -1035,6 +1035,10 @@ msgstr ""
 msgid "Colors"
 msgstr "Renkler"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/tyv.po
+++ b/po/tyv.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -1023,6 +1023,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -1032,6 +1032,10 @@ msgstr "Кольорова палітра:"
 msgid "Colors"
 msgstr "Кольори"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "Су_цільний  колір"

--- a/po/ur.po
+++ b/po/ur.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/wa.po
+++ b/po/wa.po
@@ -1023,6 +1023,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1033,6 +1033,10 @@ msgstr "调色板(_A)："
 msgid "Colors"
 msgstr "色彩"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "纯色(_S)"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -1024,6 +1024,10 @@ msgstr ""
 msgid "Colors"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1032,6 +1032,10 @@ msgstr "調色盤(_A)："
 msgid "Colors"
 msgstr "色彩"
 
+#: ../terminatorlib/preferences.glade.h:114
+msgid "Show b_old text in bright colors"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:115
 msgid "_Solid color"
 msgstr "固定顏色(_S)"

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -232,6 +232,7 @@ DEFAULTS = {
                 'custom_command'        : '',
                 'use_system_font'       : True,
                 'use_theme_colors'      : False,
+                'bold_is_bright'        : False,
                 'encoding'              : 'UTF-8',
                 'active_encodings'      : ['UTF-8', 'ISO-8859-1'],
                 'focus_on_close'        : 'auto',

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -2639,6 +2639,24 @@
                                         <property name="top_attach">1</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="bold_text_is_bright_checkbutton">
+                                        <property name="label" translatable="yes">Show b_old text in bright colors</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="xalign">0.5</property>
+                                        <property name="draw_indicator">True</property>
+                                        <signal name="toggled" handler="on_bold_text_is_bright_checkbutton_toggled" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">2</property>
+                                        <property name="width">2</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                               </object>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -516,6 +516,9 @@ class PrefsEditor:
         # Use system colors
         widget = guiget('use_theme_colors_checkbutton')
         widget.set_active(self.config['use_theme_colors'])
+        # Bold is bright
+        widget = guiget('bold_text_is_bright_checkbutton')
+        widget.set_active(self.config['bold_is_bright'])
         # Colorscheme
         widget = guiget('color_scheme_combobox')
         scheme = None
@@ -1498,6 +1501,11 @@ class PrefsEditor:
             self.on_color_scheme_combobox_changed(scheme)
 
         self.config['use_theme_colors'] = active
+        self.config.save()
+
+    def on_bold_text_is_bright_checkbutton_toggled(self, widget):
+        """Bold-is-bright setting changed"""
+        self.config['bold_is_bright'] = widget.get_active()
         self.config.save()
 
     def on_cellrenderer_accel_edited(self, liststore, path, key, mods, _code):

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -701,6 +701,9 @@ class Terminal(Gtk.VBox):
             except:
                 pass
         self.vte.set_allow_bold(self.config['allow_bold'])
+        if hasattr(self.vte, 'set_bold_is_bright'):
+            self.vte.set_bold_is_bright(self.config['bold_is_bright'])
+
         if self.config['use_theme_colors']:
             self.fgcolor_active = self.vte.get_style_context().get_color(Gtk.StateType.NORMAL)  # VERIFY FOR GTK3: do these really take the theme colors?
             self.bgcolor = self.vte.get_style_context().get_background_color(Gtk.StateType.NORMAL)


### PR DESCRIPTION
This PR implements the suggested bold-is-bright checkbox.

Appearance:
![Settings UI](https://user-images.githubusercontent.com/6003171/80288183-835b3d80-8736-11ea-9c11-e532ab734af4.png)

Fixes https://github.com/gnome-terminator/terminator/issues/38