### PR TITLE
Make tabs detachable + minor bugfix

### DIFF
--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -88,6 +88,7 @@ class Notebook(Container, Gtk.Notebook):
         window.resize(size.width, size.height)
 
         self.detach_tab(widget)
+        self.disconnect_child(widget)
         self.hoover()
         window.add(widget)
 

--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -37,6 +37,7 @@ class Notebook(Container, Gtk.Notebook):
         self.register_signals(Notebook)
         self.connect('switch-page', self.deferred_on_tab_switch)
         self.connect('scroll-event', self.on_scroll_event)
+        self.connect('create-window', self.create_window_detach)
         self.configure()
 
         self.set_can_focus(False)
@@ -76,6 +77,21 @@ class Notebook(Container, Gtk.Notebook):
 #        style.ythickness = 0
 #        self.modify_style(style)
         self.last_active_term = {}
+
+    def create_window_detach(self, notebook, widget, x, y):
+        """Create a window to contain a detached tab"""
+        maker = Factory()
+
+        window = maker.make('Window')
+        window.move(x, y)
+        size = self.window.get_size()
+        window.resize(size.width, size.height)
+
+        self.detach_tab(widget)
+        self.hoover()
+        window.add(widget)
+
+        window.show_all()
 
     def create_layout(self, layout):
         """Apply layout configuration"""
@@ -173,6 +189,7 @@ class Notebook(Container, Gtk.Notebook):
             sibling.force_set_profile(None, widget.get_profile())
 
         self.insert_page(container, None, page_num)
+        self.set_tab_detachable(container, True)
         self.child_set_property(container, 'tab-expand', True)
         self.child_set_property(container, 'tab-fill', True)
         self.set_tab_reorderable(container, True)
@@ -299,6 +316,7 @@ class Notebook(Container, Gtk.Notebook):
 
         dbg('inserting page at position: %s' % tabpos)
         self.insert_page(widget, None, tabpos)
+        self.set_tab_detachable(widget, True)
 
         if maker.isinstance(widget, 'Terminal'):
             containers, objects = ([], [widget])

--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -80,6 +80,7 @@ class Notebook(Container, Gtk.Notebook):
 
     def create_window_detach(self, notebook, widget, x, y):
         """Create a window to contain a detached tab"""
+        dbg('creating window for detached tab: %s' % widget)
         maker = Factory()
 
         window = maker.make('Window')

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -299,7 +299,7 @@ class Window(Container, Gtk.Window):
     def on_destroy_event(self, widget, data=None):
         """Handle window destruction"""
         dbg('destroying self')
-        for terminal in self.get_visible_terminals():
+        for terminal in self.get_terminals():
             terminal.close()
         self.cnxids.remove_all()
         self.terminator.deregister_window(self)


### PR DESCRIPTION
Fixes #302

Note - This pull request is to show the progress. I have done very little testing, so I don't recommend pulling it right now.

## About
As said in the issue comments, `set_tab_detachable` does the job. The [code](https://stackoverflow.com/a/56377756) found on StackOverflow gave me a guideline, but much of that stuff is already implemented somewhere in Terminator. So I had to create only one function, `create_window_detach`.

About `self.hoover`: without calling that function, if a tab is detached and a notebook only has 2 tabs, the resulting notebook only has 1 tab, causing some troubles.

Most of the work was about reading the documentation.

---

I'll finish testing soon, and maybe fix that Drag-and-drop problem that we were talking about in the comments, since it's related.