### PR TITLE
Fix: Allow Key Bindings with Shift-Modified Keys

### DIFF
--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1550,6 +1550,21 @@ class PrefsEditor:
 
     def on_cellrenderer_accel_edited(self, liststore, path, key, mods, _code):
         """Handle an edited keybinding"""
+        if mods & Gdk.ModifierType.SHIFT_MASK:
+            key_with_shift = Gdk.Keymap.translate_keyboard_state(
+                self.keybindings.keymap,
+                hardware_keycode=_code,
+                state=Gdk.ModifierType.SHIFT_MASK,
+                group=0,
+            )
+            keyval_lower, keyval_upper = Gdk.keyval_convert_case(key)
+
+            # Remove the Shift modifier from `mods` if a new key binding doesn't
+            # contain a letter and its key value (`key`) can't be modified by a
+            # Shift key.
+            if key_with_shift.level != 0 and keyval_lower == keyval_upper:
+                mods = Gdk.ModifierType(mods & ~Gdk.ModifierType.SHIFT_MASK)
+
         celliter = liststore.get_iter_from_string(path)
         liststore.set(celliter, 2, key, 3, mods)
 


### PR DESCRIPTION
This PR should fix #149. 

The idea is to check whether a key value will change if a Shift key is down (see [level](https://developer.gnome.org/pygtk/stable/class-gdkkeymap.html)). If it will, then remove the Shift modifier from `mods`. 

One exception: if a key binding contains a letter then the Shift modifier is not removed. This is because, for some reason, a key value of a letter is never modified by the Shift modifier and always corresponds to a key value of a lowercase character. This is already handled in `terminatorlib/keybindings.py`. 

I'm new to GTK, so not quite sure how to emulate signals with PyTest. I tested the following key bindings (manually) to make sure it works: 

- `Ctrl + Shift + 1` translates to `Ctrl + !`
- `Ctrl + A` translates to `Ctrl + A`
- `Ctrl + Shift + A` translates to `Shift + Ctrl + A`
- `Ctrl + Shift + F1` translates to `Shift + Ctrl + F1`
- `Ctrl + Shift + Page Up` translates to `Shift + Ctrl + Page Up`
- `Ctrl + Shift + Up` translates to `Shift + Ctrl + Up`
- `Shift + Up` translates to `Shift + Up`
- `Shift + A` translates to `Shift + A`
- `Ctrl + Shift + [` translates to `Ctrl + {`