### PR TITLE
Fixed geometry hints

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1330,6 +1330,9 @@ class Terminal(Gtk.VBox):
         if self.config['geometry_hinting']:
             window = self.get_toplevel()
             window.deferred_set_rough_geometry_hints()
+        else:
+            window = self.get_toplevel()
+            window.disable_geometry_hints()
 
     def on_vte_notify_enter(self, term, event):
         """Handle the mouse entering this terminal"""

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -667,7 +667,10 @@ class Window(Container, Gtk.Window):
         geometry.base_height = extra_height
         geometry.width_inc = font_width
         geometry.height_inc = font_height
-        self.set_geometry_hints(self, geometry, Gdk.WindowHints.BASE_SIZE | Gdk.WindowHints.RESIZE_INC)
+        self.set_geometry_hints(None, geometry, Gdk.WindowHints.BASE_SIZE | Gdk.WindowHints.RESIZE_INC)
+
+    def disable_geometry_hints(self):
+        self.set_geometry_hints(None, None, 0)
 
     def tab_change(self, widget, num=None):
         """Change to a specific tab"""


### PR DESCRIPTION
I tried to use Window geometry hints, but it didn't work.
I tested this on: Debian 11 (all updates), Debian 10 and Ubuntu 20.04.

Details:
it seems that "set_geometry_hints" wants "None" as first argument.
Also, it's necessary to disable geometry hints, if we want to avoid restarting terminator.
So I wrote a little function that does that.