### PR TITLE
Added new get_focused_terminal dbus command which returns uuid of current focused terminal

### DIFF
--- a/remotinator
+++ b/remotinator
@@ -35,17 +35,18 @@ from terminatorlib.translation import _
 APP_NAME='remotinator'
 
 COMMANDS={
-    #  Command         uuid req.    Description
-    'new_window':       [False, _('Open a new window')],
-    'new_tab':          [True,  _('Open a new tab')],
-    'hsplit':           [True,  _('Split the current terminal horizontally')],
-    'vsplit':           [True,  _('Split the current terminal vertically')],
-    'get_terminals':    [False, _('Get a list of all terminals')],
-    'get_window':       [True,  _('Get the UUID of a parent window')],
-    'get_window_title': [True,  _('Get the title of a parent window')],
-    'get_tab':          [True,  _('Get the UUID of a parent tab')],
-    'get_tab_title':    [True,  _('Get the title of a parent tab')],
-    'switch_profile':   [True,  _('Switch current terminal profile')],
+    #  Command             uuid req.    Description
+    'new_window':           [False, _('Open a new window')],
+    'new_tab':              [True,  _('Open a new tab')],
+    'hsplit':               [True,  _('Split the current terminal horizontally')],
+    'vsplit':               [True,  _('Split the current terminal vertically')],
+    'get_terminals':        [False, _('Get a list of all terminals')],
+    'get_focused_terminal': [False, _('Get the uuid of the current focused terminal')],
+    'get_window':           [True,  _('Get the UUID of a parent window')],
+    'get_window_title':     [True,  _('Get the title of a parent window')],
+    'get_tab':              [True,  _('Get the UUID of a parent tab')],
+    'get_tab_title':        [True,  _('Get the title of a parent tab')],
+    'switch_profile':      [True,  _('Switch current terminal profile')],
     }
 
 if __name__ == '__main__':
@@ -88,9 +89,9 @@ if __name__ == '__main__':
     if uuid_required:
         uuid = options.get('uuid', os.environ.get('TERMINATOR_UUID'))
         if uuid:
-            func(uuid, options)
+            print(str(func(uuid, options)))
         else:
             err("$TERMINATOR_UUID is not set, or passed as an option.")
             sys.exit(1)
     else:
-        func(options)
+        print(str(func(options)))

--- a/terminatorlib/ipc.py
+++ b/terminatorlib/ipc.py
@@ -151,6 +151,13 @@ class DBusService(Borg, dbus.service.Object):
         return [x.uuid.urn for x in self.terminator.terminals]
 
     @dbus.service.method(BUS_NAME)
+    def get_focused_terminal(self):
+        """Returns the uuid of the currently focused terminal"""
+        if self.terminator.last_focused_term:
+            return self.terminator.last_focused_term.uuid.urn
+        return None
+
+    @dbus.service.method(BUS_NAME)
     def get_window(self, uuid=None):
         """Return the UUID of the parent window of a given terminal"""
         terminal = self.terminator.find_terminal_by_uuid(uuid)
@@ -217,7 +224,7 @@ def with_proxy(func):
                 "Remotinator can't connect to terminator. " +
                 "May be terminator is not running.")
 
-        func(proxy, *args, **argd)
+        return func(proxy, *args, **argd)
     return _exec
 
 @with_proxy
@@ -258,6 +265,11 @@ def vsplit(session, uuid, options):
 def get_terminals(session, options):
     """Call the dbus method to return a list of all terminals"""
     print('\n'.join(session.get_terminals()))
+
+@with_proxy
+def get_focused_terminal(session, options):
+    """Call the dbus method to return the currently focused terminal"""
+    return session.get_focused_terminal()
 
 @with_proxy
 def get_window(session, uuid, options):


### PR DESCRIPTION
I found `has_focus` wasn't working but `self.terminator.last_focused_term.uuid.urn` seems to be working. I also updated remotinator to support new `get_focused_terminal` ipc command.