### PR TITLE
Revert "Merge pull request #208 from mattrose/update-vte-spawn"

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1489,18 +1489,14 @@ class Terminal(Gtk.VBox):
 
         dbg('Forking shell: "%s" with args: %s' % (shell, args))
         args.insert(0, shell)
-        self.pid = self.vte.spawn_async(
-            Vte.PtyFlags.DEFAULT,
-            self.cwd,
-            args,
-            envv,
-            GLib.SpawnFlags.FILE_AND_ARGV_ZERO | GLib.SpawnFlags.DO_NOT_REAP_CHILD,
-            None,
-            None,
-            -1,
-            None,
-            None,
-            None)
+        result,  self.pid = self.vte.spawn_sync(Vte.PtyFlags.DEFAULT,
+                                       self.cwd,
+                                       args,
+                                       envv,
+                                       GLib.SpawnFlags.FILE_AND_ARGV_ZERO | GLib.SpawnFlags.DO_NOT_REAP_CHILD,
+                                       None,
+                                       None,
+                                       None)
         self.command = shell
 
         self.titlebar.update()


### PR DESCRIPTION
This reverts commit f5cbdce5fce1522007c9f4937e06a8a4e9486a51, reversing
changes made to e1476a2ef23def50f3a7ca70ce639e50b8f94346.

VTE.Terminal.spawn_async is not ready for prime time yet, apparently