### PR TITLE
Command notify

### DIFF
--- a/terminatorlib/plugins/command_notify.py
+++ b/terminatorlib/plugins/command_notify.py
@@ -7,8 +7,12 @@ depends on https://github.com/GNOME/vte/blob/vte-0-58/src/vte.sh (which has to
 be added to /etc/profile.d) and you need to ensure `__vte_prompt_command` is
 executed on `PROMPT_COMMAND` in Bash or in `precmd_functions` in Zsh.
 
+This plugin also relies on the widely distributed vte patches to wire in a 
+`notification_received` signal to catch the OSC escape sequence in the prompt
+
 Code is adapted from https://github.com/x4lldux/terminator-long-cmd-notify
 Thanks to @xll4dux on Github for the code and his permission to use it
+
 """
 import terminatorlib.plugin as plugin
 from terminatorlib.terminator import Terminator

--- a/terminatorlib/plugins/command_notify.py
+++ b/terminatorlib/plugins/command_notify.py
@@ -19,7 +19,7 @@ VERSION = '0.1.0'
 AVAILABLE = ['CommandNotify']
 
 
-class LongCommandNotify(plugin.Plugin):
+class CommandNotify(plugin.Plugin):
     capabilities = ['command_watch']
     watched = set()
 

--- a/terminatorlib/plugins/command_notify.py
+++ b/terminatorlib/plugins/command_notify.py
@@ -7,7 +7,8 @@ depends on https://github.com/GNOME/vte/blob/vte-0-58/src/vte.sh (which has to
 be added to /etc/profile.d) and you need to ensure `__vte_prompt_command` is
 executed on `PROMPT_COMMAND` in Bash or in `precmd_functions` in Zsh.
 
-Code is written in Hy and generated to Python3.
+Code is adapted from https://github.com/x4lldux/terminator-long-cmd-notify
+Thanks to @xll4dux on Github for the code and his permission to use it
 """
 import terminatorlib.plugin as plugin
 from terminatorlib.terminator import Terminator

--- a/terminatorlib/plugins/command_notify.py
+++ b/terminatorlib/plugins/command_notify.py
@@ -18,10 +18,15 @@ import terminatorlib.plugin as plugin
 from terminatorlib.terminator import Terminator
 import gi
 gi.require_version('Notify', '0.7')
-from gi.repository import GObject, GLib, Notify
+from gi.repository import GObject, GLib, Notify, Vte
 VERSION = '0.1.0'
-AVAILABLE = ['CommandNotify']
 
+### Test for proper signal
+try:
+    Vte.Terminal().connect('notification-received',lambda *args: None,None)
+    AVAILABLE = ['CommandNotify']
+except TypeError as e:
+    pass
 
 class CommandNotify(plugin.Plugin):
     capabilities = ['command_watch']
@@ -49,7 +54,6 @@ class CommandNotify(plugin.Plugin):
         self.watched = new_watched
 
     def update_watched_delayed(self, term, event, arg1 = None):
-        print('foo: %s / bar: %s / baz: %s' % (str(term),str(event),arg1))
         def add_watch(self):
             self.update_watched()
             return False

--- a/terminatorlib/plugins/command_notify.py
+++ b/terminatorlib/plugins/command_notify.py
@@ -16,7 +16,7 @@ import gi
 gi.require_version('Notify', '0.7')
 from gi.repository import GObject, GLib, Notify
 VERSION = '0.1.0'
-AVAILABLE = ['LongCommandNotify']
+AVAILABLE = ['CommandNotify']
 
 
 class LongCommandNotify(plugin.Plugin):

--- a/terminatorlib/plugins/command_notify.py
+++ b/terminatorlib/plugins/command_notify.py
@@ -48,8 +48,8 @@ class CommandNotify(plugin.Plugin):
                 notify = None
         self.watched = new_watched
 
-    def update_watched_delayed(self):
-
+    def update_watched_delayed(self, term, event, arg1 = None):
+        print('foo: %s / bar: %s / baz: %s' % (str(term),str(event),arg1))
         def add_watch(self):
             self.update_watched()
             return False

--- a/terminatorlib/plugins/command_notify.py
+++ b/terminatorlib/plugins/command_notify.py
@@ -1,0 +1,58 @@
+"""
+This plugin will launch a notification when a long running command finishes
+and terminal is not active.
+
+It uses VTE's special sequence which is sent when shell prints the prompt. It
+depends on https://github.com/GNOME/vte/blob/vte-0-58/src/vte.sh (which has to
+be added to /etc/profile.d) and you need to ensure `__vte_prompt_command` is
+executed on `PROMPT_COMMAND` in Bash or in `precmd_functions` in Zsh.
+
+Code is written in Hy and generated to Python3.
+"""
+import terminatorlib.plugin as plugin
+from terminatorlib.terminator import Terminator
+import gi
+gi.require_version('Notify', '0.7')
+from gi.repository import GObject, GLib, Notify
+VERSION = '0.1.0'
+AVAILABLE = ['LongCommandNotify']
+
+
+class LongCommandNotify(plugin.Plugin):
+    capabilities = ['command_watch']
+    watched = set()
+
+    def __init__(self):
+        self.update_watched()
+        Notify.init('Terminator')
+        return None
+
+    def update_watched(self):
+        """Updates the list of watched terminals"""
+        new_watched = set()
+        for term in Terminator().terminals:
+            new_watched.add(term)
+            if not term in self.watched:
+                vte = term.get_vte()
+                term.connect('focus-out', self.update_watched_delayed, None)
+                vte.connect('focus-out-event', self.
+                    update_watched_delayed, None)
+                notify = vte.connect(
+                    'notification-received', self.notification_received, term)
+            else:
+                notify = None
+        self.watched = new_watched
+
+    def update_watched_delayed(self):
+
+        def add_watch(self):
+            self.update_watched()
+            return False
+        GObject.idle_add(add_watch, self)
+        return True
+
+    def notification_received(self, vte, summary, body, _terminator_term):
+        Notify.Notification.new(summary, body, 'terminator').show(
+            ) if not vte.has_focus() else None
+        return None
+


### PR DESCRIPTION
So, as per usual, this has a bunch of caveats.  It only works on Redhat-ish systems, as they're the ones who have integrated [this patch](https://bug711059.bugzilla-attachments.gnome.org/attachment.cgi?id=371905).  Cross-platform support for notification on prompt is bogged down in https://gitlab.freedesktop.org/terminal-wg/specifications/-/issues/13 so this is the best I can do until we can get VTE to agree on some kind of signal to the UI when a command is complete.

fixes #11 kinda