### PR TITLE
Fix: Key Binding Clearing in `Preferences > Keybindings`

### DIFF
--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1745,7 +1745,7 @@ class PrefsEditor:
         liststore.set(celliter, 2, 0, 3, 0)
 
         binding = liststore.get_value(liststore.get_iter(path), 0)
-        self.config['keybindings'][binding] = None
+        self.config['keybindings'][binding] = ""
         self.config.save()
 
     def on_open_manual(self,  widget):

--- a/tests/test_prefseditor_keybindings.py
+++ b/tests/test_prefseditor_keybindings.py
@@ -251,3 +251,50 @@ def test_keybinding_edit_produce_expected_accels(
     accel_after_edit = (keyval_after_edit, mods_after_edit)
 
     assert accel_after_edit == expected_accel
+
+
+@pytest.mark.parametrize(
+    "accel_params",
+    [
+        # Format: (path, key, mods, hardware_keycode)
+        # 1) 'broadcast_all' 1
+        ("0", Gdk.KEY_1, Gdk.ModifierType(0), 10),
+        # 2) 'broadcast_group' Ctrl+Alt+Shift+Up
+        ("1", Gdk.KEY_Up, CONTROL_ALT_SHIFT_MOD, 111),
+    ],
+)
+def test_keybinding_successfully_reassigned_after_clearing(accel_params):
+    """
+    Tests that a key binding is successfully reassigned after it has been cleared,
+    that is no error is thrown at any stage.
+    """
+    from terminatorlib import terminal
+    from terminatorlib import prefseditor
+
+    term = terminal.Terminal()
+    prefs_editor = prefseditor.PrefsEditor(term=term)
+
+    widget = prefs_editor.builder.get_object("keybindingtreeview")
+    liststore = widget.get_model()
+
+    path, key, mods, hardware_keycode = accel_params
+    # Assign a key binding
+    prefs_editor.on_cellrenderer_accel_edited(
+        liststore=liststore,
+        path=path,
+        key=key,
+        mods=mods,
+        _code=hardware_keycode,
+    )
+    # Clear the key binding
+    prefs_editor.on_cellrenderer_accel_cleared(liststore=liststore, path=path)
+    # Reassign the key binding
+    prefs_editor.on_cellrenderer_accel_edited(
+        liststore=liststore,
+        path=path,
+        key=key,
+        mods=mods,
+        _code=hardware_keycode,
+    )
+
+    reset_config_keybindings()

--- a/tests/test_prefseditor_keybindings.py
+++ b/tests/test_prefseditor_keybindings.py
@@ -252,6 +252,8 @@ def test_keybinding_edit_produce_expected_accels(
 
     assert accel_after_edit == expected_accel
 
+    reset_config_keybindings()
+
 
 @pytest.mark.parametrize(
     "accel_params",


### PR DESCRIPTION
This PR should fix incorrect clearing of key bindings in `Preferences > Keybindings`, which was introduced in #196.

**Steps to Reproduce:**
1. Open `Preferences > Keybindings`.
2. Clear any non-empty key binding, that is double click on any key binding which doesn't say `Disabled` and then press Backspace.
3. Try to assign a new key binding to any action - it won't work.

This happens because `Gtk.accelerator_parse`, which was used in #196, doesn't allow `None` to be used as a value. To fix this, the key binding value is now set to an empty string (`""`)  instead of `None` the moment it's been cleared.

I also added a test to reproduce the behaviour described in this PR. 

