### PR TITLE
Update AUTHORS with a full list from GIT history

### DIFF
--- a/.authors.footer
+++ b/.authors.footer
@@ -1,0 +1,25 @@
+
+## Other contributors
+
+People that contributed to Terminator in other ways.
+
+* Huang He
+* Chris Oattes
+* Nicolas Roman
+* Takao Fujiwara
+* Jordan Callicoat
+
+# Artwork
+
+* Cory Kontros - Produced our current icon under the CC-by-SA licence
+* Cristian Grada - Drew our original icon and licenced it to us under GPL
+
+# Translations
+
+* Maxim Derkach
+* Mats Henrikson
+* Nizar Kerkeni
+* "Data"
+* Cristian Grada
+* "zhuqin"
+* and many others.

--- a/.authors.header
+++ b/.authors.header
@@ -1,0 +1,4 @@
+## Authors and contributors for Terminator
+
+This list is generated from the GIT log.
+

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,25 @@
+Andrea Corbellini <corbellini.andrea@gmail.com> <andrea.corbellini@beeseek.org>
+Bryce Harrington <bryce@bryceharrington.org>
+Chris Jones <cmsj@tenshu.net> <cmsj@kodachi>
+Chris Jones <cmsj@tenshu.net> <cmsj@tenshu>
+Chris Jones <cmsj@tenshu.net> <cmsj@waishou>
+Chris Jones <cmsj@tenshu.net> <root@kodachi>
+Chris Jones <cmsj@tenshu.net> cmsj@canonical.com <>
+Daniel T Chen <crimsun@ubuntu.com> <crimsun@errno>
+David Caro Estévez <david.caro.estevez@gmail.com> <David>
+Dmitry Soldatov <grapescan@gmail.com> <boh@veteran>
+Emmanuel Bretelle <chantra@debuntu.org> <chantra@ketu>
+Emmanuel Bretelle <chantra@debuntu.org> <chantra@mangal>
+Emmanuel Bretelle <chantra@debuntu.org> <ebretelle@mangal>
+Jose I. Monreal <jmonreal@gmail.com> <jmonreal@Nidaime>
+Mackenzie Morgan <maco.m@ubuntu.com> <maco@betty>
+Markus Frosch <markus@lazyfrosch.de> <lazyfrosch@debian.org>
+Nicolas Valcárcel <nvalcarcel@ubuntu.com> <nvalcarcel@canonical.com>
+Nicolas Valcárcel <nvalcarcel@ubuntu.com> <nvalcarcel@ubuntu-pe.org>
+Nicolas Valcárcel <nvalcarcel@ubuntu.com> <nvalcarcel@ubuntu.com>
+Nicolas Valcárcel <nvalcarcel@ubuntu.com> <nxvl@LePew>
+Nicolas Valcárcel <nvalcarcel@ubuntu.com> <nxvl@stable>
+Pavel Khlebovich <pas.anddev@gmail.com> <pas@pas-desktop>
+Peter Bjørn Jørgensen <peterbjorgensen@gmail.com> <peter@arch>
+Thomas Hurst <tom@hur.st> <freaky@udat.nightsdawn.sf>
+judgedreads <pearce@millerdedmon.com> judgedreads pearce@millerdedmon.com <>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,32 +1,86 @@
-Upstream Authors (in no discernible order):
+## Authors and contributors for Terminator
 
-    Chris Jones
-    Huang He
-    Kees Cook
-    Thomas Meire
-    Nicolas Valcarcel
-    Emmanuel Bretelle
-    Chris Oattes
-    Markus Korn
-    Mackenzie Morgan
-    Daniel T Chen
-    Nicolas Roman
-    Takao Fujiwara
-    Jordan Callicoat
-    Stephen Boddy
-    Bryce Harrington
+This list is generated from the GIT log.
 
