### PR TITLE
fixes for --config-json

### DIFF
--- a/terminatorlib/ipc.py
+++ b/terminatorlib/ipc.py
@@ -15,6 +15,7 @@ from .factory import Factory
 from .util import dbg, err, enumerate_descendants
 from .terminal import Terminal
 from .container import Container
+from .configjson import ConfigJson
 from gi.repository import Gtk as gtk
 from gi.repository import GObject as gobject
 
@@ -74,6 +75,15 @@ class DBusService(Borg, dbus.service.Object):
     def new_window_cmdline(self, options=dbus.Dictionary()):
         """Create a new Window"""
         dbg('dbus method called: new_window with parameters %s'%(options))
+        if options['configjson']:
+            dbg(options['configjson'])
+            configjson = ConfigJson()
+            layoutname = configjson.extend_config(options['configjson'])
+            if layoutname and ((not options['layout']) or options['layout'] == 'default'):
+                options['layout'] = layoutname
+                if not options['profile']:
+                    options['profile'] = configjson.get_profile_to_use()
+
         oldopts = self.terminator.config.options_get()
         oldopts.__dict__ = options
         self.terminator.config.options_set(oldopts)

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -362,6 +362,8 @@ class PrefsEditor:
         widget = guiget('profilelist')
         liststore = widget.get_model()
         profiles = self.config.list_profiles()
+        if '__internal_json_profile__' in profiles:
+            profiles.remove('__internal_json_profile__')
         self.profileiters = {}
         for profile in profiles:
             if profile == 'default':
@@ -377,6 +379,8 @@ class PrefsEditor:
         widget = guiget('layoutlist')
         liststore = widget.get_model()
         layouts = self.config.list_layouts()
+        if '__internal_json_layout__' in layouts:
+            layouts.remove('__internal_json_layout__')
         self.layoutiters = {}
         for layout in layouts:
             if layout == 'default':
@@ -387,7 +391,7 @@ class PrefsEditor:
         selection = widget.get_selection()
         selection.connect('changed', self.on_layout_selection_changed)
         terminator = Terminator()
-        if terminator.layoutname:
+        if terminator.layoutname and terminator.layoutname != '__internal_json_layout__':
             layout_to_highlight = terminator.layoutname
         else:
             layout_to_highlight = 'default'
@@ -947,7 +951,6 @@ class PrefsEditor:
         self.config.save()
 
     def on_background_image_file_set(self,widget):
-        print(widget.get_filename())
         self.config['background_image'] = widget.get_filename()
         self.config.save()
 


### PR DESCRIPTION
fixes #401 

Also cleans up the preferences window when a json layout or profile is called and doesn't expose the internal json parameters.

Also cleans up a print statement from a while ago when I was working on background images.