### PR TITLE
fix issue #74

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -36,7 +36,8 @@ class Overpaint(Vte.Terminal):
     def __init__(self):
         Vte.Terminal.__init__(self)
         self.config = Config()
-
+        self.dim_p = float(self.config['inactive_color_offset'])
+        self.dim_l = round(1.0 - self.dim_p,3) 
     def dim(self,b):
         self.overpaint = b
 
@@ -44,7 +45,7 @@ class Overpaint(Vte.Terminal):
         bgc = Vte.Terminal.get_color_background_for_draw(self)
         Vte.Terminal.do_draw(self,cr)
         if self.overpaint:
-            bgc.alpha = float(self.config['inactive_color_offset'])
+            bgc.alpha = self.dim_l
             cr.set_operator(cairo.Operator.OVER)
             Gdk.cairo_set_source_rgba(cr,bgc)
             cr.rectangle(0.0,0.0,self.get_allocated_width(),self.get_allocated_height())


### PR DESCRIPTION
This PR implements a different method for dimming terminals when the focus left them.  We used to manually go through each color in the user's settings and set them a little bit darker.  This works for 16 colors and 256 colors, but the vte people want to change this.  I've moved it so that we just paint a semi-transparent layer of the background color over the entire terminal and this approach actually simplifies the code quite a bit. 