### PR TITLE
Fix layout launcher error

### DIFF
--- a/terminator
+++ b/terminator
@@ -68,6 +68,9 @@ if __name__ == '__main__':
   
     OPTIONS = terminatorlib.optionparse.parse_options()
 
+    TERMINATOR = Terminator()
+    TERMINATOR.set_origcwd(ORIGCWD)
+
     if OPTIONS.select:
         # launch gui, return selection
         LAYOUTLAUNCHER=LayoutLauncher()
@@ -112,8 +115,6 @@ if __name__ == '__main__':
             pass
 
         MAKER = Factory()
-        TERMINATOR = Terminator()
-        TERMINATOR.set_origcwd(ORIGCWD)
         TERMINATOR.set_dbus_data(dbus_service)
         TERMINATOR.reconfigure()
         TERMINATOR.ibus_running = ibus_running


### PR DESCRIPTION
The layout launcher crashing with an error upon attempting to select a layout.

```
$ ./terminator -s
```

![Terminator-Session-Launcher-Small](https://user-images.githubusercontent.com/6560620/81200565-81954380-8f9a-11ea-9d6b-cb81d6cc4ea3.png)

Then select a layout, and this crash happens:

```
Traceback (most recent call last):
  File "/home/fernando/Projects/terminator/terminatorlib/layoutlauncher.py", line 87, in on_row_activated
	self.launch_layout()
  File "/home/fernando/Projects/terminator/terminatorlib/layoutlauncher.py", line 100, in launch_layout
	spawn_new_terminator(self.terminator.origcwd, ['-u', '-l', layout])
  File "/home/fernando/Projects/terminator/terminatorlib/util.py", line 335, in spawn_new_terminator
	cmd = os.path.join (cwd, sys.argv[0])
  File "/usr/lib/python3.8/posixpath.py", line 76, in join
	a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

‘LayoutLauncher’ needs to know the current working directory, which as being passed as ‘None’ to `spawn_new_terminator()` in the `terminatorlib/layoutlauncher.py` . This commit fixes it by setting the current directory unconditionally so it is always available throughout the application.

**NOTE**: It only happens when invoking the layout launcher with the `-s` option as shown above. It works fine if we open the layout launcher with `Alt-l` _after_ Terminator is already running.