### PR TITLE
Fix #345 The Alt+L layout chooser is too small

### DIFF
--- a/terminatorlib/layoutlauncher.glade
+++ b/terminatorlib/layoutlauncher.glade
@@ -26,7 +26,7 @@
                 <property name="hscrollbar_policy">never</property>
                 <property name="vscrollbar_policy">automatic</property>
                 <property name="width_request">250</property>
-                <property name="height_request">250</property>
+                <property name="height_request">300</property>
                 <child>
                   <object class="GtkTreeView" id="layoutlist">
                     <property name="visible">True</property>

--- a/terminatorlib/layoutlauncher.py
+++ b/terminatorlib/layoutlauncher.py
@@ -54,6 +54,7 @@ class LayoutLauncher:
             icon = self.window.render_icon(Gtk.STOCK_DIALOG_INFO, Gtk.IconSize.BUTTON)
             self.window.set_icon(icon)
 
+        self.window.set_size_request(250, 300)
         self.builder.connect_signals(self)
         self.window.connect('destroy', self.on_destroy_event)
         self.window.show_all()


### PR DESCRIPTION
I am not sure, but directly setting the size on Python fixed the issue in my platform.

I am also increasing the height +50 pixels because a rectangular size seems more fit than a square box.

![image](https://user-images.githubusercontent.com/5332158/103419887-b2526a80-4b73-11eb-87e8-e0db6e42fa2c.png)
