### PR TITLE
WIP/crazy idea: add feature to embed browser tab

### DIFF
--- a/terminatorlib/browser.py
+++ b/terminatorlib/browser.py
@@ -1,0 +1,156 @@
+"""A simple browser widget with WebKit2"""
+
+import gi
+gi.require_version('WebKit2', '4.0')
+from gi.repository import GObject, Gtk, WebKit2
+from .terminator import Terminator
+
+class Browser(Gtk.VBox):
+    __gsignals__ = {
+        'title-change': (GObject.SignalFlags.RUN_LAST, None,
+            (GObject.TYPE_STRING,)),
+        'tab-new': (GObject.SignalFlags.RUN_LAST, None,
+            (GObject.TYPE_BOOLEAN, GObject.TYPE_OBJECT)),
+        'browser-tab-new': (GObject.SignalFlags.RUN_LAST, None,
+            (GObject.TYPE_BOOLEAN, GObject.TYPE_OBJECT)),
+        'tab-change': (GObject.SignalFlags.RUN_LAST, None,
+            (GObject.TYPE_INT,)),
+        'move-tab': (GObject.SignalFlags.RUN_LAST, None,
+            (GObject.TYPE_STRING,)),
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(Browser, self).__init__(*args, **kwargs)
+
+        self.window_title = "New browser window"
+
+        self.terminator = Terminator()
+
+        self.uri_entry = Gtk.Entry()
+        self.uri_entry.connect("activate", self.on_uri_set)
+        self.go_button = Gtk.Button("Go")
+        self.go_button.connect("clicked", self.on_uri_set)
+
+        self.uri_bar = Gtk.HBox()
+        self.uri_bar.pack_start(self.uri_entry, True, True, 0)
+        self.uri_bar.pack_start(self.go_button, False, False, 0)
+
+        self.webview = WebKit2.WebView()
+        self.webview.connect('notify::title', self.on_title_change)
+        self.webview.connect('notify::uri', self.on_uri)
+        self.webview.load_uri('about:blank')
+
+        self.scrolled_window = Gtk.ScrolledWindow()
+        self.scrolled_window.add(self.webview)
+
+        self.pack_start(self.uri_bar, False, False, 0)
+        self.pack_start(self.scrolled_window, True, True, 0)
+
+        self.connect('key-press-event', self.on_keypress)
+        self.show_all()
+
+
+    def on_uri_set(self, *args, **kwargs):
+        uri = self.uri_entry.get_text()
+        if '://' not in uri:
+            uri = 'http://' + uri
+        self.webview.load_uri(uri)
+
+    def on_uri(self, *args, **kwargs):
+        uri = self.webview.get_uri()
+        self.uri_entry.set_text(uri)
+
+    def on_keypress(self, widget, event):
+        mapping = self.terminator.keybindings.lookup(event)
+        if mapping:
+            try:
+                handler = getattr(self, "key_" + mapping)
+                handler()
+                return(True)
+            except AttributeError:
+                return(False)
+        return(False)
+
+    def get_window_title(self):
+        return self.window_title
+
+    def on_title_change(self, widget, event):
+        title = widget.get_title()
+        self.window_title = title
+        self.emit('title-change', title)
+
+    ########################################################################
+    # FIXME: all os the keybinding handlers below were copied from Terminal
+    ########################################################################
+
+    def key_new_window(self):
+        self.terminator.new_window(self.get_cwd(), self.get_profile())
+
+    def key_new_tab(self):
+        self.get_toplevel().tab_new(self)
+
+    def key_new_browser_tab(self):
+        self.get_toplevel().browser_tab_new(self)
+
+    def key_new_terminator(self):
+        spawn_new_terminator(self.origcwd, ['-u'])
+
+    def key_move_tab_right(self):
+        self.emit('move-tab', 'right')
+
+    def key_move_tab_left(self):
+        self.emit('move-tab', 'left')
+
+    def key_next_tab(self):
+        self.emit('tab-change', -1)
+
+    def key_prev_tab(self):
+        self.emit('tab-change', -2)
+
+    def key_switch_to_tab_1(self):
+        self.emit('tab-change', 0)
+
+    def key_switch_to_tab_2(self):
+        self.emit('tab-change', 1)
+
+    def key_switch_to_tab_3(self):
+        self.emit('tab-change', 2)
+
+    def key_switch_to_tab_4(self):
+        self.emit('tab-change', 3)
+
+    def key_switch_to_tab_5(self):
+        self.emit('tab-change', 4)
+
+    def key_switch_to_tab_6(self):
+        self.emit('tab-change', 5)
+
+    def key_switch_to_tab_7(self):
+        self.emit('tab-change', 6)
+
+    def key_switch_to_tab_8(self):
+        self.emit('tab-change', 7)
+
+    def key_switch_to_tab_9(self):
+        self.emit('tab-change', 8)
+
+    def key_switch_to_tab_10(self):
+        self.emit('tab-change', 9)
+
+    def key_new_tab(self):
+        self.get_toplevel().tab_new(self)
+
+    def key_new_browser_tab(self):
+        self.get_toplevel().browser_tab_new(self)
+
+    def key_new_terminator(self):
+        spawn_new_terminator(self.origcwd, ['-u'])
+
+    def key_help(self):
+        manual_index_page = manual_lookup()
+        if manual_index_page:
+            self.open_url(manual_index_page)
+
+
+GObject.type_register(Browser)
+# vim: set expandtab ts=4 sw=4:

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -124,6 +124,7 @@ DEFAULTS = {
             'zoom_out'         : '<Control>minus',
             'zoom_normal'      : '<Control>0',
             'new_tab'          : '<Shift><Control>t',
+            'new_browser_tab'  : '<Shift><Control>b',
             'cycle_next'       : '<Control>Tab',
             'cycle_prev'       : '<Shift><Control>Tab',
             'go_next'          : '<Shift><Control>n',

--- a/terminatorlib/factory.py
+++ b/terminatorlib/factory.py
@@ -15,6 +15,9 @@ True
 >>> vpaned = maker.make_vpaned()
 >>> maker.isinstance(vpaned, 'VPaned')
 True
+>>> browser = maker.make_browser()
+>>> maker.isinstance(browser, 'Browser')
+True
 
 """
 
@@ -30,6 +33,7 @@ class Factory(Borg):
              'HPaned': 'paned',
              'Paned': 'paned',
              'Notebook': 'notebook',
+             'Browser': 'browser',
              'Container': 'container',
              'Window': 'window'}
     types_keys = list(types.keys())
@@ -119,3 +123,6 @@ class Factory(Borg):
         from . import notebook
         return(notebook.Notebook(kwargs['window']))
 
+    def make_browser(self, **kwargs):
+        from . import browser
+        return(browser.Browser())

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -99,6 +99,7 @@ class PrefsEditor:
                         'zoom_out'         : _('Decrease font size'),
                         'zoom_normal'      : _('Restore original font size'),
                         'new_tab'          : _('Create a new tab'),
+                        'new_browser_tab'  : _('Create a new browser tab'),
                         'cycle_next'       : _('Focus the next terminal'),
                         'cycle_prev'       : _('Focus the previous terminal'),
                         'go_next'          : _('Focus the next terminal'),

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -52,6 +52,8 @@ class Terminal(Gtk.VBox):
         'rotate-ccw': (GObject.SignalFlags.RUN_LAST, None, ()),
         'tab-new': (GObject.SignalFlags.RUN_LAST, None,
             (GObject.TYPE_BOOLEAN, GObject.TYPE_OBJECT)),
+        'browser-tab-new': (GObject.SignalFlags.RUN_LAST, None,
+            (GObject.TYPE_BOOLEAN, GObject.TYPE_OBJECT)),
         'tab-top-new': (GObject.SignalFlags.RUN_LAST, None, ()),
         'focus-in': (GObject.SignalFlags.RUN_LAST, None, ()),
         'focus-out': (GObject.SignalFlags.RUN_LAST, None, ()),
@@ -1858,6 +1860,9 @@ class Terminal(Gtk.VBox):
 
     def key_new_tab(self):
         self.get_toplevel().tab_new(self)
+
+    def key_new_browser_tab(self):
+        self.get_toplevel().browser_tab_new(self)
 
     def key_new_terminator(self):
         spawn_new_terminator(self.origcwd, ['-u'])

--- a/terminatorlib/terminal_popup_menu.py
+++ b/terminatorlib/terminal_popup_menu.py
@@ -135,6 +135,11 @@ class TerminalPopupMenu(object):
                 terminal))
             menu.append(item)
 
+            item = Gtk.MenuItem.new_with_mnemonic(_('Open _Browser Tab'))
+            item.connect('activate', lambda x: terminal.emit('browser-tab-new', False,
+                terminal))
+            menu.append(item)
+
             if self.terminator.debug_address is not None:
                 item = Gtk.MenuItem.new_with_mnemonic(_('Open _Debug Tab'))
                 item.connect('activate', lambda x:

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -275,6 +275,14 @@ class Window(Container, Gtk.Window):
         self.present()
         return self.get_child().newtab(debugtab, cwd=cwd, profile=profile)
 
+    def browser_tab_new(self, *args, **kwargs):
+        maker = Factory()
+        if not self.is_child_notebook():
+            dbg('Making a new Notebook')
+            notebook = maker.make('Notebook', window=self)
+        browser = maker.make('Browser')
+        return self.get_child().newtab(widget=browser)
+
     def on_delete_event(self, window, event, data=None):
         """Handle a window close request"""
         maker = Factory()
@@ -423,6 +431,7 @@ class Window(Container, Gtk.Window):
                        'ungroup-tab': self.ungroup_tab,
                        'move-tab': self.move_tab,
                        'tab-new': [self.tab_new, widget],
+                       'browser-tab-new': self.browser_tab_new,
                        'navigate': self.navigate_terminal}
 
             for signal in signals:
@@ -592,6 +601,8 @@ class Window(Container, Gtk.Window):
             terminals.update(child.get_visible_terminals())
         elif maker.isinstance(child, 'Terminal'):
             terminals[child] = child.get_allocation()
+        elif maker.isinstance(child, 'Browser'):
+            pass
         else:
             err('Unknown child type %s' % type(child))
 


### PR DESCRIPTION
Here is a crazy idea.

I need to do a remote presentation/live demo in a few days, and I anticipate that I will need to switch back forth between a terminal and a browser. I don't want to share my entire desktop, and I don't want to be constantly picking a window to share.

So I wrote this to be able to embed a simple WebKit2 based browser tab in terminator.
It's not finished, but it kind of works for me so far.

Is this crazy? Would people be willing to carry this feature going forward? I admit it's very niche, but it's also very useful for the use case it's intended to cover.