### PR TITLE
Bug Fix: 'Clear selection on copy' is always unchecked

### DIFF
--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -790,7 +790,7 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkCheckButton">
+                                  <object class="GtkCheckButton" id="clear_select_on_copy">
                                     <property name="label" translatable="yes">Clear selection on copy</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -353,6 +353,9 @@ class PrefsEditor:
         # Smart copy
         widget = guiget('smart_copy')
         widget.set_active(self.config['smart_copy'])
+        # Clear selection on copy
+        widget = guiget('clear_select_on_copy')
+        widget.set_active(self.config['clear_select_on_copy'])
         #Titlebar font selector
         # Use system font
         widget = guiget('title_system_font_checkbutton')


### PR DESCRIPTION
The checkbox for "Clear selection on copy" was always unchecked, because the widget active status was not set.
And the id of the checkbox in preferences.glade was not set.

### To Reproduce
Try to check "Clear selection on copy" and then close the preferences menu. When opened again, it's unchecked.