### PR TITLE
Update README with install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can find the project on https://github.com/gnome-terminator/terminator
 
 ## Installing
 
-Terminator is available for most (if not all) Linux distributions from the distribution's repository of binary packages.  It is also available on FreeBSD.   Please search your repository for `terminator`  If you want to build from source, or want to run the bleeding-edge master version, you can follow the instructions in [INSTALL.md](https://github.com/gnome-terminator/terminator/blob/master/INSTALL.md)
+Terminator is available for most (if not all) Linux distributions from the distribution's repository of binary packages.  It is also available on FreeBSD.   Please search your repository for `terminator`  If you want to find information on how to enable an updated package repository for your OS, build from source, or want to run the bleeding-edge master version, you can follow the instructions in [INSTALL.md](https://github.com/gnome-terminator/terminator/blob/master/INSTALL.md)
 
 
 #### Quick Start:


### PR DESCRIPTION
Added a hint on where to look for information on enabling terminator package repository.
Personally I couldn't find the new terminator in my Ubuntu 20.04 packages. Only the old terminator (1.9) was available.
There are instructions on how to add the custom ppa with binary for Ubuntu 20.04 in the  terminator/INSTALL.md.
Core README.md however makes it look like the INSTALL.md is only for source install.

It was just misleading, at least for me, and I was googling for a while on how to get this working having the information right under my nose.