### PR TITLE
Make LayoutLauncher window a little larger by default

### DIFF
--- a/terminatorlib/layoutlauncher.glade
+++ b/terminatorlib/layoutlauncher.glade
@@ -25,10 +25,10 @@
                 <property name="can_focus">True</property>
                 <property name="hscrollbar_policy">never</property>
                 <property name="vscrollbar_policy">automatic</property>
+                <property name="width_request">250</property>
+                <property name="height_request">250</property>
                 <child>
                   <object class="GtkTreeView" id="layoutlist">
-                    <property name="width_request">150</property>
-                    <property name="height_request">200</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="model">layoutstore</property>


### PR DESCRIPTION
The Layout Launcher initial window is too small, especially the height.

![Terminator-Session-Launcher-Small](https://user-images.githubusercontent.com/6560620/81204754-10588f00-8fa0-11ea-85ab-91ff1e41c55c.png)

This commit makes it a little larger by default:

![Terminator-Session-Launcher-Larger](https://user-images.githubusercontent.com/6560620/81204768-18183380-8fa0-11ea-9271-84806248e13b.png)
