### PR TITLE
Fix TODO for documenting vte regex matching constants

### DIFF
--- a/terminatorlib/regex.py
+++ b/terminatorlib/regex.py
@@ -6,8 +6,10 @@ import gi
 gi.require_version('Vte', '2.91')  # vte-0.38 (gnome-3.14)
 from gi.repository import GLib, Vte
 
-# constants for vte regex matching
-# TODO: Please replace with a proper reference to VTE, I found none!
+# constants for vte regex matching are documented in the pcre2 api:
+#   https://www.pcre.org/current/doc/html/pcre2api.html
+# the corresponding bits are defined here:
+#   https://vcs.pcre.org/pcre2/code/trunk/src/pcre2.h.in?view=markup
 PCRE2_MULTILINE = 0x00000400
 FLAGS_GLIB = (GLib.RegexCompileFlags.OPTIMIZE | GLib.RegexCompileFlags.MULTILINE)
 if hasattr(Vte, 'REGEX_FLAGS_DEFAULT'):


### PR DESCRIPTION
While browsing the issues and the source code I encountered this TODO. After some searching I found where the constants are documented and defined. I have added the references to the source code as comments.