### PR TITLE
Add layout launcher to terminal popup menu.

### DIFF
--- a/terminatorlib/terminal_popup_menu.py
+++ b/terminatorlib/terminal_popup_menu.py
@@ -13,6 +13,7 @@ from .util import err, dbg
 from .config import Config
 from .prefseditor import PrefsEditor
 from . import plugin
+from layoutlauncher import LayoutLauncher
 
 class TerminalPopupMenu(object):
     """Class implementing the Terminal context menu"""
@@ -211,6 +212,7 @@ class TerminalPopupMenu(object):
                 submenu.append(item)
 
         self.add_encoding_items(menu)
+        self.add_layout_launcher(menu)
 
         try:
             menuitems = []
@@ -233,6 +235,11 @@ class TerminalPopupMenu(object):
 
         return(True)
 
+    def add_layout_launcher(self, menu):
+        """Add the layout list to the menu"""
+        item = Gtk.MenuItem.new_with_mnemonic(_('_Layouts...'))
+        item.connect('activate', lambda x: LayoutLauncher())
+        menu.append(item)
 
     def add_encoding_items(self, menu):
         """Add the encoding list to the menu"""

--- a/terminatorlib/terminal_popup_menu.py
+++ b/terminatorlib/terminal_popup_menu.py
@@ -13,7 +13,7 @@ from .util import err, dbg
 from .config import Config
 from .prefseditor import PrefsEditor
 from . import plugin
-from layoutlauncher import LayoutLauncher
+from .layoutlauncher import LayoutLauncher
 
 class TerminalPopupMenu(object):
     """Class implementing the Terminal context menu"""
@@ -306,4 +306,3 @@ class TerminalPopupMenu(object):
             radioitem.connect ('activate', terminal.on_encoding_change, 
                                encoding[1])
             submenu.append (radioitem)
-


### PR DESCRIPTION
I often want to launch a layout, but can't remember what the keyboard shortcut is. This patch adds it to the right-click popup menu.

Older patch on Launchpad:

https://bugs.launchpad.net/terminator/+bug/1800735