### PR TITLE
fix issue with older vte lib

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -42,7 +42,13 @@ class Overpaint(Vte.Terminal):
         self.overpaint = b
 
     def do_draw(self,cr):
-        bgc = Vte.Terminal.get_color_background_for_draw(self)
+        ### get_color_background_for_draw is not available in older 
+        ### versions of vte
+        try:
+            bgc = Vte.Terminal.get_color_background_for_draw(self)
+        except AttributeError as e:
+            bgc = Gdk.RGBA()
+            bgc.parse(self.config['background_color'])
         Vte.Terminal.do_draw(self,cr)
         if self.overpaint:
             bgc.alpha = self.dim_l


### PR DESCRIPTION
The background overpainting stuff uses Vte.Terminal.get_color_background_for_draw() to get the background color, but this doesn't exist on versions prior to 0.60, if it doesn't exist, fallback to reading the background color from the config.  I think It's a bit slower, but it works.

fixes #292 