### PR TITLE
Add a "Copy" button to clone profiles

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -310,6 +310,10 @@ class Config(object):
         """Get our profile"""
         return(self.profile)
 
+    def get_profile_by_name(self, profile):
+        """Get the profile with the specified name"""
+        return(self.base.profiles[profile])
+
     def set_profile(self, profile, force=False):
         """Set our profile (which usually means change it)"""
         options = self.options_get()
@@ -322,9 +326,9 @@ class Config(object):
             dbg('Config::set_profile: %s does not exist, creating' % profile)
             self.base.profiles[profile] = copy(DEFAULTS['profiles']['default'])
 
-    def add_profile(self, profile):
+    def add_profile(self, profile, toclone):
         """Add a new profile"""
-        return(self.base.add_profile(profile))
+        return(self.base.add_profile(profile, toclone))
 
     def del_profile(self, profile):
         """Delete a profile"""
@@ -814,11 +818,15 @@ class ConfigBase(Borg):
         if plugin in self.plugins:
             del self.plugins[plugin]
 
-    def add_profile(self, profile):
+    def add_profile(self, profile, toclone):
         """Add a new profile"""
         if profile in self.profiles:
             return(False)
-        self.profiles[profile] = copy(DEFAULTS['profiles']['default'])
+        if toclone is not None:
+            newprofile = copy(toclone)
+        else:
+            newprofile = copy(DEFAULTS['profiles']['default'])
+        self.profiles[profile] = newprofile
         return(True)
 
     def add_layout(self, name, layout):

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -1287,6 +1287,22 @@
                             <property name="position">1</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkButton" id="profileclonebutton">
+                            <property name="label">gtk-copy</property>
+                            <property name="use-action-appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="use-stock">True</property>
+                            <signal name="clicked" handler="on_profileclonebutton_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1334,22 +1334,23 @@ class PrefsEditor:
         self.config['window_state'] = value
         self.config.save()
 
-    def on_profileaddbutton_clicked(self, _button):
-        """Add a new profile to the list"""
+    # helper function, not a signal
+    def addprofile(self, name, toclone):
+        """Add a profile"""
         guiget = self.builder.get_object
 
         treeview = guiget('profilelist')
         model = treeview.get_model()
         values = [ r[0] for r in model ]
 
-        newprofile = _('New Profile')
+        newprofile = name
         if newprofile in values:
             i = 1
             while newprofile in values:
                 i = i + 1
-                newprofile = '%s %d' % (_('New Profile'), i)
+                newprofile = '%s %d' % (name, i)
 
-        if self.config.add_profile(newprofile):
+        if self.config.add_profile(newprofile, toclone):
             res = model.append([newprofile, True])
             if res:
                 path = model.get_path(res)
@@ -1357,6 +1358,10 @@ class PrefsEditor:
                                     start_editing=True)
 
         self.layouteditor.update_profiles()
+
+    def on_profileaddbutton_clicked(self, _button):
+        """Add a new profile to the list"""
+        self.addprofile(_('New Profile'), None)
 
     def on_profileremovebutton_clicked(self, _button):
         """Remove a profile from the list"""
@@ -1376,6 +1381,18 @@ class PrefsEditor:
         model.remove(rowiter)
         selection.select_iter(model.get_iter_first())
         self.layouteditor.update_profiles()
+
+    def on_profileclonebutton_clicked(self, _button):
+        """"Clone a profile and add the new one to the list"""
+        guiget = self.builder.get_object
+
+        treeview = guiget('profilelist')
+        selection = treeview.get_selection()
+        (model, rowiter) = selection.get_selected()
+        profile = model.get_value(rowiter, 0)
+
+        toclone = self.config.get_profile_by_name(profile)
+        self.addprofile(profile, toclone)
 
     def on_layoutaddbutton_clicked(self, _button):
         """Add a new layout to the list"""


### PR DESCRIPTION
Very simple changes, but such a big time saver.
Currently, if you want to duplicate a profile, you either do it in the config file, or you have to add a new profile and manually set all of the settings again.

Also as a note, I think the `Disable Ctrl+mousewheel zoom` button in Profiles is broken. It sometimes does not change value when switching between profiles.