### PR TITLE
Fix crash when GdkX11 module is not available when creating layout

### DIFF
--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -407,7 +407,7 @@ class Terminator(Borg):
             window.grab_focus()
             try:
                 t = GdkX11.x11_get_server_time(window.get_window())
-            except (TypeError, AttributeError):
+            except (NameError,TypeError, AttributeError):
                 t = 0
             window.get_window().focus(t)
 
@@ -423,7 +423,7 @@ class Terminator(Borg):
                 window.grab_focus()
                 try:
                     t = GdkX11.x11_get_server_time(window.get_window())
-                except (TypeError, AttributeError):
+                except (NameError,TypeError, AttributeError):
                     t = 0
                 window.get_window().focus(t)
 


### PR DESCRIPTION
I'm probably the only person who uses terminator with the Quartz backend (on a mac) and does not even have the X11 libs installed, but I think we'll run into this more and more often as X11 gets phased out and wayland is used more often