### PR TITLE
Do not crash when dbus server is unavailable, just emit an error message

### DIFF
--- a/terminatorlib/ipc.py
+++ b/terminatorlib/ipc.py
@@ -11,7 +11,7 @@ from .borg import Borg
 from .terminator import Terminator
 from .config import Config
 from .factory import Factory
-from .util import dbg,  enumerate_descendants
+from .util import dbg, err, enumerate_descendants
 
 CONFIG = Config()
 if not CONFIG['dbus']:
@@ -46,7 +46,11 @@ class DBusService(Borg, dbus.service.Object):
         """Ensure we are populated"""
         if not self.bus_name:
             dbg('Checking for bus name availability: %s' % BUS_NAME)
-            bus = dbus.SessionBus()
+            try:
+                bus = dbus.SessionBus()
+            except Exception as e:
+                err('Unable to connect to DBUS Server, proceeding as standalone')
+                raise ImportError
             proxy = bus.get_object('org.freedesktop.DBus', 
                                    '/org/freedesktop/DBus')
             flags = 1 | 4 # allow replacement | do not queue


### PR DESCRIPTION
In a situation where we have all of the dbus libraries installed, but there is no dbus server available, for whatever reason (see bug #65 for one), don't crash, just proceed without dbus

This is actually a pretty rare situation, but I can see this happening under some unusual setups.  It happened to me running on a mac.  I got around it by installing the dbus server, but some people may not want to do that.
