### PR TITLE
load config from XDG_CONFIG_DIRS if user config file doesn't exist

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -606,7 +606,7 @@ class ConfigBase(Borg):
             dbg('ConfigBase::load: config already loaded')
             return
 
-        if self.command_line_options.config:
+        if self.command_line_options and self.command_line_options.config:
             filename = self.command_line_options.config
         else:
             filename = os.path.join(get_config_dir(), 'config')

--- a/terminatorlib/util.py
+++ b/terminatorlib/util.py
@@ -185,6 +185,15 @@ def widget_pixbuf(widget, maxsize=None):
     
     return(scaledpixbuf)
 
+def get_system_config_dir():
+    system_config_dir = '/etc/xdg'
+    if 'XDG_CONFIG_DIRS' in os.environ.keys():
+        for sysconfdir in os.environ['XDG_CONFIG_DIRS'].split(":"):
+                if os.path.isdir(sysconfdir):
+                    system_config_dir = sysconfdir
+                    break
+    return(os.path.join(system_config_dir,'terminator'))
+
 def get_config_dir():
     """Expand all the messy nonsense for finding where ~/.config/terminator
     really is"""


### PR DESCRIPTION
This makes us follow the XDG spec better.  If a user configuration doesn't exist in ~/.config/terminator/config look through the paths in the environment variable $XDG_CONFIG_DIRS and /etc/xdg [1]

fixes #308 

[1] https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html