### PR TITLE
Tmux control mode v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ terminatorlib/meliae
 .intltool*
 data/terminator.appdata.xml
 data/terminator.desktop
+
+venv/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ Packages are known to be available under the name "terminator" under a
 lot of distributions, see below for a list.
 
 I also maintain a PPA for Ubuntu 20.04 and up that has the latest release
-If you're running ubuntu 20.04 or later, you can run 
+If you're running ubuntu 20.04 or later, you can run
 
 ```
 sudo add-apt-repository ppa:mattrose/terminator
@@ -24,13 +24,19 @@ dependencies yourself:
 **Python 3.5+ recommended:** `python3` or `python37` (in FreeBSD)
 
 **Python GTK and VTE bindings:**
-     
-     Fedora/CentOS: python3-gobject python3-configobj python3-psutil vte291 
+
+     Fedora/CentOS: python3-gobject python3-configobj python3-psutil vte291
                     keybinder3 intltool gettext
-     Debian/Ubuntu: python3-gi python3-gi-cairo python3-psutil python3-configobj 
-                    gir1.2-keybinder-3.0 gir1.2-vte-2.91 gettext intltool dbus-x11 
-     FreeBSD:       py37-psutil py37-configobj keybinder-gtk3 py37-gobject3 gettext 
+     Debian/Ubuntu: python3-gi python3-gi-cairo python3-psutil python3-configobj
+                    gir1.2-keybinder-3.0 gir1.2-vte-2.91 gettext intltool dbus-x11
+     FreeBSD:       py37-psutil py37-configobj keybinder-gtk3 py37-gobject3 gettext
                     intltool libnotify vte3
+
+**Python PyParsing library (only required for Tmux mode):**
+
+     Debian/Ubuntu: python-pyparsing
+
+     FreeBSD: devel/py-pyparsing
 
 If you don't care about native language support or icons, Terminator
 should run just fine directly from this directory, just:
@@ -43,7 +49,7 @@ And go from there.  Manpages are available in the 'doc' directory.
 > make sure to update either the shebangs, call the scripts with `python3` or
 > use a wrapper script.
 >
-> Setuptools install will update the scripts with the correct shebang.  
+> Setuptools install will update the scripts with the correct shebang.
 
 To install properly, run:
 
@@ -74,7 +80,7 @@ Where ${PREFIX} is the base install directory; e.g. /usr/local.
 If you maintain terminator for an OS other than these, please get in touch
 or issue a PR to this file.
 
-Distribution | Contact | Package Info | Source Code | Bug Tracker | 
+Distribution | Contact | Package Info | Source Code | Bug Tracker |
 -------------|---------|-----|-------------|-------------|
 ArchLinux    | [@grazzolini] | [archlinux.org] | [git.archlinux.org] | [bugs.archlinux.org]
 CentOS EPEL  | [@mattrose], [@dmaphy] |  | [src.fedoraproject.org/branches]

--- a/TMUX.md
+++ b/TMUX.md
@@ -4,10 +4,10 @@ Terminator support the [tmux control mode](http://man7.org/linux/man-pages/man1/
 
 Remote SSH example, starts tmux on remote host and displays tabs and splits in terminator:
 ```
-terminator -M --remote example.org
+terminator -t --remote example.org
 ```
 
 Local session:
 ```
