### PR TITLE
update Terminal.spawn_child() to use spawn_async, not spawn_sync

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1488,14 +1488,18 @@ class Terminal(Gtk.VBox):
 
         dbg('Forking shell: "%s" with args: %s' % (shell, args))
         args.insert(0, shell)
-        result,  self.pid = self.vte.spawn_sync(Vte.PtyFlags.DEFAULT,
-                                       self.cwd,
-                                       args,
-                                       envv,
-                                       GLib.SpawnFlags.FILE_AND_ARGV_ZERO | GLib.SpawnFlags.DO_NOT_REAP_CHILD,
-                                       None,
-                                       None,
-                                       None)
+        self.pid = self.vte.spawn_async(
+            Vte.PtyFlags.DEFAULT,
+            self.cwd,
+            args,
+            envv,
+            GLib.SpawnFlags.FILE_AND_ARGV_ZERO | GLib.SpawnFlags.DO_NOT_REAP_CHILD,
+            None,
+            None,
+            -1,
+            None,
+            None,
+            None)
         self.command = shell
 
         self.titlebar.update()


### PR DESCRIPTION
2 reasons for this:

1.  spawn_sync is being deprecated.
2.  spawn_async API has a callback and other goodies that we can leverage in the future.