### PR TITLE
fix up language strings in .po files

### DIFF
--- a/po/ckb.po
+++ b/po/ckb.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:39+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: ckb.po\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:39+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: en_AU\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:39+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: en_CA\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:39+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: en_GB\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/es.po
+++ b/po/es.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:39+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: es\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/fy.po
+++ b/po/fy.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:38+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: fy\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/nl.po
+++ b/po/nl.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:38+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: nl\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/oc.po
+++ b/po/oc.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:38+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: oc\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:39+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: ru_RU\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/si.po
+++ b/po/si.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:39+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: si\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/tyv.po
+++ b/po/tyv.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:39+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: tyv\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:39+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: zh_CN\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Launchpad-Export-Date: 2020-03-24 06:39+0000\n"
 "X-Generator: Launchpad (build 3a6db24bbe7280ec09bae73384238390fcc98ad3)\n"
-"Language: \n"
+"Language: zh_TW\n"
 
 #. Command         uuid req.    Description
 #: ../remotinator.py:38


### PR DESCRIPTION
So, some of the language files (I think the oldest ones from the early 2000s) have an empty "Language:" section of the .po file.  msgfmt deals with this just fine, but the library I'm planning to replace it with (Babel) doesn't deal with that, and throws an exception

  File "/usr/local/lib/python3.8/site-packages/babel/core.py", line 1094, in parse_locale
    raise ValueError('expected only letters, got %r' % lang)
