### PR TITLE
BugFix: terminal won't restart if there is no custom command

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1461,7 +1461,7 @@ class Terminal(Gtk.VBox):
         self.is_held_open = True
         self.titlebar.update()
 
-    def spawn_child(self, init_command=None, widget=None, respawn=False, debugserver=False):
+    def spawn_child(self, widget=None, respawn=False, debugserver=False, init_command=None):
         args = []
         shell = None
         command = init_command
@@ -1492,9 +1492,10 @@ class Terminal(Gtk.VBox):
             command = self.layout_command
         elif debugserver is True:
             details = self.terminator.debug_address
-            dbg('spawning debug session with: %s:%s' % (details[0],
-                details[1]))
-            command = 'telnet %s %s' % (details[0], details[1])
+            if details is not None:
+                dbg('spawning debug session with: %s:%s' % (details[0],
+                    details[1]))
+                command = 'telnet %s %s' % (details[0], details[1])
 
         # working directory set in layout config
         if self.directory:


### PR DESCRIPTION
Fixes a problem that we discovered in #498, but not the entire issue.
For some reason, something related to debug makes Terminator crash. That might be another bug.

Apparently, the parameter order was messed up, and the `Restart the command` thing would work only when there is a custom command. With this patch it should work fine even if it's not selected.