### PR TITLE
Add 'wide_handle' property 

### DIFF
--- a/terminatorlib/paned.py
+++ b/terminatorlib/paned.py
@@ -507,6 +507,7 @@ class HPaned(Paned, Gtk.HPaned):
         """Class initialiser"""
         Paned.__init__(self)
         GObject.GObject.__init__(self)
+        self.props.wide_handle = True
         self.register_signals(HPaned)
         self.cnxids.new(self, 'button-press-event', self.on_button_press)
         self.cnxids.new(self, 'button-release-event', self.on_button_release)


### PR DESCRIPTION
to allow you to paste from the first column to the right of a vertically split window.  Fixes #191 