### PR TITLE
Fix terminator -x "runstring"

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1419,6 +1419,7 @@ class Terminal(Gtk.VBox):
         args = []
         shell = None
         command = None
+        execute = None
 
         if self.terminator.doing_layout == True:
             dbg('still laying out, refusing to spawn a child')
@@ -1432,7 +1433,8 @@ class Terminal(Gtk.VBox):
             command = options.command
             options.command = None
         elif options and options.execute:
-            command = options.execute
+            #command = options.execute
+            execute = options.execute
             options.execute = None
         elif self.config['use_custom_command']:
             command = self.config['custom_command']
@@ -1453,12 +1455,15 @@ class Terminal(Gtk.VBox):
             self.set_cwd(options.working_directory)
             options.working_directory = ''
 
-        if type(command) is list:
+        if type(execute) is list:
+            shell = util.shell_lookup()
+            args.insert(0, shell)
+            args += ['-c', execute[0]]
+        elif type(command) is list:
             shell = util.path_lookup(command[0])
             args = command
         else:
             shell = util.shell_lookup()
-
             if self.config['login_shell']:
                 args.insert(0, "-%s" % shell)
             else:


### PR DESCRIPTION
Matt suggest in some post something along the line of terminator -x "runstring".
To my grand surpise this doesn't work and fail with a backtrace like

$ python3 /d1/terminator-matt/terminator -x "echo yo; sleep 3"
Traceback (most recent call last):
  File "/d1/terminator-matt/terminator", line 128, in <module>
    TERMINATOR.layout_done()
  File "/d1/terminator-matt/terminatorlib/terminator.py", line 329, in layout_done
    terminal.spawn_child()
  File "/d1/terminator-matt/terminatorlib/terminal.py", line 1471, in spawn_child
    self.vte.feed(_('Unable to find a shell'))
TypeError: Item 0: Must be number, not str

This proposed fix gets

$ terminator -x "echo yo; sleep 3"
<pre>
+--------------------------------------------+ 
| [>_]                          [-] [o] [X]  |
+--------------------------------------------+
|yo                                          |
|                                            |
|                                            |
+--------------------------------------------+
</pre>

The above terminator window appears for 3 sec as expected.
Note the fix make --new-tab working the same way.
