### PR TITLE
fixed 'validate' module import for newer version of configobj

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -74,7 +74,10 @@ import os
 import shutil
 from copy import copy
 from configobj import ConfigObj, flatten_errors
-from validate import Validator
+try:
+    from validate import Validator
+except ModuleNotFoundError:
+    from configobj.validate import Validator
 from .borg import Borg
 from .util import dbg, err, DEBUG, get_system_config_dir, get_config_dir, dict_diff
 


### PR DESCRIPTION
In the last version of python-configobj (5.0.6-10), the path to the validate module has changed, this fixed #324.
For now downgrading to 5.0.6-9 fixes the problem, but it probably needs to be updated in the future

