### PR TITLE
update to non-deprecated Gtk.Menu popup call

### DIFF
--- a/terminatorlib/terminal_popup_menu.py
+++ b/terminatorlib/terminal_popup_menu.py
@@ -237,7 +237,7 @@ class TerminalPopupMenu(object):
             err('TerminalPopupMenu::show: %s' % ex)
 
         menu.show_all()
-        menu.popup(None, None, None, None, button, time)
+        menu.popup_at_pointer(None)
 
         return(True)
 


### PR DESCRIPTION
apparently Gtk.Menu.popup() was deprecated in 3.22 and doesn't work on wayland and sway