### PR TITLE
Propagate tab-swictch events if there is only one tab

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -885,6 +885,20 @@ class Terminal(Gtk.VBox):
         # FIXME: Does keybindings really want to live in Terminator()?
         mapping = self.terminator.keybindings.lookup(event)
 
+        # Just propagate tab-swictch events if there is only one tab
+        if (
+                mapping and (
+                    mapping.startswith('switch_to_tab') or
+                    mapping in ('next_tab', 'prev_tab')
+                )
+        ):
+            window = self.get_toplevel()
+            child = window.get_children()[0]
+            if isinstance(child, Terminal):
+                # not a Notebook instance => a single tab is used
+                # .get_n_pages() can not be used
+                return(False)
+
         if mapping == "hide_window":
             return(False)
 


### PR DESCRIPTION
If there is only one active tab, terminator should not consume tab-select events.
Those should instead be propagated, so they can be used by other programs "further down the line". Tab switch keybindings are often shared with terminal programs like WeeChat and irssi that also implement tabs.
