### PR TITLE
add feat: config to open links with single click

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -125,6 +125,7 @@ DEFAULTS = {
             'line_height'           : 1.0,
             'case_sensitive'        : True,
             'invert_search'         : False,
+            'link_single_click'     : False,
         },
         'keybindings': {
             'zoom_in'          : '<Control>plus',

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkListStore" id="BackspaceKeyListStore">
@@ -345,20 +345,20 @@
   </object>
   <object class="GtkAdjustment" id="adjustment7">
     <property name="upper">1</property>
-    <property name="step_increment">0.1</property>
-    <property name="page_increment">0.2</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">0.20000000000000001</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_lineheight">
     <property name="lower">1</property>
     <property name="upper">2</property>
     <property name="value">1</property>
-    <property name="step_increment">0.1</property>
-    <property name="page_increment">0.2</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">0.20000000000000001</property>
   </object>
   <object class="GtkAdjustment" id="background_darkness_scale">
     <property name="upper">1</property>
-    <property name="step_increment">0.1</property>
-    <property name="page_increment">0.2</property>
+    <property name="step_increment">0.10000000000000001</property>
+    <property name="page_increment">0.20000000000000001</property>
   </object>
   <object class="GtkWindow" id="prefswin">
     <property name="can_focus">False</property>
@@ -366,6 +366,9 @@
     <property name="title" translatable="yes">Terminator Preferences</property>
     <property name="default_width">640</property>
     <property name="default_height">400</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkBox" id="dialog_vbox1">
         <property name="visible">True</property>
@@ -700,7 +703,7 @@
                                   </object>
                                   <packing>
                                     <property name="left_attach">0</property>
-                                    <property name="top_attach">5</property>
+                                    <property name="top_attach">6</property>
                                     <property name="width">3</property>
                                   </packing>
                                 </child>
@@ -747,7 +750,7 @@
                                   </object>
                                   <packing>
                                     <property name="left_attach">0</property>
-                                    <property name="top_attach">6</property>
+                                    <property name="top_attach">7</property>
                                     <property name="width">4</property>
                                   </packing>
                                 </child>
@@ -799,6 +802,21 @@
                                     <property name="left_attach">2</property>
                                     <property name="top_attach">3</property>
                                     <property name="width">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="link_single_click">
+                                    <property name="label" translatable="yes">Open links with a single click (instead of Ctrl-left click)</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="draw_indicator">True</property>
+                                    <signal name="toggled" handler="on_link_single_click_toggled" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">5</property>
+                                    <property name="width">4</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -3256,7 +3274,7 @@
                             <property name="use_markup">True</property>
                             <property name="wrap">True</property>
                             <property name="xalign">0</property>
-                            <property name="yalign">0.00000000745058015283</property>
+                            <property name="yalign">7.4505801528346183e-09</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
@@ -4106,9 +4124,6 @@ Much of the behavior of Terminator is based on GNOME Terminal, and we are adding
         </child>
       </object>
     </child>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
   </object>
   <object class="GtkSizeGroup" id="sizegroup1">
     <widgets>
@@ -4141,7 +4156,7 @@ Much of the behavior of Terminator is based on GNOME Terminal, and we are adding
   </object>
   <object class="GtkAdjustment" id="background_image_shading_adjustment">
     <property name="upper">1</property>
-    <property name="step_increment">0.1</property>
+    <property name="step_increment">0.10000000000000001</property>
     <property name="page_increment">0.01</property>
   </object>
 </interface>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -24,7 +24,7 @@ def get_color_string(widcol):
 
 def color2hex(widget):
     """Pull the colour values out of a Gtk ColorPicker widget and return them
-    as 8bit hex values, sinces its default behaviour is to give 16bit values"""
+   as 8bit hex values, sinces its default behaviour is to give 16bit values"""
     return get_color_string(widget.get_color())
 
 def rgba2hex(widget):
@@ -619,6 +619,9 @@ class PrefsEditor:
         widget.set_value(float(self.config['inactive_color_offset']))
         widget = guiget('inactive_color_offset_value_label')
         widget.set_text('%d%%' % (int(float(self.config['inactive_color_offset'])*100)))
+        # Open links with a single click (instead of a Ctrl-left click)
+        widget = guiget('link_single_click')
+        widget.set_active(self.config['link_single_click'])
         # Use custom URL handler
         widget = guiget('use_custom_url_handler_checkbox')
         widget.set_active(self.config['use_custom_url_handler'])
@@ -1417,6 +1420,10 @@ class PrefsEditor:
         self.config.del_layout(layout)
         model.remove(rowiter)
         selection.select_iter(model.get_iter_first())
+        self.config.save()
+
+    def on_link_single_click_toggled(self, checkbox):
+        self.config['link_single_click'] = widget.get_active()
         self.config.save()
 
     def on_use_custom_url_handler_checkbutton_toggled(self, checkbox):

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1423,6 +1423,9 @@ class PrefsEditor:
         self.config.save()
 
     def on_link_single_click_toggled(self, checkbox):
+        """Configure link_single_click option from checkbox."""
+        guiget = self.builder.get_object
+        widget = guiget('link_single_click')
         self.config['link_single_click'] = widget.get_active()
         self.config.save()
 

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -942,7 +942,7 @@ class Terminal(Gtk.VBox):
         # Ctrl-click event here.
         if event.button == self.MOUSEBUTTON_LEFT:
             # Ctrl+leftclick on a URL should open it
-            if event.get_state() & Gdk.ModifierType.CONTROL_MASK == Gdk.ModifierType.CONTROL_MASK:
+            if self.config["link_single_click"] or event.get_state() & Gdk.ModifierType.CONTROL_MASK == Gdk.ModifierType.CONTROL_MASK:
                 # Check new OSC-8 method first
                 url = self.vte.hyperlink_check_event(event)
                 dbg('url: %s' % url)


### PR DESCRIPTION
Instead of Ctrl-left click.

Note: I only have glade 3.22.2 instead of the 3.36.0 used for the previous setup.
I guess that's why there have been some editions in the XML, apart for the new checkbox.
I have absolutely no idea if that's a problem or not… the window works well on my Ubuntu 20.04, at least.