### PR TITLE
Fixed issue #433 (layout sometimes ignores ratio)

### DIFF
--- a/terminatorlib/paned.py
+++ b/terminatorlib/paned.py
@@ -488,11 +488,15 @@ class Paned(Container):
         return float(position) / float(non_separator_size)
 
     def set_position_by_ratio(self):
+        # For reasons unknown to me, self.ratio often changes when the following loop is executed
+        ratio = self.ratio
+
         # Fix for strange race condition where every so often get_length returns 1. (LP:1655027)
         while self.terminator.doing_layout and self.get_length() == 1:
             while Gtk.events_pending():
                 Gtk.main_iteration()
 
+        self.ratio = ratio
         self.set_pos(self.position_by_ratio(self.get_length(), self.get_handlesize(), self.ratio))
 
     def set_position(self, pos):


### PR DESCRIPTION
Since the bug is well explained in the issue, let's talk about the patch.

I studied this problem for a few hours.
Apparently, this bug *always* occurs when there are two terminals (horizontal or vertical, doesn't matter).
It also occurs when there are more than two, but I didn't figure out any logical pattern.

### Technical details
Basically, while loading a layout, the function `set_position_by_ratio` indirectly calls `new_size` (through Gtk.main_iteration()) which calls `self.set_position(self.get_position())`.
Only after set_position is executed the position is actually set (inside `set_position_by_ratio`), based on the ratio.
But the problem is that set_position takes self.get_position() as argument, while it still hasn't been set. So it calculates the new ratio, which is always about 0.5.

### Fix
Initially, I wanted to remove `self.set_position(self.get_position())` from `new_size`, but that would break stuff. (When splitting a terminal, the ratio has to be calculated again because of that line of separation between the terminals).
So I instead just store self.ratio on a temp variable and restore the value after Gtk.main_iteration() has done.