### PR TITLE
Fix: Allow `Shift+Tab` Key Binding

### DIFF
--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1673,7 +1673,9 @@ class PrefsEditor:
 
     def on_cellrenderer_accel_edited(self, liststore, path, key, mods, _code):
         """Handle an edited keybinding"""
-        if mods & Gdk.ModifierType.SHIFT_MASK:
+        # Ignore `Gdk.KEY_Tab` so that `Shift+Tab` is displayed as `Shift+Tab`
+        # in `Preferences>Keybindings` and NOT `Left Tab` (see `Gdk.KEY_ISO_Left_Tab`).
+        if mods & Gdk.ModifierType.SHIFT_MASK and key != Gdk.KEY_Tab:
             key_with_shift = Gdk.Keymap.translate_keyboard_state(
                 self.keybindings.keymap,
                 hardware_keycode=_code,
@@ -1687,6 +1689,7 @@ class PrefsEditor:
             # Shift key.
             if key_with_shift.level != 0 and keyval_lower == keyval_upper:
                 mods = Gdk.ModifierType(mods & ~Gdk.ModifierType.SHIFT_MASK)
+                key = key_with_shift.keyval
 
         accel = Gtk.accelerator_name(key, mods)
         current_binding = liststore.get_value(liststore.get_iter(path), 0)


### PR DESCRIPTION
PR #150 introduced a bug which made it impossible to add the `Shift+Tab` key binding in `Preferences>Keybindings`. This PR should fix this. 

The commit messages in this PR have a more detailed explanation about the nature of the bug. 

I also added automated tests to check that editing a key binding in `Preferences>Keybindings` with the predefined key combinations, including `Shift+Tab`, produce the expected accelerator.