### PR TITLE
Change how config file is saved

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -71,7 +71,6 @@ KeyError: 'ConfigBase::get_item: unknown key algo'
 """
 
 import os
-import pathlib
 import shutil
 from copy import copy
 from configobj import ConfigObj, flatten_errors
@@ -720,19 +719,15 @@ class ConfigBase(Borg):
         config_dir = get_config_dir()
         if not os.path.isdir(config_dir):
             os.makedirs(config_dir)
-
-        config_file = pathlib.Path(self.command_line_options.config)
-        if not config_file.is_file():
-            config_file.touch()
         try:
-            backup_file = config_file.with_suffix('.bak')
+            backup_file = self.command_line_options.config + '~'
 
-            shutil.copy2(config_file, backup_file)
+            shutil.copy2(self.command_line_options.config, backup_file)
 
-            with open(config_file, 'wb') as fh:
+            with open(self.command_line_options.config, 'wb') as fh:
                 parser.write(fh)
 
-            backup_file.unlink()
+            os.remove(backup_file)
         except Exception as ex:
             err('ConfigBase::save: Unable to save config: %s' % ex)
 

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -71,6 +71,7 @@ KeyError: 'ConfigBase::get_item: unknown key algo'
 """
 
 import os
+import shutil
 from copy import copy
 from configobj import ConfigObj, flatten_errors
 from validate import Validator
@@ -687,7 +688,7 @@ class ConfigBase(Borg):
         """Force a reload of the base config"""
         self.loaded = False
         self.load()
-        
+
     def save(self):
         """Save the config to a file"""
         dbg('ConfigBase::save: saving config')
@@ -719,12 +720,14 @@ class ConfigBase(Borg):
         if not os.path.isdir(config_dir):
             os.makedirs(config_dir)
         try:
-            temp_file = self.command_line_options.config + '.tmp'
+            backup_file = self.command_line_options.config + '~'
 
-            with open(temp_file, 'wb') as fh:
+            shutil.copy2(self.command_line_options.config, backup_file)
+
+            with open(self.command_line_options.config, 'wb') as fh:
                 parser.write(fh)
 
-            os.rename(temp_file, self.command_line_options.config)
+            os.remove(backup_file)
         except Exception as ex:
             err('ConfigBase::save: Unable to save config: %s' % ex)
 

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -71,6 +71,7 @@ KeyError: 'ConfigBase::get_item: unknown key algo'
 """
 
 import os
+import pathlib
 import shutil
 from copy import copy
 from configobj import ConfigObj, flatten_errors
@@ -719,15 +720,19 @@ class ConfigBase(Borg):
         config_dir = get_config_dir()
         if not os.path.isdir(config_dir):
             os.makedirs(config_dir)
+
+        config_file = pathlib.Path(self.command_line_options.config)
+        if not config_file.is_file():
+            config_file.touch()
         try:
-            backup_file = self.command_line_options.config + '~'
+            backup_file = config_file.with_suffix('.bak')
 
-            shutil.copy2(self.command_line_options.config, backup_file)
+            shutil.copy2(config_file, backup_file)
 
-            with open(self.command_line_options.config, 'wb') as fh:
+            with open(config_file, 'wb') as fh:
                 parser.write(fh)
 
-            os.remove(backup_file)
+            backup_file.unlink()
         except Exception as ex:
             err('ConfigBase::save: Unable to save config: %s' % ex)
 

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -719,7 +719,11 @@ class ConfigBase(Borg):
         config_dir = get_config_dir()
         if not os.path.isdir(config_dir):
             os.makedirs(config_dir)
+
         try:
+            if not os.path.isfile(self.command_line_options.config):
+                open(self.command_line_options.config, 'a').close()
+
             backup_file = self.command_line_options.config + '~'
 
             shutil.copy2(self.command_line_options.config, backup_file)


### PR DESCRIPTION
This PR changes how the config file is saved.

Current behavior:
1. write parser contents to config.tmp
2. rename config.tmp to config

Proposed behavior:
1. copy config to config~
2. write parser contents to config
3. remove config~ (this could be optional)


Fixes #234