### PR TITLE
add line_height config variable

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -233,6 +233,7 @@ DEFAULTS = {
                 'use_system_font'       : True,
                 'use_theme_colors'      : False,
                 'bold_is_bright'        : False,
+                'line_height'           : 1.0,
                 'encoding'              : 'UTF-8',
                 'active_encodings'      : ['UTF-8', 'ISO-8859-1'],
                 'focus_on_close'        : 'auto',

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -693,6 +693,8 @@ class Terminal(Gtk.VBox):
             except:
                 pass
         self.vte.set_allow_bold(self.config['allow_bold'])
+        if hasattr(self.vte,'set_cell_height_scale'): 
+            self.vte.set_cell_height_scale(self.config['line_height'])
         if hasattr(self.vte, 'set_bold_is_bright'):
             self.vte.set_bold_is_bright(self.config['bold_is_bright'])
 
@@ -812,6 +814,7 @@ class Terminal(Gtk.VBox):
             elif self.config['scrollbar_position'] == 'right':
                 self.terminalbox.reorder_child(self.vte, 0)
 
+        
         self.vte.set_rewrap_on_resize(self.config['rewrap_on_resize'])
 
         self.titlebar.update()


### PR DESCRIPTION
This is a WIP right now.  I'm going to wire up the preferences dialog next.  If you want to try this out, you can add a `line_height` entry to a profile in `~/.config/terminator/config`