### PR TITLE
fix io errors on debugserver

### DIFF
--- a/terminatorlib/debugserver.py
+++ b/terminatorlib/debugserver.py
@@ -33,7 +33,7 @@ class PythonConsoleServer(socketserver.BaseRequestHandler):
   def handle(self):
     ddbg("debugserver: handling")
     try:
-      self.socketio = self.request.makefile()
+      self.socketio = self.request.makefile(mode='rw')
       sys.stdout = self.socketio
       sys.stdin = self.socketio
       sys.stderr = self.socketio


### PR DESCRIPTION
A weird difference between python 2 and 3, I believe.  Without this when you try and run the debug server it will not be able to read or write to the socket the debugserver creates.