### PR TITLE
Fixed race condition when calling grab_focus after underlying vte could be closed

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1244,7 +1244,7 @@ class Terminal(Gtk.VBox):
 
     def grab_focus(self):
         """Steal focus for this terminal"""
-        if not self.vte.has_focus():
+        if self.vte and not self.vte.has_focus():
             self.vte.grab_focus()
 
     def ensure_visible_and_focussed(self):


### PR DESCRIPTION
I found a race condition where the command I specified for the new vte had already exited by the time `grab_focus` was called. This caused the terminal to start cleaning up and the `self.vte` was `None` by the time `grab_focus` executed.

This caused a `Could not call method 'has_focus()' on NoneType` error. Not a huge deal because the terminal closed itself anyway. Easy fix to avoid the error by adding the None check before the `has_focus` call.