### PR TITLE
Apparently mint does not like it when you call unmaximize twice

### DIFF
--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -344,7 +344,9 @@ class Window(Container, Gtk.Window):
         if value == True:
             self.maximize()
         else:
-            self.unmaximize()
+            ### Apparently if you call unmaximize twice in Mint it breaks other stuff
+            if self.props.is_maximized == True:
+                self.unmaximize()
 
     def set_fullscreen(self, value):
         """Set the fullscreen state of the window from the supplied value"""


### PR DESCRIPTION
This fixes #168 and I tried to very gingerly fix it, but I kinda want to test the crap out of this before merging, as the current code works everywhere but Mint.

