### PR TITLE
fix login_shell option so that it sends -l rather than -shell

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1460,7 +1460,7 @@ class Terminal(Gtk.VBox):
             shell = util.shell_lookup()
 
             if self.config['login_shell']:
-                args.insert(0, "-%s" % shell)
+                args.insert(0, "-l")
             else:
                 args.insert(0, shell)
 


### PR DESCRIPTION
So there was something I noticed while working on #202 where the "login shell" option in preferences was just wrong.  When that option was enabled, rather than sending the "-l" option to the shell, indicating you wanted a login shell, it would send: -$SHELL ($SHELL being whatever your shell was set to, so -/bin/bash or -/bin/zsh)  This does not do what the option says it does, see 

```
Terminal::spawn_child: Forking shell: "/bin/bash" with args: ['-/bin/bash', '-c', 'foo']
```
 