### PR TITLE
Update terminator.appdata.xml.in

### DIFF
--- a/data/terminator.appdata.xml.in
+++ b/data/terminator.appdata.xml.in
@@ -3,7 +3,7 @@
 <component type="desktop">
  <id>terminator.desktop</id>
  <metadata_license>CC0-1.0</metadata_license>
- <project_license>GPL-2.0 only</project_license>
+ <project_license>GPL-2.0-only</project_license>
  <_name>Terminator</_name>
  <_summary>Multiple terminals in one window</_summary>
  <description>
@@ -33,15 +33,15 @@
  </description>
  <screenshots>
   <screenshot type="default">
-   <image>http://4.bp.blogspot.com/-xt4Tja1TMQ0/Vdemmf8wYSI/AAAAAAAAA9A/uROTre0PMls/s1600/terminator_main_basic.png</image>
+   <image>https://4.bp.blogspot.com/-xt4Tja1TMQ0/Vdemmf8wYSI/AAAAAAAAA9A/uROTre0PMls/s1600/terminator_main_basic.png</image>
    <_caption>The main window showing the application in action</_caption>
   </screenshot>
   <screenshot>
-   <image>http://4.bp.blogspot.com/-rRxALSpEEZw/Vdeu58JgpnI/AAAAAAAAA9o/XewWKJ5HNo4/s1600/terminator_main_complex.png</image>
+   <image>https://4.bp.blogspot.com/-rRxALSpEEZw/Vdeu58JgpnI/AAAAAAAAA9o/XewWKJ5HNo4/s1600/terminator_main_complex.png</image>
    <_caption>Getting a little crazy with the terminals</_caption>
   </screenshot>
   <screenshot>
-   <image>http://2.bp.blogspot.com/-t_8oRyMXUls/VdemmRVnZnI/AAAAAAAAA88/rHIr8L1X7Ho/s1600/terminator_prefs_global.png</image>
+   <image>https://2.bp.blogspot.com/-t_8oRyMXUls/VdemmRVnZnI/AAAAAAAAA88/rHIr8L1X7Ho/s1600/terminator_prefs_global.png</image>
    <_caption>The preferences window where you can change the defaults</_caption>
   </screenshot>
  </screenshots>


### PR DESCRIPTION
This commit is based on a patch from Debian Salsa repository. See https://salsa.debian.org/python-team/packages/terminator/-/blob/7c08e04fb205a61e41110b3f274298c9c660efd1/debian/patches/appdata_improvement.patch

- Changed screenshots urls from http to https
- Updated the license identifier to match [SPDX licence list](https://spdx.org/licenses/) (the one on the debian patch is a deprecated identifier)