### PR TITLE
Added option to disable ctrl+mousewheel zoom

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -118,7 +118,6 @@ DEFAULTS = {
             'title_font'            : 'Sans 9',
             'putty_paste_style'     : False,
             'smart_copy'            : True,
-            'disable_mousewheel_zoom': False,
         },
         'keybindings': {
             'zoom_in'          : '<Control>plus',
@@ -222,6 +221,7 @@ DEFAULTS = {
                 'scroll_on_output'      : False,
                 'scrollback_lines'      : 500,
                 'scrollback_infinite'   : False,
+                'disable_mousewheel_zoom': False,
                 'exit_action'           : 'close',
                 'palette'               : '#2e3436:#cc0000:#4e9a06:#c4a000:\
 #3465a4:#75507b:#06989a:#d3d7cf:#555753:#ef2929:#8ae234:#fce94f:\

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -118,6 +118,7 @@ DEFAULTS = {
             'title_font'            : 'Sans 9',
             'putty_paste_style'     : False,
             'smart_copy'            : True,
+            'disable_mousewheel_zoom': False,
         },
         'keybindings': {
             'zoom_in'          : '<Control>plus',

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -552,6 +552,24 @@
                                     <property name="width">2</property>
                                   </packing>
                                 </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="disablemousewheelzoom">
+                                    <property name="label" translatable="yes">Disable Ctrl+mousewheel zoom</property>
+                                    <property name="use_action_appearance">False</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="xalign">0.5</property>
+                                    <property name="active">True</property>
+                                    <property name="draw_indicator">True</property>
+                                    <signal name="toggled" handler="on_disable_mousewheel_zoom_toggled" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">7</property>
+                                    <property name="width">2</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">True</property>

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -552,24 +552,6 @@
                                     <property name="width">2</property>
                                   </packing>
                                 </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="disablemousewheelzoom">
-                                    <property name="label" translatable="yes">Disable Ctrl+mousewheel zoom</property>
-                                    <property name="use_action_appearance">False</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="xalign">0.5</property>
-                                    <property name="active">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <signal name="toggled" handler="on_disable_mousewheel_zoom_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">0</property>
-                                    <property name="top_attach">7</property>
-                                    <property name="width">2</property>
-                                  </packing>
-                                </child>
                               </object>
                               <packing>
                                 <property name="expand">True</property>
@@ -1645,6 +1627,23 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="disablemousewheelzoom">
+                                <property name="label" translatable="yes">Disable Ctrl+mousewheel zoom</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="xalign">0.5</property>
+                                <property name="draw_indicator">True</property>
+                                <signal name="toggled" handler="on_disable_mousewheel_zoom_toggled" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">6</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkBox" id="word_chars_hbox">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -1682,7 +1681,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">6</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                           </object>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -286,6 +286,9 @@ class PrefsEditor:
         else:
             active = 1
         widget.set_active(active)
+        # Disable Ctrl+mousewheel zoom
+        widget = guiget('disablemousewheelzoom')
+        widget.set_active(self.config['disable_mousewheel_zoom'])
         # scroll_tabbar
         widget = guiget('scrolltabbarcheck')
         widget.set_active(self.config['scroll_tabbar'])
@@ -693,6 +696,11 @@ class PrefsEditor:
     def on_dbuscheck_toggled(self, widget):
         """DBus server setting changed"""
         self.config['dbus'] = widget.get_active()
+        self.config.save()
+
+    def on_disable_mousewheel_zoom_toggled(self, widget):
+        """Ctrl+mousewheel zoom setting changed"""
+        self.config['disable_mousewheel_zoom'] = widget.get_active()
         self.config.save()
 
     def on_winbordercheck_toggled(self, widget):

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -972,12 +972,13 @@ class Terminal(Gtk.VBox):
 
     def on_mousewheel(self, widget, event):
         """Handler for modifier + mouse wheel scroll events"""
-        if self.config["disable_mousewheel_zoom"] is True:
-            return (True)
         SMOOTH_SCROLL_UP = event.direction == Gdk.ScrollDirection.SMOOTH and event.delta_y <= 0.
         SMOOTH_SCROLL_DOWN = event.direction == Gdk.ScrollDirection.SMOOTH and event.delta_y > 0.
         if event.state & Gdk.ModifierType.CONTROL_MASK == Gdk.ModifierType.CONTROL_MASK:
-            # Ctrl + mouse wheel up/down with Shift and Super additions
+            # Zoom the terminal(s) in or out if not disabled in config
+            if self.config["disable_mousewheel_zoom"] is True:
+                return (False)
+            # Choice of target terminals depends on Shift and Super modifiers
             if event.state & Gdk.ModifierType.MOD4_MASK == Gdk.ModifierType.MOD4_MASK:
                 targets=self.terminator.terminals
             elif event.state & Gdk.ModifierType.SHIFT_MASK == Gdk.ModifierType.SHIFT_MASK:

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -972,6 +972,8 @@ class Terminal(Gtk.VBox):
 
     def on_mousewheel(self, widget, event):
         """Handler for modifier + mouse wheel scroll events"""
+        if self.config["disable_mousewheel_zoom"] is True:
+            return (True)
         SMOOTH_SCROLL_UP = event.direction == Gdk.ScrollDirection.SMOOTH and event.delta_y <= 0.
         SMOOTH_SCROLL_DOWN = event.direction == Gdk.ScrollDirection.SMOOTH and event.delta_y > 0.
         if event.state & Gdk.ModifierType.CONTROL_MASK == Gdk.ModifierType.CONTROL_MASK:


### PR DESCRIPTION
Addressing the longstanding <kbd>Ctrl+scroll</kbd> zoom in/out issue, as expressed in these old requests
- https://bugs.launchpad.net/terminator/+bug/1505292
- https://bugs.launchpad.net/terminator/+bug/1638607

## What problem does this PR solve?
Some laptop users (including myself) often bump the trackpad while holding <kbd>Ctrl</kbd>, which results in the terminal drastically zooming in and out (it's super sensitive).

The usual fix to get around this was to press <kbd>Ctrl+0</kbd> to reset the zoom everytime it happened, but this often fails to restore the original symmetry among split windows in apps like `vim` and `tmux`.

Needless to say, it's also annoying having to reset zoom scale so often.

## What this PR does
- Adds a checkbox to the `Profiles > General` section of terminator preferences
- If checked, don't run the <kbd>Ctrl+mousewheel</kbd> signal handler that's responsible for zooming the terminal in and out
- keyboard bindings for zooming still work
---
Thanks for taking over maintenance :) Cool to see this project active again!