### PR TITLE
fix detection of whether or not ibus is running

### DIFF
--- a/terminator
+++ b/terminator
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     # Environment also needs IBUS_DISABLE_SNOOPER=1, or double chars appear
     # in the receivers.
     username = pwd.getpwuid(os.getuid()).pw_name
-    ibus_running = [p for p in psutil.process_iter() if p.name == 'ibus-daemon' and p.username == username]
+    ibus_running = [p for p in psutil.process_iter() if p.name() == 'ibus-daemon' and p.username() == username]
     ibus_running = len(ibus_running) > 0
     if ibus_running:
         os.environ['IBUS_DISABLE_SNOOPER']='1'


### PR DESCRIPTION
for #78 

Well, this was an adventure.  It turns out that it wasn't the environment variable that changed, but actually the internals of the python psutil module, which meant that we weren't actually detecting whether or not ibus was running, and consequently never setting the proper ibus environment variable.  