### PR TITLE
fix cwd for non-vte shells

### DIFF
--- a/terminatorlib/cwd.py
+++ b/terminatorlib/cwd.py
@@ -2,33 +2,21 @@
 # GPL v2 only
 """cwd.py - function necessary to get the cwd for a given pid on various OSes
 
->>> cwd = get_default_cwd()
->>> cwd.__class__.__name__
-'str'
->>> func = get_pid_cwd()
+
+>>> cwd = get_pid_cwd(None)
 >>> cwd.__class__.__name__
 'str'
 
 """
 
-import platform
-import os
-import pwd
 import psutil
-from .util import dbg, err
+from .util import dbg
 
-def get_default_cwd():
-    """Determine a reasonable default cwd"""
-    try:
-        cwd = os.getcwd()
-    except (FileNotFoundError,OSError):
-        err("unable to set current working directory, does not exist")
-        cwd = '/'
-    
-    return(cwd)
-
-def get_pid_cwd():
+def get_pid_cwd(pid = None):
     """Determine the cwd of the current process"""
-    return psutil.Process().as_dict()['cwd']
+    psinfo =  psutil.Process(pid).as_dict()
+    dbg('psinfo: %s %s' % (psinfo['cwd'],psinfo['pid']))
+    # return func
+    return psinfo['cwd']
 
 # vim: set expandtab ts=4 sw=4:

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -18,7 +18,7 @@ except ImportError:
 from .util import dbg, err, spawn_new_terminator, make_uuid, manual_lookup, display_manager
 from . import util
 from .config import Config
-from .cwd import get_default_cwd
+from .cwd import get_pid_cwd
 from .factory import Factory
 from .terminator import Terminator
 from .titlebar import Titlebar
@@ -128,7 +128,7 @@ class Terminal(Gtk.VBox):
 
         self.config = Config()
 
-        self.cwd = get_default_cwd()
+        self.cwd = get_pid_cwd()
         self.origcwd = self.terminator.origcwd
         self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
 
@@ -223,7 +223,8 @@ class Terminal(Gtk.VBox):
             return(GLib.filename_from_uri(vte_cwd)[0])
         else:
             # Fall back to old gtk2 method
-            return(self.terminator.pid_cwd())
+            dbg('calling get_pid_cwd')
+            return(get_pid_cwd(self.pid))
 
     def close(self):
         """Close ourselves"""

--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -15,7 +15,6 @@ from .config import Config
 from .keybindings import Keybindings
 from .util import dbg, err, enumerate_descendants
 from .factory import Factory
-from .cwd import get_pid_cwd
 from .version import APP_NAME, APP_VERSION
 
 try:
@@ -54,7 +53,6 @@ class Terminator(Borg):
     origcwd = None
     dbus_path = None
     dbus_name = None
-    pid_cwd = None
     gnome_client = None
     debug_address = None
     ibus_running = None
@@ -98,8 +96,6 @@ class Terminator(Borg):
             self.style_providers = []
         if not self.doing_layout:
             self.doing_layout = False
-        if not self.pid_cwd:
-            self.pid_cwd = get_pid_cwd
         if self.gnome_client is None:
             self.attempt_gnome_client()
         self.connect_signals()


### PR DESCRIPTION
This came from a comment in gitter where @FernandoBasso noticed that the cwd wasn't being set properly if the vte shell functions weren't installed.