### PR TITLE
Key binding option for creating group in current terminal

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -174,6 +174,7 @@ DEFAULTS = {
             'reset'            : '<Shift><Control>r',
             'reset_clear'      : '<Shift><Control>g',
             'hide_window'      : '<Shift><Control><Alt>a',
+            'create_group'     : '',
             'group_all'        : '<Super>g',
             'group_all_toggle' : '',
             'ungroup_all'      : '<Shift><Super>g',

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -154,6 +154,7 @@ class PrefsEditor:
                         'reset'            : _('Reset the terminal'),
                         'reset_clear'      : _('Reset and clear the terminal'),
                         'hide_window'      : _('Toggle window visibility'),
+                        'create_group'     : _('Create new group'),
                         'group_all'        : _('Group all terminals'),
                         'group_all_toggle' : _('Group/Ungroup all terminals'),
                         'ungroup_all'      : _('Ungroup all terminals'),

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1870,6 +1870,9 @@ class Terminal(Gtk.VBox):
     def key_reset_clear(self):
         self.vte.reset (True, True)
 
+    def key_create_group(self):
+        self.titlebar.create_group()
+
     def key_group_all(self):
         self.emit('group-all')
 


### PR DESCRIPTION
This behaves exactly as the "New Group" titlebar menu option.  It will move the focus to the randomly selected group name, and let you edit it, and then returns focus.

It's currently disabled, but settable in the preferences.