-Artwork:
-    Cory Kontros - Produced our current icon under the CC-by-SA licence
-    Cristian Grada - Drew our original icon and licenced it to us under GPL
+* Alexey Sokolov <sokolov@google.com>
+* Andrea Corbellini <corbellini.andrea@gmail.com>
+* Andre Hilsendeger <Andre.Hilsendeger@gmail.com>
+* Andrew Felske <knopper67@archlinux.us>
+* Antonio Terceiro <terceiro@debian.org>
+* Ariel Zelivansky <ariel.zelivans@gmail.com>
+* Braden M. Kelley <redbmk@gmail.com>
+* Brian Murray <brian@canonical.com>
+* Bruno Braga <bruno.braga@gmail.com>
+* Bryce Harrington <bryce@bryceharrington.org>
+* Chacal <chacal_exodius@hotmail.com>
+* Chris James <hashdevine@gmail.com>
+* Chris Jones <cmsj@tenshu.net>
+* Cory Kontros <coryisatm@ubuntu.com>
+* Daniel T Chen <crimsun@ubuntu.com>
+* David Caro Estévez <david.caro.estevez@gmail.com>
+* Dmitry Soldatov <grapescan@gmail.com>
+* Edoardo Batini <eodbat@gmail.com>
+* Elliot Murphy <elliot@elliotmurphy.com>
+* Emilien Klein <emilien@klein.st>
+* Emilio Pozuelo Monfort <pochu@debian.org>
+* Emmanuel Bretelle <chantra@debuntu.org>
+* Fernando Basso <fernandobasso.br@gmail.com>
+* Francis Smit (Grizzly) <grizzly@smit.id.au>
+* Guilherme Salgado <salgado@canonical.com>
+* Hajimu UMEMOTO <ume@mahoroba.org>
+* Iain Lane <iain@orangesquash.org.uk>
+* Jakub Vaněk <vanek.jakub4@seznam.cz>
+* Jamu Kakar <jkakar@kakar.ca>
+* José Augusto <joseaugusto.881@outlook.com>
+* Jose I. Monreal <jmonreal@gmail.com>
+* judgedreads <pearce@millerdedmon.com>
+* Juliano Fischer Naves <julianofischer@gmail.com>
+* Julien Nicoulaud <julien.nicoulaud@gmail.com>
+* Julien Thewys <jth@openerp.com>
+* Kees Cook <kees@outflux.net>
+* Lucian Adrian Grijincu <lucian.grijincu@gmail.com>
+* Mackenzie Morgan <maco.m@ubuntu.com>
+* Markus Frosch <markus@lazyfrosch.de>
+* Markus Korn <thekorn@gmx.de>
+* Matt Rose <mattrose@folkwolf.net>
+* Nathan Handler <nhandler@ubuntu.com>
+* Neal Fultz <nfultz@neal-1015pe>
+* Nicolas Valcárcel <nvalcarcel@ubuntu.com>
+* Pavel Khlebovich <pas.anddev@gmail.com>
+* Peter B. Jørgensen <peterbjorgensen@gmail.com>
+* Peter Bjørn Jørgensen <peterbjorgensen@gmail.com>
+* Peter Lind <peter.e.lind@gmail.com>
+* Przemek Wesolek <jest@luna>
+* Roberto Aguilar <roberto.c.aguilar@gmail.com>
+* Ryan Fonnesbeck <fonz@fonzinc.com>
+* shiraeeshi <shiraeeshi@mail.ru>
+* Siegfried-Angel Gevatter Pujals <rainct@ubuntu.com>
+* Stephen Boddy <stephen.j.boddy@gmail.com>
+* Thomas Hurst <tom@hur.st>
+* Thomas Meire <blackskad@gmail.com>
+* Tony Baker <frd91gt@gmail.com>
 
-Translations:
-    Thomas Meire
-    Maxim Derkach
-    Nicolas Valcárcel
-    Mats Henrikson
-    Nizar Kerkeni
-    "Data"
-    Cristian Grada
-    "zhuqin"
-    and many others.
+## Other contributors
+
+People that contributed to Terminator in other ways.
+
+* Huang He
+* Chris Oattes
+* Nicolas Roman
+* Takao Fujiwara
+* Jordan Callicoat
+
+# Artwork
+
+* Cory Kontros - Produced our current icon under the CC-by-SA licence
+* Cristian Grada - Drew our original icon and licenced it to us under GPL
+
+# Translations
+
+* Maxim Derkach
+* Mats Henrikson
+* Nizar Kerkeni
+* "Data"
+* Cristian Grada
+* "zhuqin"
+* and many others.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,6 +25,16 @@ dos2unix CHANGELOG.md
 
 Check and review CHANGELOG.md for the expected result.
 
+## Update AUTHORS
+
+This will make sure we mention everyone that has contributed to Terminator.
+
+```
+git log --use-mailmap | grep ^Author: | cut -f2- -d' ' | grep -v ^Launchpad | sort | uniq | sed 's/^/* /' | cat .authors.header - .authors.footer > AUTHORS
+```
+
+Make sure to review the list, and update `.mailmap` when it is necessary.
+
 ## Git Tag
 
 Commit these changes to the "master" branch:


### PR DESCRIPTION
This is an approach to mention everyone contributing to Terminator.