-terminator -M
+terminator -t
 ```

--- a/TMUX.md
+++ b/TMUX.md
@@ -1,0 +1,13 @@
+# Tmux control mode
+
+Terminator support the [tmux control mode](http://man7.org/linux/man-pages/man1/tmux.1.html#CONTROL_MODE).
+
+Remote SSH example, starts tmux on remote host and displays tabs and splits in terminator:
+```
+terminator -M --remote example.org
+```
+
+Local session:
+```
+terminator -M
+```

--- a/setup.py
+++ b/setup.py
@@ -230,6 +230,7 @@ setup(name=APP_NAME,
       packages=[
           'terminatorlib',
           'terminatorlib.plugins',
+          'terminatorlib.tmux',
       ],
       setup_requires=[
           'pytest-runner',

--- a/terminator
+++ b/terminator
@@ -23,6 +23,7 @@ import sys
 import os
 import psutil
 import pwd
+import time
 try:
     ORIGCWD = os.getcwd()
 except OSError:
@@ -88,8 +89,10 @@ if __name__ == '__main__':
         # continue. Failure to import dbus, or the global config option "dbus"
         # being False will cause us to continue without the dbus server and open a
         # window.
+        # Disable DBUS if using tmux, so we can have multiple sessions (e.g. local
+        # and remote, multiple remotes, etc.)
         try:
-            if OPTIONS.nodbus:
+            if OPTIONS.nodbus or OPTIONS.tmux:
                 dbg('dbus disabled by command line')
                 raise ImportError
             from terminatorlib import ipc
@@ -125,12 +128,17 @@ if __name__ == '__main__':
         TERMINATOR.ibus_running = ibus_running
 
         try:
+            if OPTIONS.tmux:
+                TERMINATOR.start_tmux(remote=OPTIONS.remote)
+                while TERMINATOR.initial_layout is None:
+                    time.sleep(0.1)
             dbg('Creating a terminal with layout: %s' % OPTIONS.layout)
             TERMINATOR.create_layout(OPTIONS.layout)
         except (KeyError,ValueError) as ex:
             err('layout creation failed, creating a window ("%s")' % ex)
             TERMINATOR.new_window()
         TERMINATOR.layout_done()
+        TERMINATOR.initial_layout = None
 
     if OPTIONS.debug and OPTIONS.debug >= 2:
         import terminatorlib.debugserver as debugserver

--- a/terminatorlib/cwd.py
+++ b/terminatorlib/cwd.py
@@ -14,6 +14,8 @@ from .util import dbg
 
 def get_pid_cwd(pid = None):
     """Determine the cwd of the current process"""
+    if pid is not None:
+        pid = int(pid)
     psinfo =  psutil.Process(pid).as_dict()
     dbg('psinfo: %s %s' % (psinfo['cwd'],psinfo['pid']))
     # return func

--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -164,7 +164,9 @@ class Notebook(Container, Gtk.Notebook):
             sibling.set_cwd(cwd)
             if self.config['always_split_with_profile']:
                 sibling.force_set_profile(None, widget.get_profile())
-            sibling.spawn_child()
+            sibling.spawn_child(
+                orientation='vertical' if vertical else 'horizontal',
+                active_pane_id=getattr(widget, 'pane_id', None))
             if widget.group and self.config['split_to_group']:
                 sibling.set_group(None, widget.group)
         elif self.config['always_split_with_profile']:

--- a/terminatorlib/optionparse.py
+++ b/terminatorlib/optionparse.py
@@ -57,7 +57,7 @@ def parse_options():
             dest='borderless', help=_('Disable window borders'))
     parser.add_option('-H', '--hidden', action='store_true', dest='hidden',
             help=_('Hide the window at startup'))
-    parser.add_option('-M', '--tmux', action='store_true',
+    parser.add_option('-t', '--tmux', action='store_true',
             dest='tmux', help=_('Enable tmux integration'))
     parser.add_option('-T', '--title', dest='forcedtitle', 
                       help=_('Specify a title for the window'))

--- a/terminatorlib/optionparse.py
+++ b/terminatorlib/optionparse.py
@@ -57,6 +57,8 @@ def parse_options():
             dest='borderless', help=_('Disable window borders'))
     parser.add_option('-H', '--hidden', action='store_true', dest='hidden',
             help=_('Hide the window at startup'))
+    parser.add_option('-M', '--tmux', action='store_true',
+            dest='tmux', help=_('Enable tmux integration'))
     parser.add_option('-T', '--title', dest='forcedtitle', 
                       help=_('Specify a title for the window'))
     parser.add_option('--geometry', dest='geometry', type='string', 
@@ -72,6 +74,8 @@ def parse_options():
                 callback=execute_cb, 
                 help=_('Use the rest of the command line as a command to '
                        'execute inside the terminal, and its arguments'))
+    parser.add_option('--remote', dest='remote',
+            help=_('Specify a remote server for tmux to connect to'))
     parser.add_option('-g', '--config', dest='config', 
                       help=_('Specify a config file'))
     parser.add_option('-j', '--config-json', dest='configjson', 

--- a/terminatorlib/paned.py
+++ b/terminatorlib/paned.py
@@ -52,7 +52,9 @@ class Paned(Container):
             sibling.set_cwd(cwd)
             if self.config['always_split_with_profile']:
                 sibling.force_set_profile(None, widget.get_profile())
-            sibling.spawn_child()
+            sibling.spawn_child(
+                orientation='vertical' if vertical else 'horizontal',
+                active_pane_id=getattr(widget, 'pane_id', None))
             if widget.group and self.config['split_to_group']:
                 sibling.set_group(None, widget.group)
         elif self.config['always_split_with_profile']:

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -274,6 +274,9 @@ class Terminal(Gtk.VBox):
     def get_cwd(self):
         """Return our cwd"""
         vte_cwd = self.vte.get_current_directory_uri()
+        if self.terminator.tmux_control and self.terminator.tmux_control.remote is not None:
+            return None
+
         if vte_cwd:
             # OSC7 pwd gives an answer
             return(GLib.filename_from_uri(vte_cwd)[0])

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -929,6 +929,7 @@ class Terminal(Gtk.VBox):
 
         if self.terminator.tmux_control:
             self.control.send_keypress(event, pane_id=self.pane_id)
+            return True
 
         return False
 

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     from urllib import unquote as urlunquote
 
-from .util import dbg, err, spawn_new_terminator, make_uuid, manual_lookup, display_manager
+from .util import dbg, err, spawn_new_terminator, make_uuid, manual_lookup, display_manager, get_column_row_count
 from . import util
 from .config import Config
 from .cwd import get_pid_cwd

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1512,6 +1512,7 @@ class Terminal(Gtk.VBox):
 
         dbg('Forking shell: "%s" with args: %s' % (shell, args))
         if self.terminator.tmux_control:
+            dbg('Sending command to a new tmux pane: {}' % args)
             if self.terminator.initial_layout:
                 pass
             else:
@@ -1523,6 +1524,7 @@ class Terminal(Gtk.VBox):
                                          orientation=orientation,
                                          pane_id=active_pane_id)
         else:
+            dbg('Forking shell: "%s" with args: %s' % (shell, args))
             args.insert(0, shell)
             result,  self.pid = self.vte.spawn_sync(Vte.PtyFlags.DEFAULT,
                                                     self.cwd,

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1518,11 +1518,11 @@ class Terminal(Gtk.VBox):
             else:
                 command = ' '.join(args)
                 self.pane_id = str(util.make_uuid())
-                self.control.run_command(command=command,
-                                         cwd=self.cwd,
-                                         marker=self.pane_id,
-                                         orientation=orientation,
-                                         pane_id=active_pane_id)
+                self.control.spawn_tmux_child(command=command,
+                                              cwd=self.cwd,
+                                              marker=self.pane_id,
+                                              orientation=orientation,
+                                              pane_id=active_pane_id)
         else:
             dbg('Forking shell: "%s" with args: %s' % (shell, args))
             args.insert(0, shell)

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -421,7 +421,6 @@ class Terminal(Gtk.VBox):
 
     def connect_signals(self):
         """Connect all the gtk signals and drag-n-drop mechanics"""
-
         self.scrollbar.connect('button-press-event', self.on_buttonpress)
 
         self.cnxids.new(self.vte, 'key-press-event', self.on_keypress)

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1742,7 +1742,7 @@ class Terminal(Gtk.VBox):
             self.directory = layout['directory']
         if 'uuid' in layout and layout['uuid'] != '':
             self.uuid = make_uuid(layout['uuid'])
-        if layout.has_key('tmux'):
+        if 'tmux' in layout and layout['tmux'] != '':
             tmux = layout['tmux']
             self.pane_id = tmux['pane_id']
             self.terminator.pane_id_to_terminal[self.pane_id] = self

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1075,6 +1075,10 @@ class Terminal(Gtk.VBox):
             # on self
             return
 
+        if self.terminator.tmux_control:
+            # Moving the terminals around is not supported in tmux mode
+            return
+
         alloc = widget.get_allocation()
 
         if self.config['use_theme_colors']:
@@ -1196,6 +1200,10 @@ class Terminal(Gtk.VBox):
 
         # The widget argument is actually a Vte.Terminal(). Turn that into a
         # terminatorlib Terminal()
+        if self.terminator.tmux_control:
+            # Moving the terminals around is not supported in tmux mode
+            return
+
         maker = Factory()
         while True:
             widget = widget.get_parent()
@@ -1620,10 +1628,16 @@ class Terminal(Gtk.VBox):
 
     def zoom_in(self):
         """Increase the font size"""
+        if self.terminator.tmux_control:
+            # Zooming causes all kinds of issues when in tmux mode, so we'll just disable it for now
+            return
         self.zoom_font(True)
 
     def zoom_out(self):
         """Decrease the font size"""
+        if self.terminator.tmux_control:
+            # Zooming causes all kinds of issues when in tmux mode, so we'll just disable it for now
+            return
         self.zoom_font(False)
 
     def zoom_font(self, zoom_in):
@@ -1642,6 +1656,9 @@ class Terminal(Gtk.VBox):
 
     def zoom_orig(self):
         """Restore original font size"""
+        if self.terminator.tmux_control:
+            # Zooming causes all kinds of issues when in tmux mode, so we'll just disable it for now
+            return
         if self.config['use_system_font']:
             font = self.config.get_system_mono_font()
         else:

--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -16,8 +16,8 @@ from .keybindings import Keybindings
 from .util import dbg, err, enumerate_descendants
 from .factory import Factory
 from .version import APP_NAME, APP_VERSION
-import tmux.control
-import tmux.notifications
+from .tmux import notifications
+from .tmux import control
 
 try:
     from gi.repository import GdkX11
@@ -100,10 +100,6 @@ class Terminator(Borg):
             self.style_providers = []
         if not self.doing_layout:
             self.doing_layout = False
-        if not self.pid_cwd:
-            self.pid_cwd = get_pid_cwd()
-        if self.gnome_client is None:
-            self.attempt_gnome_client()
         if self.pane_id_to_terminal is None:
             self.pane_id_to_terminal = {}
 
@@ -125,8 +121,8 @@ class Terminator(Borg):
     def start_tmux(self, remote=None):
         """Store the command line argument intended for tmux and start the process"""
         if self.tmux_control is None:
-            handler = tmux.notifications.NotificationsHandler(self)
-            self.tmux_control = tmux.control.TmuxControl(
+            handler = notifications.NotificationsHandler(self)
+            self.tmux_control = control.TmuxControl(
                 session_name='terminator',
                 notifications_handler=handler)
         self.tmux_control.remote = remote
@@ -522,7 +518,7 @@ class Terminator(Borg):
             css += """
                 .terminator-terminal-window separator {
                     min-height: %spx;
-                    min-width: %spx; 
+                    min-width: %spx;
                 }
                 """ % (self.config['handle_size'],self.config['handle_size'])
         style_provider = Gtk.CssProvider()
@@ -668,11 +664,11 @@ class Terminator(Borg):
     def zoom_in_all(self):
         for term in self.terminals:
             term.zoom_in()
-    
+
     def zoom_out_all(self):
         for term in self.terminals:
             term.zoom_out()
-    
+
     def zoom_orig_all(self):
         for term in self.terminals:
             term.zoom_orig()

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -64,7 +64,7 @@ class TmuxControl(object):
             return
         popen_command = "ssh " + self.remote
         self.tmux = subprocess.Popen(
-            popen_command, stdout=subprocess.PIPE, stdin=subprocess.PIPE, shell=True
+            popen_command, stdout=subprocess.PIPE, stdin=subprocess.PIPE, shell=True, bufsize=0
         )
         self.input = self.tmux.stdin
         self.output = self.tmux.stdout

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -130,7 +130,7 @@ class TmuxControl(object):
         if not self.tmux:
             self.tmux = subprocess.Popen(popen_command,
                                      stdout=subprocess.PIPE,
-                                     stdin=subprocess.PIPE)
+                                     stdin=subprocess.PIPE, bufsize=0)
             self.input = self.tmux.stdin
             self.output = self.tmux.stdout
         self.requests.put(notifications.noop)

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -9,42 +9,38 @@ from gi.repository import Gtk, Gdk
 from terminatorlib.tmux import notifications
 from terminatorlib.util import dbg
 
-ESCAPE_CODE = '\033'
-TMUX_BINARY = 'tmux'
+ESCAPE_CODE = "\033"
+TMUX_BINARY = "tmux"
+
 
 def esc(seq):
-    return '{}{}'.format(ESCAPE_CODE, seq)
+    return "{}{}".format(ESCAPE_CODE, seq)
 
 
 KEY_MAPPINGS = {
-    Gdk.KEY_BackSpace: '\b',
-    Gdk.KEY_Tab: '\t',
-    Gdk.KEY_Insert: esc('[2~'),
-    Gdk.KEY_Delete: esc('[3~'),
-    Gdk.KEY_Page_Up: esc('[5~'),
-    Gdk.KEY_Page_Down: esc('[6~'),
-    Gdk.KEY_Home: esc('[1~'),
-    Gdk.KEY_End: esc('[4~'),
-    Gdk.KEY_Up: esc('[A'),
-    Gdk.KEY_Down: esc('[B'),
-    Gdk.KEY_Right: esc('[C'),
-    Gdk.KEY_Left: esc('[D'),
+    Gdk.KEY_BackSpace: "\b",
+    Gdk.KEY_Tab: "\t",
+    Gdk.KEY_Insert: esc("[2~"),
+    Gdk.KEY_Delete: esc("[3~"),
+    Gdk.KEY_Page_Up: esc("[5~"),
+    Gdk.KEY_Page_Down: esc("[6~"),
+    Gdk.KEY_Home: esc("[1~"),
+    Gdk.KEY_End: esc("[4~"),
+    Gdk.KEY_Up: esc("[A"),
+    Gdk.KEY_Down: esc("[B"),
+    Gdk.KEY_Right: esc("[C"),
+    Gdk.KEY_Left: esc("[D"),
 }
-ARROW_KEYS = {
-    Gdk.KEY_Up,
-    Gdk.KEY_Down,
-    Gdk.KEY_Left,
-    Gdk.KEY_Right
-}
+ARROW_KEYS = {Gdk.KEY_Up, Gdk.KEY_Down, Gdk.KEY_Left, Gdk.KEY_Right}
 MOUSE_WHEEL = {
     # TODO: make it configurable, e.g. like better-mouse-mode plugin
     Gdk.ScrollDirection.UP: "C-y C-y C-y",
     Gdk.ScrollDirection.DOWN: "C-e C-e C-e",
 }
 
+
 # TODO: implement ssh connection using paramiko
 class TmuxControl(object):
-
     def __init__(self, session_name, notifications_handler):
         self.session_name = session_name
         self.notifications_handler = notifications_handler
@@ -67,10 +63,10 @@ class TmuxControl(object):
             dbg("Already connected.")
             return
         popen_command = "ssh " + self.remote
-        self.tmux = subprocess.Popen(popen_command,
-                                 stdout=subprocess.PIPE,
-                                 stdin=subprocess.PIPE, shell=True)
-        self.input  = self.tmux.stdin
+        self.tmux = subprocess.Popen(
+            popen_command, stdout=subprocess.PIPE, stdin=subprocess.PIPE, shell=True
+        )
+        self.input = self.tmux.stdin
         self.output = self.tmux.stdout
 
         self.run_remote_command(command)
@@ -79,77 +75,93 @@ class TmuxControl(object):
         popen_command = map(quote, popen_command)
         command = " ".join(popen_command)
         if not self.input:
-            dbg('No tmux connection. [command={}]'.format(command))
+            dbg("No tmux connection. [command={}]".format(command))
         else:
             try:
-                self.input.write('exec {}\n'.format(command).encode())
+                self.input.write("exec {}\n".format(command).encode())
             except IOError:
                 dbg("Tmux server has gone away.")
                 return
 
-    def run_command(self, command, marker, cwd=None, orientation=None,
-                    pane_id=None):
+    def run_command(self, command, marker, cwd=None, orientation=None, pane_id=None):
         if self.input:
             if orientation:
-                self.split_window(cwd=cwd, orientation=orientation,
-                                  pane_id=pane_id, command=command,
-                                  marker=marker)
+                self.split_window(
+                    cwd=cwd,
+                    orientation=orientation,
+                    pane_id=pane_id,
+                    command=command,
+                    marker=marker,
+                )
             else:
                 self.new_window(cwd=cwd, command=command, marker=marker)
         else:
             self.new_session(cwd=cwd, command=command, marker=marker)
 
-    def split_window(self, cwd, orientation, pane_id,
-                     command=None, marker=''):
-        orientation = '-h' if orientation == 'horizontal' else '-v'
+    def split_window(self, cwd, orientation, pane_id, command=None, marker=""):
+        orientation = "-h" if orientation == "horizontal" else "-v"
         tmux_command = 'split-window {} -t {} -P -F "#D {}"'.format(
-            orientation, pane_id, marker)
+            orientation, pane_id, marker
+        )
         if cwd:
             tmux_command += ' -c "{}"'.format(cwd)
         if command:
             tmux_command += ' "{}"'.format(command)
 
-        self._run_command(tmux_command,
-                          callback=('pane_id_result',))
+        self._run_command(tmux_command, callback=("pane_id_result",))
 
-    def new_window(self, cwd=None, command=None, marker=''):
+    def new_window(self, cwd=None, command=None, marker=""):
         tmux_command = 'new-window -P -F "#D {}"'.format(marker)
         if cwd:
             tmux_command += ' -c "{}"'.format(cwd)
         if command:
             tmux_command += ' "{}"'.format(command)
 
-        self._run_command(tmux_command,
-                          callback=('pane_id_result',))
+        self._run_command(tmux_command, callback=("pane_id_result",))
 
     def attach_session(self):
-        popen_command = [TMUX_BINARY, '-2', '-C', 'attach-session',
-                         '-t', self.session_name]
+        popen_command = [
+            TMUX_BINARY,
+            "-2",
+            "-C",
+            "attach-session",
+            "-t",
+            self.session_name,
+        ]
         if self.remote:
             self.remote_connect(popen_command)
         if not self.tmux:
-            self.tmux = subprocess.Popen(popen_command,
-                                     stdout=subprocess.PIPE,
-                                     stdin=subprocess.PIPE, bufsize=0)
+            self.tmux = subprocess.Popen(
+                popen_command, stdout=subprocess.PIPE, stdin=subprocess.PIPE, bufsize=0
+            )
             self.input = self.tmux.stdin
             self.output = self.tmux.stdout
         self.requests.put(notifications.noop)
         self.start_notifications_consumer()
         self.initial_layout()
 
-    def new_session(self, cwd=None, command=None, marker=''):
-        popen_command = [TMUX_BINARY, '-2', '-C', 'new-session', '-s', self.session_name,
-                '-P', '-F', '#D {}'.format(marker)]
+    def new_session(self, cwd=None, command=None, marker=""):
+        popen_command = [
+            TMUX_BINARY,
+            "-2",
+            "-C",
+            "new-session",
+            "-s",
+            self.session_name,
+            "-P",
+            "-F",
+            "#D {}".format(marker),
+        ]
         if cwd and not self.remote:
-            popen_command += ['-c', cwd]
+            popen_command += ["-c", cwd]
         if command:
             popen_command.append(command)
         if self.remote:
             self.remote_connect(popen_command)
         if not self.tmux:
-            self.tmux = subprocess.Popen(popen_command,
-                                     stdout=subprocess.PIPE,
-                                     stdin=subprocess.PIPE)
+            self.tmux = subprocess.Popen(
+                popen_command, stdout=subprocess.PIPE, stdin=subprocess.PIPE
+            )
             self.input = self.tmux.stdin
             self.output = self.tmux.stdout
         # starting a new session, delete any old requests we may have
@@ -158,37 +170,42 @@ class TmuxControl(object):
         while not self.requests.empty():
             self.requests.get(timeout=1)
 
-        self.requests.put(('pane_id_result',))
+        self.requests.put(("pane_id_result",))
         self.start_notifications_consumer()
 
     def refresh_client(self, width, height):
-        dbg('{}::{}: {}x{}'.format("TmuxControl", "refresh_client", width, height))
+        dbg("{}::{}: {}x{}".format("TmuxControl", "refresh_client", width, height))
         self.width = width
         self.height = height
-        self._run_command('refresh-client -C {},{}'.format(width, height))
+        self._run_command("refresh-client -C {},{}".format(width, height))
 
     def garbage_collect_panes(self):
-        self._run_command('list-panes -s -t {} -F "#D {}"'.format(
-            self.session_name, '#{pane_pid}'),
-            callback=('garbage_collect_panes_result',))
+        self._run_command(
+            'list-panes -s -t {} -F "#D {}"'.format(self.session_name, "#{pane_pid}"),
+            callback=("garbage_collect_panes_result",),
+        )
 
     def initial_layout(self):
-        dbg('running initial layout')  # JACK_TEST
+        dbg("running initial layout")  # JACK_TEST
         self._run_command(
-            'list-windows -t {} -F "#{{window_layout}}"'
-            .format(self.session_name),
-            callback=('initial_layout_result',))
+            'list-windows -t {} -F "#{{window_layout}}"'.format(self.session_name),
+            callback=("initial_layout_result",),
+        )
 
     def initial_output(self, pane_id):
         self._run_command(
-            'capture-pane -J -p -t {} -eC -S - -E -'.format(pane_id),
-            callback=('result_callback', pane_id)
+            "capture-pane -J -p -t {} -eC -S - -E -".format(pane_id),
+            callback=("result_callback", pane_id),
         )
 
     def toggle_zoom(self, pane_id, zoom=False):
         self.is_zoomed = not self.is_zoomed
         if not zoom:
-            self._run_command('resize-pane -Z -x {} -y {} -t {}'.format(self.width, self.height, pane_id))
+            self._run_command(
+                "resize-pane -Z -x {} -y {} -t {}".format(
+                    self.width, self.height, pane_id
+                )
+            )
 
     def send_keypress(self, event, pane_id):
         keyval = event.keyval
@@ -197,29 +214,32 @@ class TmuxControl(object):
         if keyval in KEY_MAPPINGS:
             key = KEY_MAPPINGS[keyval]
             if keyval in ARROW_KEYS and state & Gdk.ModifierType.CONTROL_MASK:
-                key = '{}1;5{}'.format(key[:2], key[2:])
+                key = "{}1;5{}".format(key[:2], key[2:])
         else:
             key = event.string
 
         if state & Gdk.ModifierType.MOD1_MASK:
             # Hack to have CTRL+SHIFT+Alt PageUp/PageDown/Home/End
             # work without these silly [... escaped characters
-            if state & (Gdk.ModifierType.CONTROL_MASK |
-                        Gdk.ModifierType.SHIFT_MASK):
+            if state & (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK):
                 return
             else:
                 key = esc(key)
 
-        if key == ';':
-            key = '\\;'
+        if key == ";":
+            key = "\\;"
 
         self.send_content(key, pane_id)
 
     # Handle mouse scrolling events if the alternate_screen is visible
     # otherwise let Terminator handle all the mouse behavior
     def send_mousewheel(self, event, pane_id):
-        SMOOTH_SCROLL_UP = event.direction == Gdk.ScrollDirection.SMOOTH and event.delta_y <= 0.
-        SMOOTH_SCROLL_DOWN = event.direction == Gdk.ScrollDirection.SMOOTH and event.delta_y > 0.
+        SMOOTH_SCROLL_UP = (
+            event.direction == Gdk.ScrollDirection.SMOOTH and event.delta_y <= 0.0
+        )
+        SMOOTH_SCROLL_DOWN = (
+            event.direction == Gdk.ScrollDirection.SMOOTH and event.delta_y > 0.0
+        )
         if SMOOTH_SCROLL_UP:
             wheel = MOUSE_WHEEL[Gdk.ScrollDirection.UP]
         elif SMOOTH_SCROLL_DOWN:
@@ -235,31 +255,35 @@ class TmuxControl(object):
     def send_content(self, content, pane_id):
         key_name_lookup = "-l" if ESCAPE_CODE in content else ""
         quote = "'" if "'" not in content else '"'
-        self._run_command("send-keys -t {} {} -- {}{}{}".format(
-                pane_id, key_name_lookup, quote, content, quote))
+        self._run_command(
+            "send-keys -t {} {} -- {}{}{}".format(
+                pane_id, key_name_lookup, quote, content, quote
+            )
+        )
 
     def send_quoted_content(self, content, pane_id):
         key_name_lookup = "-l" if ESCAPE_CODE in content else ""
-        self._run_command("send-keys -t {} {} -- {}".format(
-                pane_id, key_name_lookup, content))
+        self._run_command(
+            "send-keys -t {} {} -- {}".format(pane_id, key_name_lookup, content)
+        )
 
     def _run_command(self, command, callback=None):
-        dbg('running command {}'.format(command))  # JACK_TEST
+        dbg("running command {}".format(command))  # JACK_TEST
         if not self.input:
-            dbg('No tmux connection. [command={}]'.format(command))
+            dbg("No tmux connection. [command={}]".format(command))
         else:
             try:
-                self.input.write('{}\n'.format(command).encode())
+                self.input.write("{}\n".format(command).encode())
             except IOError:
                 dbg("Tmux server has gone away.")
                 return
             callback = callback or notifications.noop
-            dbg('adding callback: {}'.format(callback))  # JACK_TEST
+            dbg("adding callback: {}".format(callback))  # JACK_TEST
             self.requests.put(callback)
 
     @staticmethod
     def kill_server():
-        command = [TMUX_BINARY, 'kill-session', '-t', 'terminator']
+        command = [TMUX_BINARY, "kill-session", "-t", "terminator"]
         subprocess.call(command)
 
     def start_notifications_consumer(self):
@@ -272,7 +296,7 @@ class TmuxControl(object):
         while True:
             try:
                 if self.tmux.poll() is not None:
-                    dbg('uhhh')  # JACK_TEST
+                    dbg("uhhh")  # JACK_TEST
                     break
             except AttributeError as e:
                 dbg("Tmux control instance was reset.")
@@ -280,8 +304,8 @@ class TmuxControl(object):
             line = self.output.readline()[:-1]
             if not line:
                 continue
-            dbg('=>>>>> LINE RECEIVED: {}'.format(line))
-            line = line[1:].split(b' ', 1)
+            dbg("=>>>>> LINE RECEIVED: {}".format(line))
+            line = line[1:].split(b" ", 1)
             marker = line[0].decode()
             line = line[1]
             # skip MOTD, anything that isn't coming from tmux control mode
@@ -291,27 +315,28 @@ class TmuxControl(object):
                 dbg("Discarding invalid output from the control terminal.")
                 continue
             notification.consume(line, self.output)
-            dbg('consumed notification')  # JACK_TEST
+            dbg("consumed notification")  # JACK_TEST
             try:  # JACK_TEST
                 handler.handle(notification)
             except Exception as e:  # JACK_TEST
-                dbg("UH OH ------------------------------------------------- {}".format(e))  # JACK_TEST
-            dbg('handled notification')  # JACK_TEST
+                dbg(
+                    "UH OH ------------------------------------------------- {}".format(
+                        e
+                    )
+                )  # JACK_TEST
+            dbg("handled notification")  # JACK_TEST
         handler.terminate()
 
     def display_pane_tty(self, pane_id):
-        tmux_command = 'display -pt "{}" "#D {}"'.format(
-            pane_id, "#{pane_tty}")
+        tmux_command = 'display -pt "{}" "#D {}"'.format(pane_id, "#{pane_tty}")
 
-        self._run_command(tmux_command,
-                callback=('pane_tty_result',))
+        self._run_command(tmux_command, callback=("pane_tty_result",))
 
     def resize_pane(self, pane_id, rows, cols):
         if self.is_zoomed:
             # if the pane is zoomed, there is no need for tmux to
             # change the current layout
             return
-        tmux_command = 'resize-pane -t "{}" -x {} -y {}'.format(
-            pane_id, cols, rows)
+        tmux_command = 'resize-pane -t "{}" -x {} -y {}'.format(pane_id, cols, rows)
 
         self._run_command(tmux_command)

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -1,0 +1,306 @@
+import threading
+import subprocess
+import Queue
+
+from pipes import quote
+from gi.repository import Gtk, Gdk
+
+from terminatorlib.tmux import notifications
+from terminatorlib.util import dbg
+
+ESCAPE_CODE = '\033'
+TMUX_BINARY = 'tmux'
+
+def esc(seq):
+    return '{}{}'.format(ESCAPE_CODE, seq)
+
+
+KEY_MAPPINGS = {
+    Gdk.KEY_BackSpace: '\b',
+    Gdk.KEY_Tab: '\t',
+    Gdk.KEY_Insert: esc('[2~'),
+    Gdk.KEY_Delete: esc('[3~'),
+    Gdk.KEY_Page_Up: esc('[5~'),
+    Gdk.KEY_Page_Down: esc('[6~'),
+    Gdk.KEY_Home: esc('[1~'),
+    Gdk.KEY_End: esc('[4~'),
+    Gdk.KEY_Up: esc('[A'),
+    Gdk.KEY_Down: esc('[B'),
+    Gdk.KEY_Right: esc('[C'),
+    Gdk.KEY_Left: esc('[D'),
+}
+ARROW_KEYS = {
+    Gdk.KEY_Up,
+    Gdk.KEY_Down,
+    Gdk.KEY_Left,
+    Gdk.KEY_Right
+}
+MOUSE_WHEEL = {
+    # TODO: make it configurable, e.g. like better-mouse-mode plugin
+    Gdk.ScrollDirection.UP: "C-y C-y C-y",
+    Gdk.ScrollDirection.DOWN: "C-e C-e C-e",
+}
+
+# TODO: implement ssh connection using paramiko
+class TmuxControl(object):
+
+    def __init__(self, session_name, notifications_handler):
+        self.session_name = session_name
+        self.notifications_handler = notifications_handler
+        self.tmux = None
+        self.output = None
+        self.input = None
+        self.consumer = None
+        self.width = None
+        self.height = None
+        self.remote = None
+        self.alternate_on = False
+        self.is_zoomed = False
+        self.requests = Queue.Queue()
+
+    def reset(self):
+        self.tmux = self.input = self.output = self.width = self.height = None
+
+    def remote_connect(self, command):
+        if self.tmux:
+            dbg("Already connected.")
+            return
+        popen_command = "ssh " + self.remote
+        self.tmux = subprocess.Popen(popen_command,
+                                 stdout=subprocess.PIPE,
+                                 stdin=subprocess.PIPE, shell=True)
+        self.input  = self.tmux.stdin
+        self.output = self.tmux.stdout
+
+        self.run_remote_command(command)
+
+    def run_remote_command(self, popen_command):
+        popen_command = map(quote, popen_command)
+        command = " ".join(popen_command)
+        if not self.input:
+            dbg('No tmux connection. [command={}]'.format(command))
+        else:
+            try:
+                self.input.write('exec {}\n'.format(command))
+            except IOError:
+                dbg("Tmux server has gone away.")
+                return
+
+    def run_command(self, command, marker, cwd=None, orientation=None,
+                    pane_id=None):
+        if self.input:
+            if orientation:
+                self.split_window(cwd=cwd, orientation=orientation,
+                                  pane_id=pane_id, command=command,
+                                  marker=marker)
+            else:
+                self.new_window(cwd=cwd, command=command, marker=marker)
+        else:
+            self.new_session(cwd=cwd, command=command, marker=marker)
+
+    def split_window(self, cwd, orientation, pane_id,
+                     command=None, marker=''):
+        orientation = '-h' if orientation == 'horizontal' else '-v'
+        tmux_command = 'split-window {} -t {} -P -F "#D {}"'.format(
+            orientation, pane_id, marker)
+        if cwd:
+            tmux_command += ' -c "{}"'.format(cwd)
+        if command:
+            tmux_command += ' "{}"'.format(command)
+
+        self._run_command(tmux_command,
+                          callback=self.notifications_handler.pane_id_result)
+
+    def new_window(self, cwd=None, command=None, marker=''):
+        tmux_command = 'new-window -P -F "#D {}"'.format(marker)
+        if cwd:
+            tmux_command += ' -c "{}"'.format(cwd)
+        if command:
+            tmux_command += ' "{}"'.format(command)
+
+        self._run_command(tmux_command,
+                          callback=self.notifications_handler.pane_id_result)
+
+    def attach_session(self):
+        popen_command = [TMUX_BINARY, '-2', '-C', 'attach-session',
+                         '-t', self.session_name]
+        if self.remote:
+            self.remote_connect(popen_command)
+        if not self.tmux:
+            self.tmux = subprocess.Popen(popen_command,
+                                     stdout=subprocess.PIPE,
+                                     stdin=subprocess.PIPE)
+            self.input = self.tmux.stdin
+            self.output = self.tmux.stdout
+        self.requests.put(notifications.noop)
+        self.start_notifications_consumer()
+        self.initial_layout()
+
+    def new_session(self, cwd=None, command=None, marker=''):
+        popen_command = [TMUX_BINARY, '-2', '-C', 'new-session', '-s', self.session_name,
+                '-P', '-F', '#D {}'.format(marker)]
+        if cwd and not self.remote:
+            popen_command += ['-c', cwd]
+        if command:
+            popen_command.append(command)
+        if self.remote:
+            self.remote_connect(popen_command)
+        if not self.tmux:
+            self.tmux = subprocess.Popen(popen_command,
+                                     stdout=subprocess.PIPE,
+                                     stdin=subprocess.PIPE)
+            self.input = self.tmux.stdin
+            self.output = self.tmux.stdout
+        # starting a new session, delete any old requests we may have
+        # in the queue (e.g. those added while trying to attach to
+        # a nonexistant session)
+        with self.requests.mutex:
+            self.requests.queue.clear()
+
+        self.requests.put(self.notifications_handler.pane_id_result)
+        self.start_notifications_consumer()
+
+    def refresh_client(self, width, height):
+        dbg('{}::{}: {}x{}'.format("TmuxControl", "refresh_client", width, height))
+        self.width = width
+        self.height = height
+        self._run_command('refresh-client -C {},{}'.format(width, height))
+
+    def garbage_collect_panes(self):
+        self._run_command('list-panes -s -t {} -F "#D {}"'.format(
+            self.session_name, '#{pane_pid}'),
+            callback=self.notifications_handler.garbage_collect_panes_result)
+
+    def initial_layout(self):
+        self._run_command(
+            'list-windows -t {} -F "#{{window_layout}}"'
+            .format(self.session_name),
+            callback=self.notifications_handler.initial_layout_result)
+
+    def initial_output(self, pane_id):
+        self._run_command(
+            'capture-pane -J -p -t {} -eC -S - -E -'.format(pane_id),
+            callback=self.notifications_handler.initial_output_result_callback(
+                pane_id))
+
+    def toggle_zoom(self, pane_id, zoom=False):
+        self.is_zoomed = not self.is_zoomed
+        if not zoom:
+            self._run_command('resize-pane -Z -x {} -y {} -t {}'.format(self.width, self.height, pane_id))
+
+    def send_keypress(self, event, pane_id):
+        keyval = event.keyval
+        state = event.state
+
+        if keyval in KEY_MAPPINGS:
+            key = KEY_MAPPINGS[keyval]
+            if keyval in ARROW_KEYS and state & Gdk.ModifierType.CONTROL_MASK:
+                key = '{}1;5{}'.format(key[:2], key[2:])
+        else:
+            key = event.string
+
+        if state & Gdk.ModifierType.MOD1_MASK:
+            # Hack to have CTRL+SHIFT+Alt PageUp/PageDown/Home/End
+            # work without these silly [... escaped characters
+            if state & (Gdk.ModifierType.CONTROL_MASK |
+                        Gdk.ModifierType.SHIFT_MASK):
+                return
+            else:
+                key = esc(key)
+
+        if key == ';':
+            key = '\\;'
+
+        self.send_content(key, pane_id)
+
+    # Handle mouse scrolling events if the alternate_screen is visible
+    # otherwise let Terminator handle all the mouse behavior
+    def send_mousewheel(self, event, pane_id):
+        SMOOTH_SCROLL_UP = event.direction == Gdk.ScrollDirection.SMOOTH and event.delta_y <= 0.
+        SMOOTH_SCROLL_DOWN = event.direction == Gdk.ScrollDirection.SMOOTH and event.delta_y > 0.
+        if SMOOTH_SCROLL_UP:
+            wheel = MOUSE_WHEEL[Gdk.ScrollDirection.UP]
+        elif SMOOTH_SCROLL_DOWN:
+            wheel = MOUSE_WHEEL[Gdk.ScrollDirection.DOWN]
+        else:
+            wheel = MOUSE_WHEEL[event.direction]
+
+        if self.alternate_on:
+            self._run_command("send-keys -t {} {}".format(pane_id, wheel))
+            return True
+        return False
+
+    def send_content(self, content, pane_id):
+        key_name_lookup = "-l" if ESCAPE_CODE in content else ""
+        quote = "'" if "'" not in content else '"'
+        self._run_command("send-keys -t {} {} -- {}{}{}".format(
+                pane_id, key_name_lookup, quote, content, quote))
+
+    def send_quoted_content(self, content, pane_id):
+        key_name_lookup = "-l" if ESCAPE_CODE in content else ""
+        self._run_command("send-keys -t {} {} -- {}".format(
+                pane_id, key_name_lookup, content))
+
+    def _run_command(self, command, callback=None):
+        if not self.input:
+            dbg('No tmux connection. [command={}]'.format(command))
+        else:
+            try:
+                self.input.write('{}\n'.format(command))
+            except IOError:
+                dbg("Tmux server has gone away.")
+                return
+            callback = callback or notifications.noop
+            self.requests.put(callback)
+
+    @staticmethod
+    def kill_server():
+        command = [TMUX_BINARY, 'kill-session', '-t', 'terminator']
+        subprocess.call(command)
+
+    def start_notifications_consumer(self):
+        self.consumer = threading.Thread(target=self.consume_notifications)
+        self.consumer.daemon = True
+        self.consumer.start()
+
+    def consume_notifications(self):
+        handler = self.notifications_handler
+        while True:
+            try:
+                if self.tmux.poll() is not None:
+                    break
+            except AttributeError as e:
+                dbg("Tmux control instance was reset.")
+                return
+            line = self.output.readline()[:-1]
+            if not line:
+                continue
+            line = line[1:].split(' ')
+            marker = line[0]
+            line = line[1:]
+            # skip MOTD, anything that isn't coming from tmux control mode
+            try:
+                notification = notifications.notifications_mappings[marker]()
+            except KeyError:
+                dbg("Discarding invalid output from the control terminal.")
+                continue
+            notification.consume(line, self.output)
+            handler.handle(notification)
+        handler.terminate()
+
+    def display_pane_tty(self, pane_id):
+        tmux_command = 'display -pt "{}" "#D {}"'.format(
+            pane_id, "#{pane_tty}")
+
+        self._run_command(tmux_command,
+                callback=self.notifications_handler.pane_tty_result)
+
+    def resize_pane(self, pane_id, rows, cols):
+        if self.is_zoomed:
+            # if the pane is zoomed, there is no need for tmux to
+            # change the current layout
+            return
+        tmux_command = 'resize-pane -t "{}" -x {} -y {}'.format(
+            pane_id, cols, rows)
+
+        self._run_command(tmux_command)

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -64,7 +64,11 @@ class TmuxControl(object):
             return
         popen_command = "ssh " + self.remote
         self.tmux = subprocess.Popen(
-            popen_command, stdout=subprocess.PIPE, stdin=subprocess.PIPE, shell=True, bufsize=0
+            popen_command,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            shell=True,
+            bufsize=0,
         )
         self.input = self.tmux.stdin
         self.output = self.tmux.stdout
@@ -83,7 +87,9 @@ class TmuxControl(object):
                 dbg("Tmux server has gone away.")
                 return
 
-    def spawn_tmux_child(self, command, marker, cwd=None, orientation=None, pane_id=None):
+    def spawn_tmux_child(
+        self, command, marker, cwd=None, orientation=None, pane_id=None
+    ):
         if self.input:
             if orientation:
                 self.split_window(
@@ -310,7 +316,7 @@ class TmuxControl(object):
             try:
                 line = line[1]
             except IndexError:
-                line = b''
+                line = b""
             # skip MOTD, anything that isn't coming from tmux control mode
             try:
                 notification = notifications.notifications_mappings[marker]()

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -173,6 +173,7 @@ class TmuxControl(object):
             callback=('garbage_collect_panes_result',))
 
     def initial_layout(self):
+        dbg('running initial layout')  # JACK_TEST
         self._run_command(
             'list-windows -t {} -F "#{{window_layout}}"'
             .format(self.session_name),
@@ -243,6 +244,7 @@ class TmuxControl(object):
                 pane_id, key_name_lookup, content))
 
     def _run_command(self, command, callback=None):
+        dbg('running command {}'.format(command))  # JACK_TEST
         if not self.input:
             dbg('No tmux connection. [command={}]'.format(command))
         else:
@@ -252,6 +254,7 @@ class TmuxControl(object):
                 dbg("Tmux server has gone away.")
                 return
             callback = callback or notifications.noop
+            dbg('adding callback: {}'.format(callback))  # JACK_TEST
             self.requests.put(callback)
 
     @staticmethod
@@ -269,6 +272,7 @@ class TmuxControl(object):
         while True:
             try:
                 if self.tmux.poll() is not None:
+                    dbg('uhhh')  # JACK_TEST
                     break
             except AttributeError as e:
                 dbg("Tmux control instance was reset.")
@@ -287,7 +291,12 @@ class TmuxControl(object):
                 dbg("Discarding invalid output from the control terminal.")
                 continue
             notification.consume(line, self.output)
-            handler.handle(notification)
+            dbg('consumed notification')  # JACK_TEST
+            try:  # JACK_TEST
+                handler.handle(notification)
+            except Exception as e:  # JACK_TEST
+                dbg("UH OH ------------------------------------------------- {}".format(e))  # JACK_TEST
+            dbg('handled notification')  # JACK_TEST
         handler.terminate()
 
     def display_pane_tty(self, pane_id):

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -155,8 +155,8 @@ class TmuxControl(object):
         # starting a new session, delete any old requests we may have
         # in the queue (e.g. those added while trying to attach to
         # a nonexistant session)
-        with self.requests.mutex:
-            self.requests.queue.clear()
+        while not self.requests.empty():
+            self.requests.get(timeout=1)
 
         self.requests.put(self.notifications_handler.pane_id_result)
         self.start_notifications_consumer()

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -110,7 +110,7 @@ class TmuxControl(object):
             tmux_command += ' "{}"'.format(command)
 
         self._run_command(tmux_command,
-                          callback=self.notifications_handler.pane_id_result)
+                          callback=('pane_id_result',))
 
     def new_window(self, cwd=None, command=None, marker=''):
         tmux_command = 'new-window -P -F "#D {}"'.format(marker)
@@ -120,7 +120,7 @@ class TmuxControl(object):
             tmux_command += ' "{}"'.format(command)
 
         self._run_command(tmux_command,
-                          callback=self.notifications_handler.pane_id_result)
+                          callback=('pane_id_result',))
 
     def attach_session(self):
         popen_command = [TMUX_BINARY, '-2', '-C', 'attach-session',
@@ -158,7 +158,7 @@ class TmuxControl(object):
         while not self.requests.empty():
             self.requests.get(timeout=1)
 
-        self.requests.put(self.notifications_handler.pane_id_result)
+        self.requests.put(('pane_id_result',))
         self.start_notifications_consumer()
 
     def refresh_client(self, width, height):
@@ -170,19 +170,19 @@ class TmuxControl(object):
     def garbage_collect_panes(self):
         self._run_command('list-panes -s -t {} -F "#D {}"'.format(
             self.session_name, '#{pane_pid}'),
-            callback=self.notifications_handler.garbage_collect_panes_result)
+            callback=('garbage_collect_panes_result',))
 
     def initial_layout(self):
         self._run_command(
             'list-windows -t {} -F "#{{window_layout}}"'
             .format(self.session_name),
-            callback=self.notifications_handler.initial_layout_result)
+            callback=('initial_layout_result',))
 
     def initial_output(self, pane_id):
         self._run_command(
             'capture-pane -J -p -t {} -eC -S - -E -'.format(pane_id),
-            callback=self.notifications_handler.initial_output_result_callback(
-                pane_id))
+            callback=('result_callback', pane_id)
+        )
 
     def toggle_zoom(self, pane_id, zoom=False):
         self.is_zoomed = not self.is_zoomed
@@ -294,7 +294,7 @@ class TmuxControl(object):
             pane_id, "#{pane_tty}")
 
         self._run_command(tmux_command,
-                callback=self.notifications_handler.pane_tty_result)
+                callback=('pane_tty_result',))
 
     def resize_pane(self, pane_id, rows, cols):
         if self.is_zoomed:

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -276,9 +276,10 @@ class TmuxControl(object):
             line = self.output.readline()[:-1]
             if not line:
                 continue
-            line = line[1:].decode().split(' ')
-            marker = line[0]
-            line = line[1:]
+            dbg('=>>>>> LINE RECEIVED: {}'.format(line))
+            line = line[1:].split(b' ', 1)
+            marker = line[0].decode()
+            line = line[1]
             # skip MOTD, anything that isn't coming from tmux control mode
             try:
                 notification = notifications.notifications_mappings[marker]()

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -83,7 +83,7 @@ class TmuxControl(object):
                 dbg("Tmux server has gone away.")
                 return
 
-    def run_command(self, command, marker, cwd=None, orientation=None, pane_id=None):
+    def spawn_tmux_child(self, command, marker, cwd=None, orientation=None, pane_id=None):
         if self.input:
             if orientation:
                 self.split_window(

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -323,16 +323,12 @@ class TmuxControl(object):
                 dbg("Unknown notification.")
                 continue
             notification.consume(line, self.output)
-            dbg("consumed notification")  # JACK_TEST
-            try:  # JACK_TEST
+            dbg("consumed notification: {}".format(notification))  # JACK_TEST
+            try:
                 handler.handle(notification)
-            except Exception as e:  # JACK_TEST
-                dbg(
-                    "UH OH ------------------------------------------------- {}".format(
-                        e
-                    )
-                )  # JACK_TEST
-            dbg("handled notification")  # JACK_TEST
+            except Exception as e:
+                dbg("Error while handling notification: {}".format(e))
+            dbg("handled notification")
         handler.terminate()
 
     def display_pane_tty(self, pane_id):

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -192,7 +192,6 @@ class TmuxControl(object):
         )
 
     def initial_layout(self):
-        dbg("running initial layout")  # JACK_TEST
         self._run_command(
             'list-windows -t {} -F "#{{window_layout}}"'.format(self.session_name),
             callback=("initial_layout_result",),
@@ -321,7 +320,7 @@ class TmuxControl(object):
             try:
                 notification = notifications.notifications_mappings[marker]()
             except KeyError:
-                dbg("Discarding invalid output from the control terminal.")
+                dbg("Unknown notification.")
                 continue
             notification.consume(line, self.output)
             dbg("consumed notification")  # JACK_TEST

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -1,6 +1,7 @@
 import threading
 import subprocess
-import Queue
+
+from multiprocessing import Queue
 
 from pipes import quote
 from gi.repository import Gtk, Gdk
@@ -56,7 +57,7 @@ class TmuxControl(object):
         self.remote = None
         self.alternate_on = False
         self.is_zoomed = False
-        self.requests = Queue.Queue()
+        self.requests = Queue()
 
     def reset(self):
         self.tmux = self.input = self.output = self.width = self.height = None
@@ -81,7 +82,7 @@ class TmuxControl(object):
             dbg('No tmux connection. [command={}]'.format(command))
         else:
             try:
-                self.input.write('exec {}\n'.format(command))
+                self.input.write('exec {}\n'.format(command).encode())
             except IOError:
                 dbg("Tmux server has gone away.")
                 return
@@ -246,7 +247,7 @@ class TmuxControl(object):
             dbg('No tmux connection. [command={}]'.format(command))
         else:
             try:
-                self.input.write('{}\n'.format(command))
+                self.input.write('{}\n'.format(command).encode())
             except IOError:
                 dbg("Tmux server has gone away.")
                 return
@@ -275,7 +276,7 @@ class TmuxControl(object):
             line = self.output.readline()[:-1]
             if not line:
                 continue
-            line = line[1:].split(' ')
+            line = line[1:].decode().split(' ')
             marker = line[0]
             line = line[1:]
             # skip MOTD, anything that isn't coming from tmux control mode

--- a/terminatorlib/tmux/control.py
+++ b/terminatorlib/tmux/control.py
@@ -307,7 +307,10 @@ class TmuxControl(object):
             dbg("=>>>>> LINE RECEIVED: {}".format(line))
             line = line[1:].split(b" ", 1)
             marker = line[0].decode()
-            line = line[1]
+            try:
+                line = line[1]
+            except IndexError:
+                line = b''
             # skip MOTD, anything that isn't coming from tmux control mode
             try:
                 notification = notifications.notifications_mappings[marker]()

--- a/terminatorlib/tmux/layout.py
+++ b/terminatorlib/tmux/layout.py
@@ -1,0 +1,260 @@
+from pyparsing import *
+
+class LayoutParser():
+    """BNF representation for a Tmux Layout
+    <layout>        :: <layout_name> <comma> <element>+ ;
+    <element>       :: ( <container> | <pane> ) <comma>? ;
+    <layout_name>   :: <hexadecimal>{4} ;
+    <container>     :: <preamble> <start_token> <element>+ <end_token> ;
+    <pane>          :: <preamble> <comma> <decimal> ;
+    <preamble>      :: <size> <comma> <decimal> <comma> <decimal> ;
+    <size>          :: <decimal> "x" <decimal> ;
+    <start_token>   :: "{" | "[" ;
+    <end_token>     :: "}" | "]" ;
+    <decimal>       :: <decimal-digit>+ ;
+    <hexadecimal>   :: <hex-digit>+ ;
+    <decimal-digit> :: "0" | ... | "9" ;
+    <hex-digit>     :: <decimal-digit> | "a" | ... | "f" ;
+    <comma>         :: "," ;
+    """
+    layout_parser = None
+
+    def __init__(self):
+        decimal = Word(nums)
+
+        comma = Suppress(Literal(','))
+        start_token = Literal('{') | Literal('[')
+        end_token   = Suppress(Literal('}') | Literal(']'))
+
+        layout_name = Suppress(Word(hexnums, min=4, max=4))
+        size        = decimal("width") + Suppress(Literal('x')) + decimal("height")
+
+        preamble    = size + comma + decimal("x") + comma + decimal("y")
+        pane        = Group(preamble + comma + decimal("pane_id"))
+        element     = Forward() # will be defined later
+        container   = Group(preamble + start_token + OneOrMore(element) + end_token)
+
+        element << (container | pane) + Optional(comma)
+
+        self.layout_parser = layout_name + comma + OneOrMore(element)
+
+    def parse(self, layout):
+        parsed = self.layout_parser.parseString(layout)
+        return parsed.asList()
+
+def parse_layout(layout):
+    """Apply our application logic to the parsed layout.
+
+    Arguments:
+    layout -- Layout parsed by LayoutParser.parse(),
+              it is represented as a nested list; each nested
+              list has the following format:
+              [0]  : width,
+              [1]  : height,
+              [2]  : position on x axis,
+              [3]  : position on y axis,
+              [4]  : '{' if the current element is a horizontal splits container,
+                     '[' if the current element is a vertical splits container,
+                     '%[0-9]+' if the current element is a pane
+              [5+] : if present, they are nested lists with the same structure
+
+    """
+    result = []
+
+    children = []
+    for item in layout[5:]:
+        children.extend(parse_layout(item))
+
+    if layout[4] == '{':
+        result.append(Horizontal(
+            layout[0],
+            layout[1],
+            layout[2],
+            layout[3],
+            children
+            ))
+
+    elif layout[4] == '[':
+        result.append(Vertical(
+            layout[0],
+            layout[1],
+            layout[2],
+            layout[3],
+            children
+            ))
+    else:
+        result.append(Pane(
+            layout[0],
+            layout[1],
+            layout[2],
+            layout[3],
+            "%{}".format(layout[4])
+            ))
+
+    return result
+
+def convert_to_terminator_layout(window_layouts):
+    assert len(window_layouts) > 0
+    result = {}
+    pane_index = 0
+    window_name = 'window0'
+    parent_name = window_name
+    result[window_name] = {
+        'type': 'Window',
+        'parent': ''
+    }
+    if len(window_layouts) > 1:
+        notebook_name = 'notebook0'
+        result[notebook_name] = {
+            'type': 'Notebook',
+            'parent': parent_name
+        }
+        parent_name = notebook_name
+    order = 0
+    for window_layout in window_layouts:
+        converter = _get_converter(window_layout)
+        pane_index, order = converter(
+            result, parent_name, window_layout, pane_index, order)
+    return result
+
+
+class Container(object):
+
+    def __init__(self, width, height, x, y):
+        self.width = width
+        self.height = height
+        self.x = x
+        self.y = y
+
+    def __str__(self):
+        return (
+            '{}[width={}, height={}, x={}, y={}, {}]'
+            .format(self.__class__.__name__,
+                    self.width, self.height, self.x, self.y,
+                    self._child_str()))
+
+    __repr__ = __str__
+
+    def _child_str(self):
+        raise NotImplementedError()
+
+
+class Pane(Container):
+
+    def __init__(self, width, height, x, y, pane_id):
+        super(Pane, self).__init__(width, height, x, y)
+        self.pane_id = pane_id
+
+    def _child_str(self):
+        return 'pane_id={}'.format(self.pane_id)
+
+
+class Vertical(Container):
+
+    def __init__(self, width, height, x, y, children):
+        super(Vertical, self).__init__(width, height, x, y)
+        self.children = children
+
+    def _child_str(self):
+        return 'children={}'.format(self.children)
+
+
+class Horizontal(Container):
+
+    def __init__(self, width, height, x, y, children):
+        super(Horizontal, self).__init__(width, height, x, y)
+        self.children = children
+
+    def _child_str(self):
+        return 'children={}'.format(self.children)
+
+
+def _covert_pane_to_terminal(result, parent_name, pane, pane_index, order):
+    assert isinstance(pane, Pane)
+    terminal = _convert(parent_name, 'Terminal', pane, order)
+    order += 1
+    terminal['tmux']['pane_id'] = pane.pane_id
+    result['terminal{}'.format(pane.pane_id[1:])] = terminal
+    return pane_index, order
+
+
+def _convert_vertical_to_vpane(result, parent_name, vertical_or_children,
+                               pane_index, order):
+    return _convert_container_to_terminator_pane(
+            result, parent_name, vertical_or_children, pane_index, Vertical,
+            order)
+
+
+def _convert_horizontal_to_hpane(result, parent_name, horizontal_or_children,
+                                 pane_index, order):
+    return _convert_container_to_terminator_pane(
+            result, parent_name, horizontal_or_children, pane_index,
+            Horizontal, order)
+
+
+def _convert_container_to_terminator_pane(result, parent_name,
+                                          container_or_children,
+                                          pane_index, pane_type,
+                                          order):
+    terminator_type = 'VPaned' if issubclass(pane_type, Vertical) else 'HPaned'
+    if isinstance(container_or_children, pane_type):
+        container = container_or_children
+        pane = _convert(parent_name, terminator_type, container_or_children,
+                        order)
+        order += 1
+        children = container.children
+    else:
+        children = container_or_children
+        if len(children) == 1:
+            child = children[0]
+            child_converter = _get_converter(child)
+            return child_converter(result, parent_name, child, pane_index,
+                                   order)
+        pane = {
+            'type': terminator_type,
+            'parent': parent_name
+        }
+    pane_name = 'pane{}'.format(pane_index)
+    result[pane_name] = pane
+    parent_name = pane_name
+    pane_index += 1
+    child1 = children[0]
+    child1_converter = _get_converter(child1)
+    pane_index, order = child1_converter(result, parent_name, child1,
+                                         pane_index, order)
+    pane_index, order = _convert_container_to_terminator_pane(result,
+                                                              parent_name,
+                                                              children[1:],
+                                                              pane_index,
+                                                              pane_type,
+                                                              order)
+    return pane_index, order
+
+
+converters = {
+    Pane: _covert_pane_to_terminal,
+    Vertical: _convert_vertical_to_vpane,
+    Horizontal: _convert_horizontal_to_hpane
+}
+
+
+def _get_converter(container):
+    try:
+        return converters[type(container)]
+    except KeyError:
+        raise ValueError('Illegal window layout: {}'.format(container))
+
+
+def _convert(parent_name, type_name, container, order):
+    assert isinstance(container, Container)
+    return {
+        'type': type_name,
+        'parent': parent_name,
+        'order': order,
+        'tmux': {
+            'width': container.width,
+            'height': container.height,
+            'x': container.x,
+            'y': container.y
+        }
+    }

--- a/terminatorlib/tmux/layout.py
+++ b/terminatorlib/tmux/layout.py
@@ -1,6 +1,7 @@
 from pyparsing import *
 
-class LayoutParser():
+
+class LayoutParser:
     """BNF representation for a Tmux Layout
     <layout>        :: <layout_name> <comma> <element>+ ;
     <element>       :: ( <container> | <pane> ) <comma>? ;
@@ -17,22 +18,23 @@ class LayoutParser():
     <hex-digit>     :: <decimal-digit> | "a" | ... | "f" ;
     <comma>         :: "," ;
     """
+
     layout_parser = None
 
     def __init__(self):
         decimal = Word(nums)
 
-        comma = Suppress(Literal(','))
-        start_token = Literal('{') | Literal('[')
-        end_token   = Suppress(Literal('}') | Literal(']'))
+        comma = Suppress(Literal(","))
+        start_token = Literal("{") | Literal("[")
+        end_token = Suppress(Literal("}") | Literal("]"))
 
         layout_name = Suppress(Word(hexnums, min=4, max=4))
-        size        = decimal("width") + Suppress(Literal('x')) + decimal("height")
+        size = decimal("width") + Suppress(Literal("x")) + decimal("height")
 
-        preamble    = size + comma + decimal("x") + comma + decimal("y")
-        pane        = Group(preamble + comma + decimal("pane_id"))
-        element     = Forward() # will be defined later
-        container   = Group(preamble + start_token + OneOrMore(element) + end_token)
+        preamble = size + comma + decimal("x") + comma + decimal("y")
+        pane = Group(preamble + comma + decimal("pane_id"))
+        element = Forward()  # will be defined later
+        container = Group(preamble + start_token + OneOrMore(element) + end_token)
 
         element << (container | pane) + Optional(comma)
 
@@ -41,6 +43,7 @@ class LayoutParser():
     def parse(self, layout):
         parsed = self.layout_parser.parseString(layout)
         return parsed.asList()
+
 
 def parse_layout(layout):
     """Apply our application logic to the parsed layout.
@@ -65,61 +68,40 @@ def parse_layout(layout):
     for item in layout[5:]:
         children.extend(parse_layout(item))
 
-    if layout[4] == '{':
-        result.append(Horizontal(
-            layout[0],
-            layout[1],
-            layout[2],
-            layout[3],
-            children
-            ))
+    if layout[4] == "{":
+        result.append(Horizontal(layout[0], layout[1], layout[2], layout[3], children))
 
-    elif layout[4] == '[':
-        result.append(Vertical(
-            layout[0],
-            layout[1],
-            layout[2],
-            layout[3],
-            children
-            ))
+    elif layout[4] == "[":
+        result.append(Vertical(layout[0], layout[1], layout[2], layout[3], children))
     else:
-        result.append(Pane(
-            layout[0],
-            layout[1],
-            layout[2],
-            layout[3],
-            "%{}".format(layout[4])
-            ))
+        result.append(
+            Pane(layout[0], layout[1], layout[2], layout[3], "%{}".format(layout[4]))
+        )
 
     return result
+
 
 def convert_to_terminator_layout(window_layouts):
     assert len(window_layouts) > 0
     result = {}
     pane_index = 0
-    window_name = 'window0'
+    window_name = "window0"
     parent_name = window_name
-    result[window_name] = {
-        'type': 'Window',
-        'parent': ''
-    }
+    result[window_name] = {"type": "Window", "parent": ""}
     if len(window_layouts) > 1:
-        notebook_name = 'notebook0'
-        result[notebook_name] = {
-            'type': 'Notebook',
-            'parent': parent_name
-        }
+        notebook_name = "notebook0"
+        result[notebook_name] = {"type": "Notebook", "parent": parent_name}
         parent_name = notebook_name
     order = 0
     for window_layout in window_layouts:
         converter = _get_converter(window_layout)
         pane_index, order = converter(
-            result, parent_name, window_layout, pane_index, order)
+            result, parent_name, window_layout, pane_index, order
+        )
     return result
 
 
 class Container(object):
-
     def __init__(self, width, height, x, y):
         self.width = width
         self.height = height
@@ -127,11 +109,14 @@ class Container(object):
         self.y = y
 
     def __str__(self):
-        return (
-            '{}[width={}, height={}, x={}, y={}, {}]'
-            .format(self.__class__.__name__,
-                    self.width, self.height, self.x, self.y,
-                    self._child_str()))
+        return "{}[width={}, height={}, x={}, y={}, {}]".format(
+            self.__class__.__name__,
+            self.width,
+            self.height,
+            self.x,
+            self.y,
+            self._child_str(),
+        )
 
     __repr__ = __str__
 
@@ -140,67 +125,64 @@ class Container(object):
 
 
 class Pane(Container):
-
     def __init__(self, width, height, x, y, pane_id):
         super(Pane, self).__init__(width, height, x, y)
         self.pane_id = pane_id
 
     def _child_str(self):
-        return 'pane_id={}'.format(self.pane_id)
+        return "pane_id={}".format(self.pane_id)
 
 
 class Vertical(Container):
-
     def __init__(self, width, height, x, y, children):
         super(Vertical, self).__init__(width, height, x, y)
         self.children = children
 
     def _child_str(self):
-        return 'children={}'.format(self.children)
+        return "children={}".format(self.children)
 
 
 class Horizontal(Container):
-
     def __init__(self, width, height, x, y, children):
         super(Horizontal, self).__init__(width, height, x, y)
         self.children = children
 
     def _child_str(self):
-        return 'children={}'.format(self.children)
+        return "children={}".format(self.children)
 
 
 def _covert_pane_to_terminal(result, parent_name, pane, pane_index, order):
     assert isinstance(pane, Pane)
-    terminal = _convert(parent_name, 'Terminal', pane, order)
+    terminal = _convert(parent_name, "Terminal", pane, order)
     order += 1
-    terminal['tmux']['pane_id'] = pane.pane_id
-    result['terminal{}'.format(pane.pane_id[1:])] = terminal
+    terminal["tmux"]["pane_id"] = pane.pane_id
+    result["terminal{}".format(pane.pane_id[1:])] = terminal
     return pane_index, order
 
 
-def _convert_vertical_to_vpane(result, parent_name, vertical_or_children,
-                               pane_index, order):
+def _convert_vertical_to_vpane(
+    result, parent_name, vertical_or_children, pane_index, order
+):
     return _convert_container_to_terminator_pane(
-            result, parent_name, vertical_or_children, pane_index, Vertical,
-            order)
+        result, parent_name, vertical_or_children, pane_index, Vertical, order
+    )
 
 
-def _convert_horizontal_to_hpane(result, parent_name, horizontal_or_children,
-                                 pane_index, order):
+def _convert_horizontal_to_hpane(
+    result, parent_name, horizontal_or_children, pane_index, order
+):
     return _convert_container_to_terminator_pane(
-            result, parent_name, horizontal_or_children, pane_index,
-            Horizontal, order)
+        result, parent_name, horizontal_or_children, pane_index, Horizontal, order
+    )
 
 
-def _convert_container_to_terminator_pane(result, parent_name,
-                                          container_or_children,
-                                          pane_index, pane_type,
-                                          order):
-    terminator_type = 'VPaned' if issubclass(pane_type, Vertical) else 'HPaned'
+def _convert_container_to_terminator_pane(
+    result, parent_name, container_or_children, pane_index, pane_type, order
+):
+    terminator_type = "VPaned" if issubclass(pane_type, Vertical) else "HPaned"
     if isinstance(container_or_children, pane_type):
         container = container_or_children
-        pane = _convert(parent_name, terminator_type, container_or_children,
-                        order)
+        pane = _convert(parent_name, terminator_type, container_or_children, order)
         order += 1
         children = container.children
     else:
@@ -208,33 +190,25 @@ def _convert_container_to_terminator_pane(result, parent_name,
         if len(children) == 1:
             child = children[0]
             child_converter = _get_converter(child)
-            return child_converter(result, parent_name, child, pane_index,
-                                   order)
-        pane = {
-            'type': terminator_type,
-            'parent': parent_name
-        }
-    pane_name = 'pane{}'.format(pane_index)
+            return child_converter(result, parent_name, child, pane_index, order)
+        pane = {"type": terminator_type, "parent": parent_name}
+    pane_name = "pane{}".format(pane_index)
     result[pane_name] = pane
     parent_name = pane_name
     pane_index += 1
     child1 = children[0]
     child1_converter = _get_converter(child1)
-    pane_index, order = child1_converter(result, parent_name, child1,
-                                         pane_index, order)
-    pane_index, order = _convert_container_to_terminator_pane(result,
-                                                              parent_name,
-                                                              children[1:],
-                                                              pane_index,
-                                                              pane_type,
-                                                              order)
+    pane_index, order = child1_converter(result, parent_name, child1, pane_index, order)
+    pane_index, order = _convert_container_to_terminator_pane(
+        result, parent_name, children[1:], pane_index, pane_type, order
+    )
     return pane_index, order
 
 
 converters = {
     Pane: _covert_pane_to_terminal,
     Vertical: _convert_vertical_to_vpane,
-    Horizontal: _convert_horizontal_to_hpane
+    Horizontal: _convert_horizontal_to_hpane,
 }
 
 
@@ -242,19 +216,19 @@ def _get_converter(container):
     try:
         return converters[type(container)]
     except KeyError:
-        raise ValueError('Illegal window layout: {}'.format(container))
+        raise ValueError("Illegal window layout: {}".format(container))
 
 
 def _convert(parent_name, type_name, container, order):
     assert isinstance(container, Container)
     return {
-        'type': type_name,
-        'parent': parent_name,
-        'order': order,
-        'tmux': {
-            'width': container.width,
-            'height': container.height,
-            'x': container.x,
-            'y': container.y
-        }
+        "type": type_name,
+        "parent": parent_name,
+        "order": order,
+        "tmux": {
+            "width": container.width,
+            "height": container.height,
+            "x": container.x,
+            "y": container.y,
+        },
     }

--- a/terminatorlib/tmux/notifications.py
+++ b/terminatorlib/tmux/notifications.py
@@ -4,9 +4,14 @@ from terminatorlib.util import dbg
 from terminatorlib.tmux import layout
 
 import string
-ATTACH_ERROR_STRINGS = [b"can't find session terminator", b"no current session", b"no sessions"]
-ALTERNATE_SCREEN_ENTER_CODES = [ b"\\033[?1049h" ]
-ALTERNATE_SCREEN_EXIT_CODES  = [ b"\\033[?1049l" ]
+
+ATTACH_ERROR_STRINGS = [
+    b"can't find session terminator",
+    b"no current session",
+    b"no sessions",
+]
+ALTERNATE_SCREEN_ENTER_CODES = [b"\\033[?1049h"]
+ALTERNATE_SCREEN_EXIT_CODES = [b"\\033[?1049l"]
 
 notifications_mappings = {}
 
@@ -18,45 +23,46 @@ def notification(cls):
 
 class Notification(object):
 
-    marker = 'undefined'
+    marker = "undefined"
     attributes = []
 
     def consume(self, line, out):
         pass
 
     def __str__(self):
-        attributes = ['{}="{}"'.format(attribute, getattr(self, attribute, ''))
-                      for attribute in self.attributes]
-        return '{}[{}]'.format(self.marker, ', '.join(attributes))
+        attributes = [
+            '{}="{}"'.format(attribute, getattr(self, attribute, ""))
+            for attribute in self.attributes
+        ]
+        return "{}[{}]".format(self.marker, ", ".join(attributes))
 
 
 @notification
 class Result(Notification):
 
-    marker = 'begin'
-    attributes = ['begin_timestamp', 'code', 'result', 'end_timestamp',
-                  'error']
+    marker = "begin"
+    attributes = ["begin_timestamp", "code", "result", "end_timestamp", "error"]
 
     def consume(self, line, out):
-        timestamp, code, _ = line.split(b' ')
+        timestamp, code, _ = line.split(b" ")
         self.begin_timestamp = timestamp
         self.code = code
         result = []
         line = out.readline()[:-1]
-        while not (line.startswith(b'%end') or line.startswith(b'%error')):
+        while not (line.startswith(b"%end") or line.startswith(b"%error")):
             result.append(line)
             line = out.readline()[:-1]
         self.result = result
-        end, timestamp, code, _ = line.split(b' ')
+        end, timestamp, code, _ = line.split(b" ")
         self.end_timestamp = timestamp
-        self.error = end == b'%error'
+        self.error = end == b"%error"
 
 
 @notification
 class Exit(Notification):
 
-    marker = 'exit'
-    attributes = ['reason']
+    marker = "exit"
+    attributes = ["reason"]
 
     def consume(self, line, *args):
         self.reason = line[0] if line else None
@@ -65,40 +71,43 @@ class Exit(Notification):
 @notification
 class LayoutChange(Notification):
 
-    marker = 'layout-change'
-    attributes = ['window_id', 'window_layout', 'window_visible_layout',
-                  'window_flags']
+    marker = "layout-change"
+    attributes = ["window_id", "window_layout", "window_visible_layout", "window_flags"]
 
     def consume(self, line, *args):
         # attributes not present default to None
-        line_items = line.split(b' ')
-        window_id, window_layout, window_visible_layout, window_flags = line_items + [None] * (len(self.attributes) - len(line_items))
+        line_items = line.split(b" ")
+        window_id, window_layout, window_visible_layout, window_flags = line_items + [
+            None
+        ] * (len(self.attributes) - len(line_items))
         self.window_id = window_id
         self.window_layout = window_layout
         self.window_visible_layout = window_visible_layout
         self.window_flags = window_flags
 
+
 @notification
 class Output(Notification):
 
-    marker = 'output'
-    attributes = ['pane_id', 'output']
+    marker = "output"
+    attributes = ["pane_id", "output"]
 
     def consume(self, line, *args):
         # pane_id = line[0]
         # output = ' '.join(line[1:])
-        pane_id, output = line.split(b' ', 1)
+        pane_id, output = line.split(b" ", 1)
         self.pane_id = pane_id
         self.output = output
+
 
 @notification
 class SessionChanged(Notification):
 
-    marker = 'session-changed'
-    attributes = ['session_id', 'session_name']
+    marker = "session-changed"
+    attributes = ["session_id", "session_name"]
 
     def consume(self, line, *args):
-        session_id, session_name = line.split(b' ')
+        session_id, session_name = line.split(b" ")
         self.session_id = session_id
         self.session_name = session_name
 
@@ -106,11 +115,11 @@ class SessionChanged(Notification):
 @notification
 class SessionRenamed(Notification):
 
-    marker = 'session-renamed'
-    attributes = ['session_id', 'session_name']
+    marker = "session-renamed"
+    attributes = ["session_id", "session_name"]
 
     def consume(self, line, *args):
-        session_id, session_name = line.split(b' ')
+        session_id, session_name = line.split(b" ")
         self.session_id = session_id
         self.session_name = session_name
 
@@ -118,62 +127,62 @@ class SessionRenamed(Notification):
 @notification
 class SessionsChanged(Notification):
 
-    marker = 'sessions-changed'
+    marker = "sessions-changed"
     attributes = []
 
 
 @notification
 class UnlinkedWindowAdd(Notification):
 
-    marker = 'unlinked-window-add'
-    attributes = ['window_id']
+    marker = "unlinked-window-add"
+    attributes = ["window_id"]
 
     def consume(self, line, *args):
-        window_id, = line.split(b' ')
+        (window_id,) = line.split(b" ")
         self.window_id = window_id
 
 
 @notification
 class WindowAdd(Notification):
 
-    marker = 'window-add'
-    attributes = ['window_id']
+    marker = "window-add"
+    attributes = ["window_id"]
 
     def consume(self, line, *args):
-        window_id, = line.split(b' ')
+        (window_id,) = line.split(b" ")
         self.window_id = window_id
 
 
 @notification
 class UnlinkedWindowClose(Notification):
 
-    marker = 'unlinked-window-close'
-    attributes = ['window_id']
+    marker = "unlinked-window-close"
+    attributes = ["window_id"]
 
     def consume(self, line, *args):
-        window_id, = line.split(b' ')
+        (window_id,) = line.split(b" ")
         self.window_id = window_id
 
 
 @notification
 class WindowClose(Notification):
 
-    marker = 'window-close'
-    attributes = ['window_id']
+    marker = "window-close"
+    attributes = ["window_id"]
 
     def consume(self, line, *args):
-        window_id, = line.split(b' ')
+        (window_id,) = line.split(b" ")
         self.window_id = window_id
 
 
 @notification
 class UnlinkedWindowRenamed(Notification):
 
-    marker = 'unlinked-window-renamed'
-    attributes = ['window_id', 'window_name']
+    marker = "unlinked-window-renamed"
+    attributes = ["window_id", "window_name"]
 
     def consume(self, line, *args):
-        window_id, window_name = line.split(b' ')
+        window_id, window_name = line.split(b" ")
         self.window_id = window_id
         self.window_name = window_name
 
@@ -181,41 +190,47 @@ class UnlinkedWindowRenamed(Notification):
 @notification
 class WindowRenamed(Notification):
 
-    marker = 'window-renamed'
-    attributes = ['window_id', 'window_name']
+    marker = "window-renamed"
+    attributes = ["window_id", "window_name"]
 
     def consume(self, line, *args):
-        window_id, window_name = line.split(b' ')
+        window_id, window_name = line.split(b" ")
         self.window_id = window_id
         self.window_name = window_name
 
 
 class NotificationsHandler(object):
-
     def __init__(self, terminator):
         self.terminator = terminator
         self.layout_parser = layout.LayoutParser()
 
     def handle(self, notification):
         try:
-            dbg('looking for method for {}'.format(notification.marker))  # JACK_TEST
-            handler_method = getattr(self, 'handle_{}'.format(
-                    notification.marker.replace('-', '_')))
+            dbg("looking for method for {}".format(notification.marker))  # JACK_TEST
+            handler_method = getattr(
+                self, "handle_{}".format(notification.marker.replace("-", "_"))
+            )
             handler_method(notification)
         except AttributeError as e:  # JACK_TEST
-            dbg('------- method for {} NOT FOUND: {}'.format(notification.marker, e))  # JACK_TEST
+            dbg(
+                "------- method for {} NOT FOUND: {}".format(notification.marker, e)
+            )  # JACK_TEST
             pass
         except Exception as e:  # JACK_TEST
-            dbg('something went wrong while handling {}: {}'.format(notification.marker, e))  # JACK_TEST
+            dbg(
+                "something went wrong while handling {}: {}".format(
+                    notification.marker, e
+                )
+            )  # JACK_TEST
 
     def handle_begin(self, notification):
-        dbg('### {}'.format(notification))
+        dbg("### {}".format(notification))
         assert isinstance(notification, Result)
-        dbg('######## getting callback')  # JACK_TEST
+        dbg("######## getting callback")  # JACK_TEST
         callback = self.terminator.tmux_control.requests.get()
         dbg(callback)  # JACK_TEST
         if notification.error:
-            dbg('Request error: {}'.format(notification))
+            dbg("Request error: {}".format(notification))
             if notification.result[0] in ATTACH_ERROR_STRINGS:
                 # if we got here it means that attaching to an existing session
                 # failed, invalidate the layout so the Terminator initialization
@@ -251,7 +266,7 @@ class NotificationsHandler(object):
         # figure out the root cause
         # terminal.vte.feed(output.replace("\033g", "").encode('utf-8'))
         dbg(output)
-        terminal.vte.feed(output.decode('unicode-escape').encode('latin-1'))
+        terminal.vte.feed(output.decode("unicode-escape").encode("latin-1"))
 
     def handle_layout_change(self, notification):
         assert isinstance(notification, LayoutChange)
@@ -262,7 +277,7 @@ class NotificationsHandler(object):
         GObject.idle_add(self.terminator.tmux_control.garbage_collect_panes)
 
     def pane_id_result(self, result):
-        pane_id, marker = result[0].split(' ')
+        pane_id, marker = result[0].split(" ")
         terminal = self.terminator.find_terminal_by_pane_id(marker)
         terminal.pane_id = pane_id
         self.terminator.pane_id_to_terminal[pane_id] = terminal
@@ -271,7 +286,7 @@ class NotificationsHandler(object):
     # the Terminal class first
     def pane_tty_result(self, result):
         dbg(result)
-        pane_id, pane_tty = result[0].split(' ')
+        pane_id, pane_tty = result[0].split(" ")
         # self.terminator.pane_id_to_terminal[pane_id].tty = pane_tty
 
     def garbage_collect_panes_result(self, result):
@@ -279,7 +294,7 @@ class NotificationsHandler(object):
         removed_pane_ids = pane_id_to_terminal.keys()
 
         for line in result:
-            pane_id, pane_pid = line.split(b' ')
+            pane_id, pane_pid = line.split(b" ")
             try:
                 removed_pane_ids.remove(pane_id)
                 pane_id_to_terminal[pane_id].pid = pane_pid
@@ -288,16 +303,18 @@ class NotificationsHandler(object):
                 continue
 
         if removed_pane_ids:
+
             def callback():
                 for pane_id in removed_pane_ids:
                     terminal = pane_id_to_terminal.pop(pane_id, None)
                     if terminal:
                         terminal.close()
                 return False
+
             GObject.idle_add(callback)
 
     def initial_layout_result(self, result):
-        dbg('checking window layout')  # JACK_TEST
+        dbg("checking window layout")  # JACK_TEST
         window_layouts = []
         for line in result:
             window_layout = line.strip()
@@ -310,10 +327,10 @@ class NotificationsHandler(object):
             dbg(parsed_layout)
             window_layouts.extend(layout.parse_layout(parsed_layout[0]))
             # window_layouts.append(layout.parse_layout(window_layout))
-        dbg('window layouts: {}'.format(window_layouts))  # JACK_TEST
-        terminator_layout = layout.convert_to_terminator_layout(
-                window_layouts)
+        dbg("window layouts: {}".format(window_layouts))  # JACK_TEST
+        terminator_layout = layout.convert_to_terminator_layout(window_layouts)
         import pprint
+
         dbg(pprint.pformat(terminator_layout))
         self.terminator.initial_layout = terminator_layout
 
@@ -321,25 +338,27 @@ class NotificationsHandler(object):
         terminal = self.terminator.pane_id_to_terminal.get(pane_id)
         if not terminal:
             return
-        output = b'\r\n'.join(l for l in result if l)
+        output = b"\r\n".join(l for l in result if l)
         dbg(output)
-        terminal.vte.feed(output.decode('unicode-escape').encode('latin-1'))
+        terminal.vte.feed(output.decode("unicode-escape").encode("latin-1"))
 
     def initial_output_result_callback(self, pane_id):
         def result_callback(result):
             terminal = self.terminator.pane_id_to_terminal.get(pane_id)
             if not terminal:
                 return
-            output = '\r\n'.join(l for l in result if l)
-            terminal.vte.feed(output.decode('string_escape'))
+            output = "\r\n".join(l for l in result if l)
+            terminal.vte.feed(output.decode("string_escape"))
+
         return result_callback
 
     def terminate(self):
         def callback():
             for window in self.terminator.windows:
-                window.emit('destroy')
+                window.emit("destroy")
+
         GObject.idle_add(callback)
 
 
 def noop(*args):
-    dbg('passed on notification: {}'.format(args))
+    dbg("passed on notification: {}".format(args))

--- a/terminatorlib/tmux/notifications.py
+++ b/terminatorlib/tmux/notifications.py
@@ -275,6 +275,14 @@ class NotificationsHandler(object):
         assert isinstance(notification, WindowClose)
         GObject.idle_add(self.terminator.tmux_control.garbage_collect_panes)
 
+    def handle_window_add(self, notification):
+        assert isinstance(notification, WindowAdd)
+        GObject.idle_add(self.terminator.tmux_control.garbage_collect_panes)
+
+    def handle_unlinked_window_close(self, notification):
+        assert isinstance(notification, UnlinkedWindowClose)
+        GObject.idle_add(self.terminator.tmux_control.garbage_collect_panes)
+
     def pane_id_result(self, result):
         pane_id, marker = result[0].decode("unicode-escape").split(" ")
         terminal = self.terminator.find_terminal_by_pane_id(marker)

--- a/terminatorlib/tmux/notifications.py
+++ b/terminatorlib/tmux/notifications.py
@@ -76,7 +76,7 @@ class LayoutChange(Notification):
 
     def consume(self, line, *args):
         # attributes not present default to None
-        line_items = line.split(b" ")
+        line_items = line.decode('unicode-escape').split(" ")
         window_id, window_layout, window_visible_layout, window_flags = line_items + [
             None
         ] * (len(self.attributes) - len(line_items))
@@ -96,7 +96,7 @@ class Output(Notification):
         # pane_id = line[0]
         # output = ' '.join(line[1:])
         pane_id, output = line.split(b" ", 1)
-        self.pane_id = pane_id
+        self.pane_id = pane_id.decode('latin-1')
         self.output = output
 
 
@@ -107,7 +107,7 @@ class SessionChanged(Notification):
     attributes = ["session_id", "session_name"]
 
     def consume(self, line, *args):
-        session_id, session_name = line.split(b" ")
+        session_id, session_name = line.decode('unicode-escape').split(" ")
         self.session_id = session_id
         self.session_name = session_name
 
@@ -119,7 +119,7 @@ class SessionRenamed(Notification):
     attributes = ["session_id", "session_name"]
 
     def consume(self, line, *args):
-        session_id, session_name = line.split(b" ")
+        session_id, session_name = line.decode('unicode-escape').split(" ")
         self.session_id = session_id
         self.session_name = session_name
 
@@ -138,7 +138,7 @@ class UnlinkedWindowAdd(Notification):
     attributes = ["window_id"]
 
     def consume(self, line, *args):
-        (window_id,) = line.split(b" ")
+        (window_id,) = line.decode('unicode-escape').split(" ")
         self.window_id = window_id
 
 
@@ -149,7 +149,7 @@ class WindowAdd(Notification):
     attributes = ["window_id"]
 
     def consume(self, line, *args):
-        (window_id,) = line.split(b" ")
+        (window_id,) = line.decode('unicode-escape').split(" ")
         self.window_id = window_id
 
 
@@ -160,7 +160,7 @@ class UnlinkedWindowClose(Notification):
     attributes = ["window_id"]
 
     def consume(self, line, *args):
-        (window_id,) = line.split(b" ")
+        (window_id,) = line.decode('unicode-escape').split(" ")
         self.window_id = window_id
 
 
@@ -171,7 +171,7 @@ class WindowClose(Notification):
     attributes = ["window_id"]
 
     def consume(self, line, *args):
-        (window_id,) = line.split(b" ")
+        (window_id,) = line.decode('unicode-escape').split(" ")
         self.window_id = window_id
 
 
@@ -182,7 +182,7 @@ class UnlinkedWindowRenamed(Notification):
     attributes = ["window_id", "window_name"]
 
     def consume(self, line, *args):
-        window_id, window_name = line.split(b" ")
+        window_id, window_name = line.decode('unicode-escape').split(" ")
         self.window_id = window_id
         self.window_name = window_name
 
@@ -194,7 +194,7 @@ class WindowRenamed(Notification):
     attributes = ["window_id", "window_name"]
 
     def consume(self, line, *args):
-        window_id, window_name = line.split(b" ")
+        window_id, window_name = line.decode('unicode-escape').split(" ")
         self.window_id = window_id
         self.window_name = window_name
 
@@ -252,7 +252,7 @@ class NotificationsHandler(object):
         output = notification.output
         dbg(pane_id)
         dbg(self.terminator.pane_id_to_terminal)
-        terminal = self.terminator.pane_id_to_terminal.get(pane_id.decode())
+        terminal = self.terminator.pane_id_to_terminal.get(pane_id)
         if not terminal:
             return
         for code in ALTERNATE_SCREEN_ENTER_CODES:
@@ -266,7 +266,7 @@ class NotificationsHandler(object):
         # figure out the root cause
         # terminal.vte.feed(output.replace("\033g", "").encode('utf-8'))
         dbg(output)
-        terminal.vte.feed(output.decode("unicode-escape").encode("latin-1"))
+        terminal.vte.feed(output.decode('unicode-escape').encode("latin-1"))
 
     def handle_layout_change(self, notification):
         assert isinstance(notification, LayoutChange)
@@ -277,7 +277,7 @@ class NotificationsHandler(object):
         GObject.idle_add(self.terminator.tmux_control.garbage_collect_panes)
 
     def pane_id_result(self, result):
-        pane_id, marker = result[0].split(" ")
+        pane_id, marker = result[0].decode('unicode-escape').split(" ")
         terminal = self.terminator.find_terminal_by_pane_id(marker)
         terminal.pane_id = pane_id
         self.terminator.pane_id_to_terminal[pane_id] = terminal
@@ -294,7 +294,7 @@ class NotificationsHandler(object):
         removed_pane_ids = pane_id_to_terminal.keys()
 
         for line in result:
-            pane_id, pane_pid = line.split(b" ")
+            pane_id, pane_pid = line.decode('unicode-escape').split(" ")
             try:
                 removed_pane_ids.remove(pane_id)
                 pane_id_to_terminal[pane_id].pid = pane_pid
@@ -303,7 +303,6 @@ class NotificationsHandler(object):
                 continue
 
         if removed_pane_ids:
-
             def callback():
                 for pane_id in removed_pane_ids:
                     terminal = pane_id_to_terminal.pop(pane_id, None)

--- a/terminatorlib/tmux/notifications.py
+++ b/terminatorlib/tmux/notifications.py
@@ -43,11 +43,11 @@ class Result(Notification):
         self.code = code
         result = []
         line = out.readline()[:-1]
-        while not (line.startswith('%end') or line.startswith('%error')):
+        while not (line.startswith(b'%end') or line.startswith(b'%error')):
             result.append(line)
             line = out.readline()[:-1]
         self.result = result
-        end, timestamp, code, _ = line.split(' ')
+        end, timestamp, code, _ = line.split(b' ')
         self.end_timestamp = timestamp
         self.error = end == '%error'
 

--- a/terminatorlib/tmux/notifications.py
+++ b/terminatorlib/tmux/notifications.py
@@ -205,22 +205,20 @@ class NotificationsHandler(object):
 
     def handle(self, notification):
         try:
-            dbg("looking for method for {}".format(notification.marker))  # JACK_TEST
             handler_method = getattr(
                 self, "handle_{}".format(notification.marker.replace("-", "_"))
             )
-            handler_method(notification)
-        except AttributeError as e:  # JACK_TEST
-            dbg(
-                "------- method for {} NOT FOUND: {}".format(notification.marker, e)
-            )  # JACK_TEST
-            pass
-        except Exception as e:  # JACK_TEST
-            dbg(
-                "something went wrong while handling {}: {}".format(
-                    notification.marker, e
+        except AttributeError as e:
+            dbg("Handler for notification {} not found".format(notification.marker))
+        else:
+            try:
+                handler_method(notification)
+            except Exception as e:
+                dbg(
+                    "something went wrong while handling {}: {}".format(
+                        notification.marker, e
+                    )
                 )
-            )  # JACK_TEST
 
     def handle_begin(self, notification):
         dbg("### {}".format(notification))
@@ -321,20 +319,11 @@ class NotificationsHandler(object):
             GObject.idle_add(callback)
 
     def initial_layout_result(self, result):
-        dbg("checking window layout")  # JACK_TEST
         window_layouts = []
         for line in result:
             window_layout = line.strip()
-            dbg(window_layout)
-            try:
-                parsed_layout = self.layout_parser.parse(window_layout.decode())
-            except Exception as e:
-                dbg(e)
-                exit(1)
-            dbg(parsed_layout)
-            window_layouts.extend(layout.parse_layout(parsed_layout[0]))
-            # window_layouts.append(layout.parse_layout(window_layout))
-        dbg("window layouts: {}".format(window_layouts))  # JACK_TEST
+            parsed_layout = self.layout_parser.parse(window_layout.decode())
+            window_layouts.append(layout.parse_layout(parsed_layout[0]))
         terminator_layout = layout.convert_to_terminator_layout(window_layouts)
         import pprint
 

--- a/terminatorlib/tmux/notifications.py
+++ b/terminatorlib/tmux/notifications.py
@@ -22,7 +22,6 @@ def notification(cls):
 
 
 class Notification(object):
-
     marker = "undefined"
     attributes = []
 
@@ -76,7 +75,7 @@ class LayoutChange(Notification):
 
     def consume(self, line, *args):
         # attributes not present default to None
-        line_items = line.decode('unicode-escape').split(" ")
+        line_items = line.decode("unicode-escape").split(" ")
         window_id, window_layout, window_visible_layout, window_flags = line_items + [
             None
         ] * (len(self.attributes) - len(line_items))
@@ -96,7 +95,7 @@ class Output(Notification):
         # pane_id = line[0]
         # output = ' '.join(line[1:])
         pane_id, output = line.split(b" ", 1)
-        self.pane_id = pane_id.decode('latin-1')
+        self.pane_id = pane_id.decode("latin-1")
         self.output = output
 
 
@@ -107,7 +106,7 @@ class SessionChanged(Notification):
     attributes = ["session_id", "session_name"]
 
     def consume(self, line, *args):
-        session_id, session_name = line.decode('unicode-escape').split(" ")
+        session_id, session_name = line.decode("unicode-escape").split(" ")
         self.session_id = session_id
         self.session_name = session_name
 
@@ -119,7 +118,7 @@ class SessionRenamed(Notification):
     attributes = ["session_id", "session_name"]
 
     def consume(self, line, *args):
-        session_id, session_name = line.decode('unicode-escape').split(" ")
+        session_id, session_name = line.decode("unicode-escape").split(" ")
         self.session_id = session_id
         self.session_name = session_name
 
@@ -138,7 +137,7 @@ class UnlinkedWindowAdd(Notification):
     attributes = ["window_id"]
 
     def consume(self, line, *args):
-        (window_id,) = line.decode('unicode-escape').split(" ")
+        (window_id,) = line.decode("unicode-escape").split(" ")
         self.window_id = window_id
 
 
@@ -149,7 +148,7 @@ class WindowAdd(Notification):
     attributes = ["window_id"]
 
     def consume(self, line, *args):
-        (window_id,) = line.decode('unicode-escape').split(" ")
+        (window_id,) = line.decode("unicode-escape").split(" ")
         self.window_id = window_id
 
 
@@ -160,7 +159,7 @@ class UnlinkedWindowClose(Notification):
     attributes = ["window_id"]
 
     def consume(self, line, *args):
-        (window_id,) = line.decode('unicode-escape').split(" ")
+        (window_id,) = line.decode("unicode-escape").split(" ")
         self.window_id = window_id
 
 
@@ -171,7 +170,7 @@ class WindowClose(Notification):
     attributes = ["window_id"]
 
     def consume(self, line, *args):
-        (window_id,) = line.decode('unicode-escape').split(" ")
+        (window_id,) = line.decode("unicode-escape").split(" ")
         self.window_id = window_id
 
 
@@ -182,7 +181,7 @@ class UnlinkedWindowRenamed(Notification):
     attributes = ["window_id", "window_name"]
 
     def consume(self, line, *args):
-        window_id, window_name = line.decode('unicode-escape').split(" ")
+        window_id, window_name = line.decode("unicode-escape").split(" ")
         self.window_id = window_id
         self.window_name = window_name
 
@@ -194,7 +193,7 @@ class WindowRenamed(Notification):
     attributes = ["window_id", "window_name"]
 
     def consume(self, line, *args):
-        window_id, window_name = line.decode('unicode-escape').split(" ")
+        window_id, window_name = line.decode("unicode-escape").split(" ")
         self.window_id = window_id
         self.window_name = window_name
 
@@ -266,7 +265,7 @@ class NotificationsHandler(object):
         # figure out the root cause
         # terminal.vte.feed(output.replace("\033g", "").encode('utf-8'))
         dbg(output)
-        terminal.vte.feed(output.decode('unicode-escape').encode("latin-1"))
+        terminal.vte.feed(output.decode("unicode-escape").encode("latin-1"))
 
     def handle_layout_change(self, notification):
         assert isinstance(notification, LayoutChange)
@@ -277,7 +276,7 @@ class NotificationsHandler(object):
         GObject.idle_add(self.terminator.tmux_control.garbage_collect_panes)
 
     def pane_id_result(self, result):
-        pane_id, marker = result[0].decode('unicode-escape').split(" ")
+        pane_id, marker = result[0].decode("unicode-escape").split(" ")
         terminal = self.terminator.find_terminal_by_pane_id(marker)
         terminal.pane_id = pane_id
         self.terminator.pane_id_to_terminal[pane_id] = terminal
@@ -294,7 +293,7 @@ class NotificationsHandler(object):
         removed_pane_ids = list(pane_id_to_terminal.keys())
 
         for line in result:
-            pane_id, pane_pid = line.decode('unicode-escape').split(" ")
+            pane_id, pane_pid = line.decode("unicode-escape").split(" ")
             try:
                 removed_pane_ids.remove(pane_id)
                 pane_id_to_terminal[pane_id].pid = pane_pid
@@ -303,6 +302,7 @@ class NotificationsHandler(object):
                 continue
 
         if removed_pane_ids:
+
             def callback():
                 for pane_id in removed_pane_ids:
                     terminal = pane_id_to_terminal.pop(pane_id, None)
@@ -338,7 +338,6 @@ class NotificationsHandler(object):
         if not terminal:
             return
         output = b"\r\n".join(line for line in result if line)
-        dbg(output)
         terminal.vte.feed(output.decode("unicode-escape").encode("latin-1"))
 
     def terminate(self):

--- a/terminatorlib/tmux/notifications.py
+++ b/terminatorlib/tmux/notifications.py
@@ -198,16 +198,22 @@ class NotificationsHandler(object):
 
     def handle(self, notification):
         try:
+            dbg('looking for method for {}'.format(notification.marker))  # JACK_TEST
             handler_method = getattr(self, 'handle_{}'.format(
                     notification.marker.replace('-', '_')))
             handler_method(notification)
-        except AttributeError:
+        except AttributeError as e:  # JACK_TEST
+            dbg('------- method for {} NOT FOUND: {}'.format(notification.marker, e))  # JACK_TEST
             pass
+        except Exception as e:  # JACK_TEST
+            dbg('something went wrong while handling {}: {}'.format(notification.marker, e))  # JACK_TEST
 
     def handle_begin(self, notification):
         dbg('### {}'.format(notification))
         assert isinstance(notification, Result)
+        dbg('######## getting callback')  # JACK_TEST
         callback = self.terminator.tmux_control.requests.get()
+        dbg(callback)  # JACK_TEST
         if notification.error:
             dbg('Request error: {}'.format(notification))
             if notification.result[0] in ATTACH_ERROR_STRINGS:
@@ -291,6 +297,7 @@ class NotificationsHandler(object):
             GObject.idle_add(callback)
 
     def initial_layout_result(self, result):
+        dbg('checking window layout')  # JACK_TEST
         window_layouts = []
         for line in result:
             window_layout = line.strip()
@@ -303,6 +310,7 @@ class NotificationsHandler(object):
             dbg(parsed_layout)
             window_layouts.extend(layout.parse_layout(parsed_layout[0]))
             # window_layouts.append(layout.parse_layout(window_layout))
+        dbg('window layouts: {}'.format(window_layouts))  # JACK_TEST
         terminator_layout = layout.convert_to_terminator_layout(
                 window_layouts)
         import pprint

--- a/terminatorlib/tmux/notifications.py
+++ b/terminatorlib/tmux/notifications.py
@@ -291,7 +291,7 @@ class NotificationsHandler(object):
 
     def garbage_collect_panes_result(self, result):
         pane_id_to_terminal = self.terminator.pane_id_to_terminal
-        removed_pane_ids = pane_id_to_terminal.keys()
+        removed_pane_ids = list(pane_id_to_terminal.keys())
 
         for line in result:
             pane_id, pane_pid = line.decode('unicode-escape').split(" ")
@@ -337,19 +337,9 @@ class NotificationsHandler(object):
         terminal = self.terminator.pane_id_to_terminal.get(pane_id)
         if not terminal:
             return
-        output = b"\r\n".join(l for l in result if l)
+        output = b"\r\n".join(line for line in result if line)
         dbg(output)
         terminal.vte.feed(output.decode("unicode-escape").encode("latin-1"))
-
-    def initial_output_result_callback(self, pane_id):
-        def result_callback(result):
-            terminal = self.terminator.pane_id_to_terminal.get(pane_id)
-            if not terminal:
-                return
-            output = "\r\n".join(l for l in result if l)
-            terminal.vte.feed(output.decode("string_escape"))
-
-        return result_callback
 
     def terminate(self):
         def callback():

--- a/terminatorlib/tmux/notifications.py
+++ b/terminatorlib/tmux/notifications.py
@@ -1,0 +1,310 @@
+from gi.repository import GObject
+
+from terminatorlib.util import dbg
+from terminatorlib.tmux import layout
+
+import string
+ATTACH_ERROR_STRINGS = ["can't find session terminator", "no current session", "no sessions"]
+ALTERNATE_SCREEN_ENTER_CODES = [ "\\033[?1049h" ]
+ALTERNATE_SCREEN_EXIT_CODES  = [ "\\033[?1049l" ]
+
+notifications_mappings = {}
+
+
+def notification(cls):
+    notifications_mappings[cls.marker] = cls
+    return cls
+
+
+class Notification(object):
+
+    marker = 'undefined'
+    attributes = []
+
+    def consume(self, line, out):
+        pass
+
+    def __str__(self):
+        attributes = ['{}="{}"'.format(attribute, getattr(self, attribute, ''))
+                      for attribute in self.attributes]
+        return '{}[{}]'.format(self.marker, ', '.join(attributes))
+
+
+@notification
+class Result(Notification):
+
+    marker = 'begin'
+    attributes = ['begin_timestamp', 'code', 'result', 'end_timestamp',
+                  'error']
+
+    def consume(self, line, out):
+        timestamp, code, _ = line
+        self.begin_timestamp = timestamp
+        self.code = code
+        result = []
+        line = out.readline()[:-1]
+        while not (line.startswith('%end') or line.startswith('%error')):
+            result.append(line)
+            line = out.readline()[:-1]
+        self.result = result
+        end, timestamp, code, _ = line.split(' ')
+        self.end_timestamp = timestamp
+        self.error = end == '%error'
+
+
+@notification
+class Exit(Notification):
+
+    marker = 'exit'
+    attributes = ['reason']
+
+    def consume(self, line, *args):
+        self.reason = line[0] if line else None
+
+
+@notification
+class LayoutChange(Notification):
+
+    marker = 'layout-change'
+    attributes = ['window_id', 'window_layout', 'window_visible_layout',
+                  'window_flags']
+
+    def consume(self, line, *args):
+        # attributes not present default to None
+        window_id, window_layout, window_visible_layout, window_flags = line + [None] * (len(self.attributes) - len(line))
+        self.window_id = window_id
+        self.window_layout = window_layout
+        self.window_visible_layout = window_visible_layout
+        self.window_flags = window_flags
+
+@notification
+class Output(Notification):
+
+    marker = 'output'
+    attributes = ['pane_id', 'output']
+
+    def consume(self, line, *args):
+        pane_id = line[0]
+        output = ' '.join(line[1:])
+        self.pane_id = pane_id
+        self.output = output
+
+@notification
+class SessionChanged(Notification):
+
+    marker = 'session-changed'
+    attributes = ['session_id', 'session_name']
+
+    def consume(self, line, *args):
+        session_id, session_name = line
+        self.session_id = session_id
+        self.session_name = session_name
+
+
+@notification
+class SessionRenamed(Notification):
+
+    marker = 'session-renamed'
+    attributes = ['session_id', 'session_name']
+
+    def consume(self, line, *args):
+        session_id, session_name = line
+        self.session_id = session_id
+        self.session_name = session_name
+
+
+@notification
+class SessionsChanged(Notification):
+
+    marker = 'sessions-changed'
+    attributes = []
+
+
+@notification
+class UnlinkedWindowAdd(Notification):
+
+    marker = 'unlinked-window-add'
+    attributes = ['window_id']
+
+    def consume(self, line, *args):
+        window_id, = line
+        self.window_id = window_id
+
+
+@notification
+class WindowAdd(Notification):
+
+    marker = 'window-add'
+    attributes = ['window_id']
+
+    def consume(self, line, *args):
+        window_id, = line
+        self.window_id = window_id
+
+
+@notification
+class UnlinkedWindowClose(Notification):
+
+    marker = 'unlinked-window-close'
+    attributes = ['window_id']
+
+    def consume(self, line, *args):
+        window_id, = line
+        self.window_id = window_id
+
+
+@notification
+class WindowClose(Notification):
+
+    marker = 'window-close'
+    attributes = ['window_id']
+
+    def consume(self, line, *args):
+        window_id, = line
+        self.window_id = window_id
+
+
+@notification
+class UnlinkedWindowRenamed(Notification):
+
+    marker = 'unlinked-window-renamed'
+    attributes = ['window_id', 'window_name']
+
+    def consume(self, line, *args):
+        window_id, window_name = line
+        self.window_id = window_id
+        self.window_name = window_name
+
+
+@notification
+class WindowRenamed(Notification):
+
+    marker = 'window-renamed'
+    attributes = ['window_id', 'window_name']
+
+    def consume(self, line, *args):
+        window_id, window_name = line
+        self.window_id = window_id
+        self.window_name = window_name
+
+
+class NotificationsHandler(object):
+
+    def __init__(self, terminator):
+        self.terminator = terminator
+        self.layout_parser = layout.LayoutParser()
+
+    def handle(self, notification):
+        try:
+            handler_method = getattr(self, 'handle_{}'.format(
+                    notification.marker.replace('-', '_')))
+            handler_method(notification)
+        except AttributeError:
+            pass
+
+    def handle_begin(self, notification):
+        dbg('### {}'.format(notification))
+        assert isinstance(notification, Result)
+        callback = self.terminator.tmux_control.requests.get()
+        if notification.error:
+            dbg('Request error: {}'.format(notification))
+            if notification.result[0] in ATTACH_ERROR_STRINGS:
+                # if we got here it means that attaching to an existing session
+                # failed, invalidate the layout so the Terminator initialization
+                # can pick up from where we left off
+                self.terminator.initial_layout = {}
+                self.terminator.tmux_control.reset()
+            return
+        callback(notification.result)
+
+    def handle_output(self, notification):
+        assert isinstance(notification, Output)
+        pane_id = notification.pane_id
+        output = notification.output
+        terminal = self.terminator.pane_id_to_terminal.get(pane_id)
+        if not terminal:
+            return
+        for code in ALTERNATE_SCREEN_ENTER_CODES:
+            if code in output:
+                self.terminator.tmux_control.alternate_on = True
+        for code in ALTERNATE_SCREEN_EXIT_CODES:
+            if code in output:
+                self.terminator.tmux_control.alternate_on = False
+        # NOTE: using neovim, enabling visual-bell and setting t_vb empty results in incorrect
+        # escape sequences (C-g) being printed in the neovim window; remove them until we can
+        # figure out the root cause
+        terminal.vte.feed(output.decode('string_escape').replace("\033g",""))
+
+    def handle_layout_change(self, notification):
+        assert isinstance(notification, LayoutChange)
+        GObject.idle_add(self.terminator.tmux_control.garbage_collect_panes)
+
+    def handle_window_close(self, notification):
+        assert isinstance(notification, WindowClose)
+        GObject.idle_add(self.terminator.tmux_control.garbage_collect_panes)
+
+    def pane_id_result(self, result):
+        pane_id, marker = result[0].split(' ')
+        terminal = self.terminator.find_terminal_by_pane_id(marker)
+        terminal.pane_id = pane_id
+        self.terminator.pane_id_to_terminal[pane_id] = terminal
+
+    # NOTE: UNUSED; if we ever end up needing this, create the tty property in
+    # the Terminal class first
+    def pane_tty_result(self, result):
+        dbg(result)
+        pane_id, pane_tty = result[0].split(' ')
+        # self.terminator.pane_id_to_terminal[pane_id].tty = pane_tty
+
+    def garbage_collect_panes_result(self, result):
+        pane_id_to_terminal = self.terminator.pane_id_to_terminal
+        removed_pane_ids = pane_id_to_terminal.keys()
+
+        for line in result:
+            pane_id, pane_pid = line.split(' ')
+            try:
+                removed_pane_ids.remove(pane_id)
+                pane_id_to_terminal[pane_id].pid = pane_pid
+            except ValueError:
+                dbg("Pane already reaped, keep going.")
+                continue
+
+        if removed_pane_ids:
+            def callback():
+                for pane_id in removed_pane_ids:
+                    terminal = pane_id_to_terminal.pop(pane_id, None)
+                    if terminal:
+                        terminal.close()
+                return False
+            GObject.idle_add(callback)
+
+    def initial_layout_result(self, result):
+        window_layouts = []
+        for line in result:
+            window_layout = line.strip()
+            window_layouts.extend(layout.parse_layout(self.layout_parser.parse(window_layout)[0]))
+            # window_layouts.append(layout.parse_layout(window_layout))
+        terminator_layout = layout.convert_to_terminator_layout(
+                window_layouts)
+        import pprint
+        dbg(pprint.pformat(terminator_layout))
+        self.terminator.initial_layout = terminator_layout
+
+    def initial_output_result_callback(self, pane_id):
+        def result_callback(result):
+            terminal = self.terminator.pane_id_to_terminal.get(pane_id)
+            if not terminal:
+                return
+            output = '\r\n'.join(l for l in result if l)
+            terminal.vte.feed(output.decode('string_escape'))
+        return result_callback
+
+    def terminate(self):
+        def callback():
+            for window in self.terminator.windows:
+                window.emit('destroy')
+        GObject.idle_add(callback)
+
+
+def noop(result):
+    pass

--- a/terminatorlib/util.py
+++ b/terminatorlib/util.py
@@ -346,6 +346,30 @@ def get_column_row_count(window):
 
     return (column_sum, row_sum)
 
+def get_amount_of_terminals_in_each_direction(window):
+    base_x = base_y = None
+
+    # NOTE: on Wayland, we cannot assume that the coordinate system
+    # for our application starts at 0x0, so we try to guess our
+    # current baseline at runtime
+    if display_manager() == 'WAYLAND' and not base_x:
+        base_x, base_y = get_wayland_baseline(window)
+    else:
+        base_x = base_y = 0
+
+    terminals = window.get_visible_terminals()
+    horizontal_terminals = 0
+    vertical_terminals = 0
+    for terminal in terminals:
+        rect = terminal.get_allocation()
+
+        if rect.x <= base_x:
+            vertical_terminals += 1
+        if rect.y <= base_y:
+            horizontal_terminals += 1
+
+    return horizontal_terminals, vertical_terminals
+
 def get_wayland_baseline(window):
     terminals = window.get_visible_terminals()
 

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -506,6 +506,9 @@ class Window(Container, Gtk.Window):
 
     def zoom(self, widget, font_scale=True):
         """Zoom a terminal widget"""
+        if self.terminator.tmux_control:
+            # Zooming causes all kinds of issues when in tmux mode, so we'll just disable it for now
+            return
         children = self.get_children()
 
         if widget in children:

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -473,13 +473,15 @@ class Window(Container, Gtk.Window):
             container = maker.make('HPaned')
         
         self.set_pos_by_ratio = True
-
         if not sibling:
             sibling = maker.make('Terminal')
             sibling.set_cwd(cwd)
+            # TODO (dank): is widget ever not a Terminal?
             if self.config['always_split_with_profile']:
                 sibling.force_set_profile(None, widget.get_profile())
-            sibling.spawn_child()
+            sibling.spawn_child(
+                orientation='vertical' if vertical else 'horizontal',
+                active_pane_id=getattr(widget, 'pane_id', None))
             if widget.group and self.config['split_to_group']:
                 sibling.set_group(None, widget.group)
         elif self.config['always_split_with_profile']:
@@ -630,9 +632,9 @@ class Window(Container, Gtk.Window):
             return
 
         terminals = self.get_visible_terminals()
+
         column_sum = 0
         row_sum = 0
-
         for terminal in terminals:
             rect = terminal.get_allocation()
             if rect.x == 0:

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python2
+
+import os
+import sys, os.path
+sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), "..")))
+
+import unittest
+from terminatorlib.tmux import notifications
+
+class NotificationsTests(unittest.TestCase):
+
+    def test_layout_changed_parsing(self):
+        layouts = [
+            'sum,80x24,0,0,0',
+            'sum,80x24,0,0[80x12,0,0,0,80x5,0,13,1,80x2,0,19,2,80x2,0,22,3]',
+            'sum,80x24,0,0{40x24,0,0,0,19x24,41,0,1,9x24,61,0,2,4x24,71,0,3,4x24,76,0,4}',
+            'sum,80x24,0,0[80x12,0,0,0,80x5,0,13,1,80x5,0,19{40x5,0,19,2,19x5,41,19,3,9x5,61,19,4,4x5,71,19,5,4x5,76,19,6}]'
+        ]
+        for layout in layouts:
+            notification = notifications.LayoutChange()
+            notification.consume(['', layout])
+            print notification.window_layout
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is a cleanup of #378. A lot of changes went into this.

I spent the last couple of days getting it working. It's mostly usable at a basic level, but only if there is only one client connected at any one time. In short, the code is able to push all (most) state changes from Terminator to tmux, but it's not able to react to changes made by either an attached tmux instance or other Terminator instances attached to the same session.

If your workflow only involves having one backing headless instance of tmux running at all times and connecting/disconnecting one Terminator instance at a time, then this should be fine.

There are a few really gnarly incompatibilities between Terminator's features and what tmux allows. As an example, in Terminator you can change the zoom level of all panes independently, which is impossible in tmux. Doing it leads to very odd behaviour where a terminal appears to have a certain `height`x`width`, but the backing tmux pane is actually smaller/bigger, and text wraps in odd ways in the other panes. I ended up disabling zooming and drag&drop altogether when in tmux mode.

There are other issues: tmux's window size includes all the pane separators, so if you set a client size of 80x20 and then split it in two you don't get two 40x20 terminals, but one 39x20 and one 40x20, because the vertical separator takes up a column. Terminator determines its window size **excluding** the separator(s). I tried to add functionality to keep them in sync, but this doesn't always work.

Feel free to give it a try and see if it works fine for you.