### PR TITLE
replace feed_child_binary() calls with feed_child()

### DIFF
--- a/terminatorlib/plugins/custom_commands.py
+++ b/terminatorlib/plugins/custom_commands.py
@@ -126,7 +126,7 @@ class CustomCommandsMenu(plugin.MenuItem):
       if command[-1] != '\n':
         command = command + '\n'
       for terminal in data['terminals']:
-        terminal.vte.feed_child(command.encode(terminal.vte.get_encoding()))
+        terminal.vte.feed_child(command.encode())
 
     def configure(self, widget, data = None):
       ui = {}

--- a/terminatorlib/plugins/custom_commands.py
+++ b/terminatorlib/plugins/custom_commands.py
@@ -126,7 +126,7 @@ class CustomCommandsMenu(plugin.MenuItem):
       if command[-1] != '\n':
         command = command + '\n'
       for terminal in data['terminals']:
-        terminal.vte.feed_child_binary(command.encode(terminal.vte.get_encoding()))
+        terminal.vte.feed_child(command.encode(terminal.vte.get_encoding()))
 
     def configure(self, widget, data = None):
       ui = {}

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1198,8 +1198,7 @@ class Terminal(Gtk.VBox):
             ### Never send a CRLF to the terminal from here
             txt = txt.rstrip('\r\n')
             for term in self.terminator.get_target_terms(self):
-                txt = txt.encode(self.vte.get_encoding())
-                term.feed(txt)
+                term.feed(txt.encode())
             return
 
         widgetsrc = data.terminator.terminals[int(selection_data.get_data())]

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1198,6 +1198,7 @@ class Terminal(Gtk.VBox):
             ### Never send a CRLF to the terminal from here
             txt = txt.rstrip('\r\n')
             for term in self.terminator.get_target_terms(self):
+                txt = txt.encode(self.vte.get_encoding())
                 term.feed(txt)
             return
 
@@ -1596,7 +1597,7 @@ class Terminal(Gtk.VBox):
 
     def feed(self, text):
         """Feed the supplied text to VTE"""
-        self.vte.feed_child_binary(text.encode(self.vte.get_encoding()))
+        self.vte.feed_child(text)
 
     def zoom_in(self):
         """Increase the font size"""


### PR DESCRIPTION
feed_child_binary was a weird workaround in the VTE lib[1] it is now fixed and feed_child_binary is deprecated[2]

The downside of this is that feed_child now only accepts UTF-8 encoded strings.
I'm going to try this for now but may have to revert and lobby for feed_child_binary to come back, but we'll see how this goes.

[1] https://gitlab.gnome.org/GNOME/vte/-/issues/201
[2] https://lazka.github.io/pgi-docs/Vte-2.91/classes/Terminal.html#Vte.Terminal.feed_child_binary