### PR TITLE
Use the term 'zero padded' instead of 'padded'.

### DIFF
--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -166,7 +166,7 @@ class PrefsEditor:
                         'broadcast_group'  : _('Broadcast key presses to group'),
                         'broadcast_all'    : _('Broadcast key events to all'),
                         'insert_number'    : _('Insert terminal number'),
-                        'insert_padded'    : _('Insert padded terminal number'),
+                        'insert_padded'    : _('Insert zero padded terminal number'),
                         'edit_window_title': _('Edit window title'),
                         'edit_terminal_title': _('Edit terminal title'),
                         'edit_tab_title'   : _('Edit tab title'),

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -555,7 +555,7 @@ class Terminal(Gtk.VBox):
         item.connect('activate', lambda x: self.emit('enumerate', False))
         menu.append(item)
 
-        item = Gtk.MenuItem.new_with_mnemonic(_('Insert _padded terminal number'))
+        item = Gtk.MenuItem.new_with_mnemonic(_('Insert zero _padded terminal number'))
         item.connect('activate', lambda x: self.emit('enumerate', True))
         menu.append(item)
 


### PR DESCRIPTION
Use the term 'zero padded' instead of 'padded' in prefs key binding and terminal pop up menu, to be consistent with the doc.
https://gnome-terminator.readthedocs.io/en/latest/gettingstarted.html?highlight=padded
Beside it will be consistent with the docco, it also took me a while to understand what 'padded' mean, specially as long as you don't open more then 10 terminals where it looks like the same as non padded.

OTOH  I still don't understand what is hte use case of terminal id is for so may be this is not important.