### PR TITLE
Background image

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -250,6 +250,8 @@ DEFAULTS = {
                 'autoclean_groups'      : True,
                 'http_proxy'            : '',
                 'ignore_hosts'          : ['localhost','127.0.0.0/8','*.local'],
+                'background_image'      : '',
+                'background_alpha'      : 0.0
             },
         },
         'layouts': {

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -360,6 +360,11 @@
     <property name="step_increment">0.1</property>
     <property name="page_increment">0.2</property>
   </object>
+  <object class="GtkAdjustment" id="background_image_shading_adjustment">
+    <property name="upper">1</property>
+    <property name="step_increment">0.1</property>
+    <property name="page_increment">0.01</property>
+  </object>
   <object class="GtkWindow" id="prefswin">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
@@ -1433,6 +1438,12 @@
                                     <property name="left_attach">0</property>
                                     <property name="top_attach">2</property>
                                   </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
                                 </child>
                               </object>
                               <packing>
@@ -2860,7 +2871,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="padding">1</property>
+                                <property name="padding">5</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
@@ -2928,7 +2939,108 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Background Image:</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="padding">5</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFileChooserButton" id="background_image_file">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="title" translatable="yes">Choose file</property>
+                                <signal name="file-set" handler="on_background_image_file_set" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="pack_type">end</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Shade Background Image:</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="padding">5</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Transparent </property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkScale" id="background_image_shading_scale">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="adjustment">background_image_shading_adjustment</property>
+                                <property name="round_digits">1</property>
+                                <signal name="value-changed" handler="on_background_image_shading_scale_value_changed" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Opaque</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="pack_type">end</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">5</property>
                           </packing>
                         </child>
                       </object>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -637,7 +637,11 @@ class PrefsEditor:
         # Background shading
         widget = guiget('background_darkness_scale')
         widget.set_value(float(self.config['background_darkness']))
-
+        widget = guiget('background_image_file')
+        widget.set_filename(self.config['background_image'])
+        widget = guiget('background_image_shading_scale')
+        widget.set_value(float(self.config['background_alpha']))
+   
         ## Scrolling tab
         # Scrollbar position
         widget = guiget('scrollbar_position_combobox')
@@ -929,6 +933,15 @@ class PrefsEditor:
         else:
             value = 'left'
         self.config['scrollbar_position'] = value
+        self.config.save()
+
+    def on_background_image_file_set(self,widget):
+        print(widget.get_filename())
+        self.config['background_image'] = widget.get_filename()
+        self.config.save()
+
+    def on_background_image_shading_scale_value_changed(self,widget):
+        self.config['background_alpha'] = widget.get_value()
         self.config.save()
 
     def on_darken_background_scale_value_changed(self, widget):

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -6,7 +6,7 @@
 import os
 import signal
 import gi
-from gi.repository import GLib, GObject, Pango, Gtk, Gdk
+from gi.repository import GLib, GObject, Pango, Gtk, Gdk, GdkPixbuf
 gi.require_version('Vte', '2.91')  # vte-0.38 (gnome-3.14)
 from gi.repository import Vte
 import subprocess
@@ -135,6 +135,7 @@ class Terminal(Gtk.VBox):
         self.pending_on_vte_size_allocate = False
 
         self.vte = Vte.Terminal()
+        self.background_image = GdkPixbuf.Pixbuf.new_from_file("/Users/mattrose/test.jpg")
         self.vte.set_allow_hyperlink(True)
         self.vte._draw_data = None
         if not hasattr(self.vte, "set_opacity") or \
@@ -146,7 +147,8 @@ class Terminal(Gtk.VBox):
 
         
         self.vte.show()
-
+        self.vte.set_clear_background(False)
+        self.vte.connect("draw",self.background_draw)
         self.default_encoding = self.vte.get_encoding()
         self.update_url_matches()
 
@@ -1125,8 +1127,17 @@ class Terminal(Gtk.VBox):
         widget.disconnect(connec)
         widget._draw_data = None
 
+    def background_draw(self, widget, cr):
+        rect = self.vte.get_allocation()
+        xratio = float(rect.width) / float(self.background_image.get_width())
+        yratio = float(rect.height) / float(self.background_image.get_height())
+        cr.save()
+        cr.scale(xratio,yratio)
+        Gdk.cairo_set_source_pixbuf(cr, self.background_image, 0, 0)
+        cr.paint()
+        cr.restore()
+
     def on_draw(self, widget, context):
-        """Handle an expose event while dragging"""
         if not widget._draw_data:
             return(False)
 

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -135,7 +135,14 @@ class Terminal(Gtk.VBox):
         self.pending_on_vte_size_allocate = False
 
         self.vte = Vte.Terminal()
-        self.background_image = GdkPixbuf.Pixbuf.new_from_file("/Users/mattrose/test.jpg")
+        self.background_image = None
+        if self.config['background_image'] != '':
+            try: 
+                self.background_image = GdkPixbuf.Pixbuf.new_from_file(self.config['background_image'])
+            except Exception:
+                pass
+
+        self.background_alpha = self.config['background_alpha']
         self.vte.set_allow_hyperlink(True)
         self.vte._draw_data = None
         if not hasattr(self.vte, "set_opacity") or \
@@ -1128,12 +1135,19 @@ class Terminal(Gtk.VBox):
         widget._draw_data = None
 
     def background_draw(self, widget, cr):
+        if not self.background_image:
+                return(False)
+        print("bgcolor obj: %s" % self.bgcolor.alpha)
+        over = self.bgcolor
+        over.alpha = self.background_alpha
         rect = self.vte.get_allocation()
         xratio = float(rect.width) / float(self.background_image.get_width())
         yratio = float(rect.height) / float(self.background_image.get_height())
         cr.save()
         cr.scale(xratio,yratio)
         Gdk.cairo_set_source_pixbuf(cr, self.background_image, 0, 0)
+        cr.paint()
+        Gdk.cairo_set_source_rgba(cr,over)
         cr.paint()
         cr.restore()
 

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1137,7 +1137,6 @@ class Terminal(Gtk.VBox):
     def background_draw(self, widget, cr):
         if not self.background_image:
                 return(False)
-        print("bgcolor obj: %s" % self.bgcolor.alpha)
         over = self.bgcolor
         over.alpha = self.background_alpha
         rect = self.vte.get_allocation()


### PR DESCRIPTION
fixes #5 

This is a very barebones implementation so far, and doesn't even have GUI controls yet.  (Have I mentioned how much I hate Glade?) but...

Witth this code, in your profile, you can now set `background_image = $image_file` and it will set the background of the terminal image to the image.  This is the background for each pane, so the image will no span multiple panes, but instead will repeat (I think I can configure that if it's a popular feature request, but I don't want to get too ahead of myself)

You can also set `background_alpha = x` where x is a float between 0 and 1 (eg: 0.55) which will blend in the background color from your theme to aid readability.

I have to say, I was a huge skeptic on the usability of this, it just seemed like a popular feature and people did come up with various use-cases, but I really like the way this turned out. 