### PR TITLE
Set CAN_FOCUS to False for notebook widgets

### DIFF
--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -39,6 +39,8 @@ class Notebook(Container, Gtk.Notebook):
         self.connect('scroll-event', self.on_scroll_event)
         self.configure()
 
+        self.set_can_focus(False)
+
         child = window.get_child()
         window.remove(child)
         window.add(self)


### PR DESCRIPTION
Resolves [#issue400](https://github.com/gnome-terminator/terminator/issues/400)

Apparently, we do not need to subscribe on focus-grub event and put the grab back to the VTE terminal. Adding a setting can_focus=false is enough.

Applying it I am still able to rename the tab by a double click, though just clicking on it does not steal l the focus.