### PR TITLE
Feature: Relaunch command option on held open after child exit

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -38,7 +38,7 @@ class Overpaint(Vte.Terminal):
         self.config = Config()
         ### inactive_color_offset is the opposite of alpha level
         self.dim_p = float(self.config['inactive_color_offset'])
-        self.dim_l = round(1.0 - self.dim_p,3) 
+        self.dim_l = round(1.0 - self.dim_p,3)
     def dim(self,b):
         self.overpaint = b
 

--- a/terminatorlib/terminal_popup_menu.py
+++ b/terminatorlib/terminal_popup_menu.py
@@ -179,6 +179,12 @@ class TerminalPopupMenu(object):
             menu.append(item)
             menu.append(Gtk.SeparatorMenuItem())
 
+        if terminal.is_held_open:
+            item = Gtk.MenuItem.new_with_mnemonic(_('Relaunch Command'))
+            item.connect('activate', lambda x: terminal.spawn_child())
+            menu.append(item)
+            menu.append(Gtk.SeparatorMenuItem())
+
         item = Gtk.CheckMenuItem.new_with_mnemonic(_('Show _scrollbar'))
         item.set_active(terminal.scrollbar.get_property('visible'))
         item.connect('toggled', lambda x: terminal.do_scrollbar_toggle())

--- a/terminatorlib/titlebar.py
+++ b/terminatorlib/titlebar.py
@@ -105,10 +105,14 @@ class Titlebar(Gtk.EventBox):
         """Update our contents"""
         default_bg = False
 
+        temp_heldtext_str = ''
         temp_sizetext_str = ''
+
+        if self.terminal.is_held_open:
+            temp_heldtext_str = _('[INACTIVE: Right-Click for Relaunch option] ')
         if not self.config['title_hide_sizetext']:
             temp_sizetext_str = " %s" % (self.sizetext)
-        self.label.set_text("%s%s" % (self.termtext, temp_sizetext_str))
+        self.label.set_text("%s%s%s" % (temp_heldtext_str, self.termtext, temp_sizetext_str))
 
         if (not self.config['title_use_system_font']) and self.config['title_font']:
             title_font = Pango.FontDescription(self.config['title_font'])

--- a/terminatorlib/titlebar.py
+++ b/terminatorlib/titlebar.py
@@ -104,10 +104,11 @@ class Titlebar(Gtk.EventBox):
     def update(self, other=None):
         """Update our contents"""
         default_bg = False
-        if self.config['title_hide_sizetext']:
-            self.label.set_text("%s" % self.termtext)
-        else:
-            self.label.set_text("%s %s" % (self.termtext, self.sizetext))
+
+        temp_sizetext_str = ''
+        if not self.config['title_hide_sizetext']:
+            temp_sizetext_str = " %s" % (self.sizetext)
+        self.label.set_text("%s%s" % (self.termtext, temp_sizetext_str))
 
         if (not self.config['title_use_system_font']) and self.config['title_font']:
             title_font = Pango.FontDescription(self.config['title_font'])


### PR DESCRIPTION
This is a forward port of a feature I added to a local 0.97 copy a number of years ago after switching away from Gnome Terminal.  This approach was what I figured out first, so it may not be the best way to implement the feature (the relaunch option in the right-click menu, for example), so I'm just putting this out there and wouldn't be surprised if it needs further development before merging.

I don't recall for sure, but Terminal.relaunch_command might have been needed for some use case I've now forgotten the details to.   I've not tried re-testing without it.