### PR TITLE
Add new vsplit hsplit cmd dbus

### DIFF
--- a/remotinator
+++ b/remotinator
@@ -35,17 +35,18 @@ from terminatorlib.translation import _
 APP_NAME='remotinator'
 
 COMMANDS={
-    #  Command         uuid req.    Description
-    'new_window':       [False, _('Open a new window')],
-    'new_tab':          [True,  _('Open a new tab')],
-    'hsplit':           [True,  _('Split the current terminal horizontally')],
-    'vsplit':           [True,  _('Split the current terminal vertically')],
-    'get_terminals':    [False, _('Get a list of all terminals')],
-    'get_window':       [True,  _('Get the UUID of a parent window')],
-    'get_window_title': [True,  _('Get the title of a parent window')],
-    'get_tab':          [True,  _('Get the UUID of a parent tab')],
-    'get_tab_title':    [True,  _('Get the title of a parent tab')],
-    'switch_profile':   [True,  _('Switch current terminal profile')],
+    #  Command             uuid req.    Description
+    'new_window':           [False, _('Open a new window')],
+    'new_tab':              [True,  _('Open a new tab')],
+    'hsplit':               [True,  _('Split the current terminal horizontally')],
+    'vsplit':               [True,  _('Split the current terminal vertically')],
+    'get_terminals':        [False, _('Get a list of all terminals')],
+    'get_focused_terminal': [False, _('Get the uuid of the current focused terminal')],
+    'get_window':           [True,  _('Get the UUID of a parent window')],
+    'get_window_title':     [True,  _('Get the title of a parent window')],
+    'get_tab':              [True,  _('Get the UUID of a parent tab')],
+    'get_tab_title':        [True,  _('Get the title of a parent tab')],
+    'switch_profile':      [True,  _('Switch current terminal profile')],
     }
 
 if __name__ == '__main__':
@@ -88,9 +89,9 @@ if __name__ == '__main__':
     if uuid_required:
         uuid = options.get('uuid', os.environ.get('TERMINATOR_UUID'))
         if uuid:
-            func(uuid, options)
+            print(str(func(uuid, options)))
         else:
             err("$TERMINATOR_UUID is not set, or passed as an option.")
             sys.exit(1)
     else:
-        func(options)
+        print(str(func(options)))

--- a/terminatorlib/ipc.py
+++ b/terminatorlib/ipc.py
@@ -151,6 +151,13 @@ class DBusService(Borg, dbus.service.Object):
         return [x.uuid.urn for x in self.terminator.terminals]
 
     @dbus.service.method(BUS_NAME)
+    def get_focused_terminal(self):
+        """Returns the uuid of the currently focused terminal"""
+        if self.terminator.last_focused_term:
+            return self.terminator.last_focused_term.uuid.urn
+        return None
+
+    @dbus.service.method(BUS_NAME)
     def get_window(self, uuid=None):
         """Return the UUID of the parent window of a given terminal"""
         terminal = self.terminator.find_terminal_by_uuid(uuid)
@@ -217,7 +224,7 @@ def with_proxy(func):
                 "Remotinator can't connect to terminator. " +
                 "May be terminator is not running.")
 
-        func(proxy, *args, **argd)
+        return func(proxy, *args, **argd)
     return _exec
 
 @with_proxy
@@ -258,6 +265,11 @@ def vsplit(session, uuid, options):
 def get_terminals(session, options):
     """Call the dbus method to return a list of all terminals"""
     print('\n'.join(session.get_terminals()))
+
+@with_proxy
+def get_focused_terminal(session, options):
+    """Call the dbus method to return the currently focused terminal"""
+    return session.get_focused_terminal()
 
 @with_proxy
 def get_window(session, uuid, options):

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1420,10 +1420,10 @@ class Terminal(Gtk.VBox):
         self.is_held_open = True
         self.titlebar.update()
 
-    def spawn_child(self, widget=None, respawn=False, debugserver=False):
+    def spawn_child(self, init_command=None, widget=None, respawn=False, debugserver=False):
         args = []
         shell = None
-        command = None
+        command = init_command
 
         if self.terminator.doing_layout:
             dbg('still laying out, refusing to spawn a child')


### PR DESCRIPTION
This includes get_focused_terminal pull request too (which was separately functional) to add new `vsplit_cmd` and `hsplit_cmd` dbus ipc commands.

Now we can get the focused_terminal and then split it and run a command all over dbus. Here is the python that could call the new `hsplit_cmd`

```
   focused_terminal_uuid = ipc.get_focused_terminal(None)
   ipc.hsplit_cmd(focused_terminal_uuid, 'iftop', 'sudo /sbin/iftop -i eth0', None)
```

Then we see terminator now spawns and names the new horizontal split appropriately

![2021 02 18_23-06-01](https://user-images.githubusercontent.com/116830/108458798-489a3700-726d-11eb-945b-2798610e7f50.png)
