### PR TITLE
Improve argument parser + implement bash completion

### DIFF
--- a/completion/bash
+++ b/completion/bash
@@ -6,7 +6,7 @@ _terminator()
     _init_completion || return
 
     COMPREPLY=($(compgen -W "$($1 --help | tr ',' '\n' |
-        command sed -n -e 's/ *\(--\?[a-zA-Z\-]\+=\?\).*/\1/p')"\
+        command sed -n -e 's/^ *\(--\?[a-zA-Z\-]\+=\?\).*/\1/p')"\
     -- "$cur"))
 } &&
     complete -F _terminator terminator

--- a/completion/bash
+++ b/completion/bash
@@ -1,0 +1,14 @@
+# bash completion for terminator                           -*- shell-script -*-
+
+_terminator()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    COMPREPLY=($(compgen -W "$($1 --help | tr ',' '\n' |
+        command sed -n -e 's/ *\(--\?[a-zA-Z\-]\+=\?\).*/\1/p')"\
+    -- "$cur"))
+} &&
+    complete -F _terminator terminator
+
+# ex: filetype=sh

--- a/completion/bash
+++ b/completion/bash
@@ -5,18 +5,7 @@ _terminator()
     local cur prev words cword
     _init_completion || return
 
-    case $prev in
-        --profile | -p)
-            COMPREPLY=($(compgen -W "$($1 --list-profiles)"\
-            -- "$cur"))
-            return
-            ;;
-        --layout | -l)
-            COMPREPLY=($(compgen -W "$($1 --list-layouts)"\
-            -- "$cur"))
-            return
-            ;;
-    esac
+    # TODO implement completion for --profile and --layout
 
     COMPREPLY=($(compgen -W "$($1 --help | tr ',' '\n' |
         command sed -n -e 's/^ *\(--\?[a-zA-Z\-]\+=\?\).*/\1/p')"\

--- a/completion/bash
+++ b/completion/bash
@@ -5,6 +5,19 @@ _terminator()
     local cur prev words cword
     _init_completion || return
 
+    case $prev in
+        --profile | -p)
+            COMPREPLY=($(compgen -W "$($1 --list-profiles)"\
+            -- "$cur"))
+            return
+            ;;
+        --layout | -l)
+            COMPREPLY=($(compgen -W "$($1 --list-layouts)"\
+            -- "$cur"))
+            return
+            ;;
+    esac
+
     COMPREPLY=($(compgen -W "$($1 --help | tr ',' '\n' |
         command sed -n -e 's/^ *\(--\?[a-zA-Z\-]\+=\?\).*/\1/p')"\
     -- "$cur"))

--- a/po/af.po
+++ b/po/af.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Afrikaans (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Veelvuldige terminale in een venster"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,47 +382,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "oortjie"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Sluit oortjie"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Vertoon program se weergawenommer"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Laat die venster die hele skerm vul"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Verwyder vensterrame"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Begin met verskuilde venster"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Verskaf 'n titel vir die venster"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Gee 'n opdrag om in die terminaal uit te voer"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -402,60 +430,68 @@ msgstr ""
 "Gebruik die res van die opdragreël om as opdrag, en sy argumente, in die "
 "terminaal uit te voer."
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Stel die werkgids"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Stel 'n aangepaste WM_WINDOW_ROLE eienskap op die venster"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Gebruik 'n ander profiel as die standaard"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Skakel DBus af"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Aktiveer ontfoutingsinformasie (twee maal vir ontfoutingsbediener)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Kommageskeide lys van klasse as ontfoutingslimiet"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Kommageskeide lys van metodes as ontfoutingslimiet"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -482,7 +518,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Voorkeure"
 
@@ -507,12 +543,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -618,7 +654,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Alle"
 
@@ -891,250 +927,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1142,80 +1146,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiele"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1229,18 +1261,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1473,82 +1505,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Voeg terminaalnommer in"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Voeg aangevulde terminaalnommer in"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Voeg terminaalnommer in"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Voeg aangevulde terminaalnommer in"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nuwe profiel"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nuwe uitleg"
 
@@ -1593,141 +1637,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Split H_orisontaal"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Split Vertikaal"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Nuwe _oortjie"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Open _ontfoutingsoortjie"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zoem in op terminaal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "He_rstel alle terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Groepering"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Vertoon rol_staaf"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Enkoderings"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Verstek"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Gebruikersgedefinieerd"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Ander enkoderings"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Verwyder groep %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_roepeer alle in dié oortjie"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Verwyder alle groepe"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Sluit groep %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Geen shell gevind nie"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Kan shell nie start nie"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1831,11 +1887,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "venster"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Oortjie %d"

--- a/po/ar.po
+++ b/po/ar.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Arabic (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -80,24 +92,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "المتطرف"
 
@@ -106,7 +134,7 @@ msgid "Multiple terminals in one window"
 msgstr "العديد من الطرفيات في نافذة واحدة"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -347,7 +375,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -355,106 +383,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "تبويب"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "إغلاق تبويب"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "إظهار اصدار البرنامج"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "ملء الشاشة بالكامل"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "تعطيل حدود النافذة"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "أخفاء النافذة عند بدء التشغيل"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "تحديد عنوان للإطار"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "اختر الحجم والموضع المرغوب به للنافذة (أنظر صفحة X man)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "حدد أمراً لتنفيذه في الطرفية"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr "استخدام ما تبقى من سطر الأوامر كأمر لتنفيذه في الطرفية ، ووسائطها"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "حدد ملف التهيئة"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "أضبط مسار العمل"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "اختر أيقونة مخصصة لهذه النافذة (بأسم أو ملف)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "تعيين خاصية مخصصة WM_WINDOW_ROLE على النافذة"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "استخدام سمات مختلفة كأفتراضي"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "تعطيل DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "تمكين معالجة المعلومات (مرتين لخادم المعالجة)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "قائمة الطبقات معزولة بفواصل للحد من التصحيح"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "قائمة الوسائل معزولة بفواصل للحد من التصحيح"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "إذا كان التيرمينيتور يعمل، فقط قم بفتح نافذة جديدة"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -481,7 +517,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_تفضيلات"
 
@@ -506,12 +542,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "أمر"
 
@@ -617,7 +653,7 @@ msgid "Escape sequence"
 msgstr "انهاء التسلسل"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "الجميع"
 
@@ -890,250 +926,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_الخط:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "شامل"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "الملف الشخصي"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_استخدم خط النظام ذو العرض الثابت"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_الخط:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "اختر خط الطرفية"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_اسمح بالنص العريض"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "أظهر شريط العنوان"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "أنسخ عند التحديد"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "اختيار باعتبار رموز ال_كلمات:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>المؤشر</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>جرس الطرفيّة</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "أيقونة شريط العنوان"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "وميض مرئي"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "رنّة مسموعة"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "نافذة القائمة الومضية"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "عامّ"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_شغل الأمر كمفتاح لتسجيل الدخول"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "_شغل أمراً مخصّصاُ عوضاً عن الأمر الهيكلي"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "ال_أمر المخصّص:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "عند _وجود الأمر:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>المقدمة و الخلفية</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "استخدم ألوان سمة النظام"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "المخططات م_ضمنة:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "لون النص:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_لون الخلفية:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>لوح الألوان</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "ال_مخططات المضمنة:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "_لوح الألوان:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "اﻷلوان"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "لون _جامد"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "خلفية _شفافة"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>لا شيء</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>الأقصى</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "الخلفية"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_شريط التمرير:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "لف عند ال_خرْج"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "لف عند _نقر مفتاح"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "رجوع العجلة للوراء بدون جد معين"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "ا_لف إلى الوراء:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "سطور"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "التمرير"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1145,80 +1149,108 @@ msgstr ""
 "الخيارات موجودة فقط لتجعلك تتخطّى عددا من التطبيقات و أنظمة التشغيل التي "
 "تتوقّع سلوكا مختلفا من الطرفيّة.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "_زر Backspace يولد:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "_زر DELETE يولد:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_أعد ضبط خيارات التوافق لقيمها الافتراضية"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "التوافق"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "ملفات المستخدمين"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "المخططات"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "ارتباطات المفاتيح"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "هذه الإضافة ليس لها خيارات ضبط"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "الإضافات"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1232,18 +1264,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1476,82 +1508,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "إدراج رقم منفذ"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "ادخال رقم الطرفية المضمن"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "إدراج رقم منفذ"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "ادخال رقم الطرفية المضمن"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "ملف شخصي جديد"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "مظهر جديد"
 
@@ -1596,141 +1640,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "اقسم أف_قيا"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "اقسم ع_موديا"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "افتح _لسان"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "فتح_لسان تصحيحي"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "ت_كبير الطرفية"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_استعادة جميع الطرفيّات"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "تجميع"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "إظهار_شريط تمرير"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "الترميزات"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "افتراضي"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "المستخدم معرّف"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "ترميزات اخرى"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "حذف المجموعة %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "تجمي_ع كل التبويبات"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "حذف كل المجموعات"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "إغلاق المجموعة %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "تعثر العثور على قشرة"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "لا يمكن تمكين الهيكل"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "أعد تسمية النافذة"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "ضع عنواناً جديداً لنافذة المنهي...."
 
@@ -1834,11 +1890,22 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "نافذة"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "تبويب %d"
+
+#~ msgid "_Text color:"
+#~ msgstr "لون النص:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_لون الخلفية:"

--- a/po/ast.po
+++ b/po/ast.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Asturian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Delles terminales nuna ventana"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,47 +382,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "llingüeta"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Zarrar llingüeta"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Amosar la versión del programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Facer que la ventana llene la pantalla"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Desactivar los bordes de la ventana"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Anubrir la ventana nel aniciu"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Conseñar un títulu pa la ventana"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Escoyer un comandu pa executar dientro del terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -402,61 +430,69 @@ msgstr ""
 "Usar el resto de la llinia de comandu como comandu a executar nel terminal, "
 "colos sos argumentos"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Conseñar el direutoriu de trabayu"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Conseñar una propiedá WM_WINDOW_ROLE personalizada na ventana"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Usar un perfil diferente como predetermináu"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Desactivar DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 "Activar la información de depuráu (dos veces pal sirvidor de depuración)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Llista separada por comes de clases a les que llendar la depuración"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Llista separada por comes de métodos a los que llendar la depuración"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -483,7 +519,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferencies"
 
@@ -508,12 +544,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -619,7 +655,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Too"
 
@@ -892,250 +928,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1143,80 +1147,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Perfiles"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1230,18 +1262,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1474,82 +1506,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Escribi'l númberu de terminal"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Escribi'l númberu de terminal separtáu"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Escribi'l númberu de terminal"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Escribi'l númberu de terminal separtáu"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Perfil nuevu"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Aspeutu nuevu"
 
@@ -1594,141 +1638,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Dividir n'h_orizontal"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Dividir en v_ertical"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Abrir llingüe_ta"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Abrir llingüeta de _depuración"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zoom del terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restaurar tolos terminales"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Agrupamientu"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Amosar barra de de_splazamientu"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Codificaciones"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Predetermináu"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definío pol usuariu"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Otres codificaciones"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Desaniciar el grupu %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Ag_rupar too en llingüeta"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Desaniciar tolos grupos"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Zarrar el grupu %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Nun se pue alcontrar una shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Nun se pue aniciar la shell:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1832,11 +1888,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "ventana"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "llingüeta %d"

--- a/po/az.po
+++ b/po/az.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Azerbaijani (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Çoxsaylı terminallar bir pəncərədə"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,47 +382,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "səkmə"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Səkməni Bağla"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Proqram versiyasını göstər."
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Bütün ekran boyu"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Pəncərənin sərhəddini ləğv etmək"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Başlanma zamanı pəncərəni gizlət"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Pəncərinin adı"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "terminalda icra əmrləri"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -402,60 +430,68 @@ msgstr ""
 "Qalıq əmrlər sətrinin terminalda əmr və onun arqumentləri kimi icra etmək "
 "üçün istifadəsi"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "İş qovluğunu təyin et"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Pəncərə üçün xüsusi bir piktoqram seçin (fayl və adı ilə)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Pəncərə üzrə özünəməxsus WM_WINDOW_ROLE xüsusiyyətini seçin"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "İlkin vəziyyət olaraq fərqli profil işlət"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "DBus-ı Söndür"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Əgər artıq Terminator işləyirsə sadəcə yeni pəncərə aç"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -482,7 +518,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -507,12 +543,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -618,7 +654,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -891,250 +927,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1142,80 +1146,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1229,18 +1261,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1473,82 +1505,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1593,141 +1637,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1831,11 +1887,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Belarusian (https://www.transifex.com/terminator/teams/109338/"
@@ -70,10 +70,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -81,24 +93,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Тэрмінатар"
 
@@ -107,7 +135,7 @@ msgid "Multiple terminals in one window"
 msgstr "Некалькі тэрміналаў у акне"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -348,7 +376,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -356,106 +384,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "табуляцыя"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Зачыніць укладку"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Паказаць версію праграмы"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Зрабіць акно на ўвесь экран"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Адключыць рамкі акна"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Скрыць акно пры загрузке"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Укажыце назву акна"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Задайце патрэбны памер і становішча акна (гл X man старонку)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Задаць каманду для выканання ў тэрмінале"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Задаць файл канфигу"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -482,7 +518,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -507,12 +543,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -618,7 +654,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -891,250 +927,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1142,80 +1146,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1229,18 +1261,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1473,82 +1505,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1593,141 +1637,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1831,11 +1887,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Bulgarian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Терминатор"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Множество терминали в един прозорец"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,112 +382,120 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "табулация"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Затваряне на подпрозореца"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Показване на програмната версия"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Изключване на рамката на прозореца"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Не показвай прозореца при стартиране"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Задаване на заглавие на прозореца"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Задаване на командата, която да бъде изпълнена в командния ред"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Задаване на конфигурационнен файл"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 "Задаване на работната папка на\n"
 "                                            терминала"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Задаване на икона по избор за прозореца (по файл или име)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Използване на друг профил по подразбиране"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 "Списък с класове разделен със запетайка за ограничаване на диагностичната "
 "информация"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 "Списък с методи разделен със запетайка за ограничаване на диагностичната "
 "информация"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -486,7 +522,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Настройки"
 
@@ -511,12 +547,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Команда"
 
@@ -622,7 +658,7 @@ msgid "Escape sequence"
 msgstr "Екранираща последователност"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Всичко"
 
@@ -895,250 +931,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Шрифт:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Общи"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Профил"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "Използване на _системния шрифт с фиксирана ширина на буквите"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Шрифт:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Избор на шрифт за терминала"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "Позволяване на полу_чер текст"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Показване на заглавната лента"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Копиране при избиране"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Показалец</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Икона на заглавната лента"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Общи"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Изпълнение на команда като обвивка при влизане"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Изпълнение на команда _вместо стандартната обвивка"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Потребителска _команда:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "_При приключване на командата:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Преден план и фон</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Използване на цветовете от системната тема"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "_Вградени схеми:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Цвят на _текста:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Цвят на фона:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Палитра</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Вградени _схеми:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "_Цветова палитра:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Цветове"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Плътен цвят"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Про_зрачен фон"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Минимална</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Максимална</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Фон"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Лентата за придвижване е:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Придвижване при _извеждане на текст"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Придвижване при _натискане на клавиш"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Безкрайно придвижване назад"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Придвижване _назад:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "редове"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Придвижване"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1150,80 +1154,108 @@ msgstr ""
 "Те са тук, само за да ви позволят да работите с някои програми и операционни "
 "системи, които очакват различно поведение на терминала.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "_Клавишът „Backspace“ генерира:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Клавишът „Delete“ _генерира:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Връщане настройките за съвместимост към стандартните"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Съвместимост"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Профили"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Подредби"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Клавишни комбинации"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Тази приставка няма опции за конфигуриране"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Приставки"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1237,18 +1269,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1481,82 +1513,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Нов потребителски профил"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Нова подредба"
 
@@ -1601,141 +1645,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Разделяне х_оризонално"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Раздели в_ертикално"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Отвори _подпрозорец"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Възстановяване на всички командни редове"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Групиране"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Показване на лентата за придвижване"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Кодова таблица"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "По подразбиране"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Потребителски"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Други кодирания"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Премахване на група %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Премахване на всички групи"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Затваряне на група %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Не е намерен Шел"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Неуспешно стартиране на обвивката на командния ред"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Преименуване на прозорец"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Въведете ново заглавие за прозореца на Terminator..."
 
@@ -1839,11 +1895,22 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "прозорец"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "_Text color:"
+#~ msgstr "Цвят на _текста:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Цвят на фона:"

--- a/po/bn.po
+++ b/po/bn.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Bengali (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "টার্মিনেটর"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "এক উইন্ডোতে একাধিক টার্মিনাল"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "ট্যাব"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "ট্যাব বন্ধ কর"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "প্রোগ্রাম ভার্সন দেখাও"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "উইন্ডোকে স্ক্রীণে ফিট করাও"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "উইন্ডো বর্ডার অকার্যকর কর"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "স্টার্টআপে উইন্ডো লুকিয়ে রাখ"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "উইন্ডোর জন্য একটি টাইটেল নির্দিষ্ট করুন"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "টার্মিনালের ভেতরে এক্সিকিউট করার জন্য কমান্ড নির্দিষ্ট করুন"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "ওয়ার্কিং ডাইরেক্টরী সেট করুন"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "এই উইন্ডোতে একটি কাস্টম WM_WINDOW_ROLE প্রপার্টি সেট করুন"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "ডিফল্ট হিসেবে একটি ভিন্ন প্রোফাইল ব্যবহার কর"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "DBus অকার্যকর কর"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "ডিবাগিং তথ্য কার্যকর কর (ডিবাগ সার্ভারের জন্য দ্বিগুণ)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "প_ছন্দসমূহ"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "সব"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "প্রোফাইলমসূহ"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "টার্মিনালের সংখ্যাটি লিখুন"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "টার্মিনালের সংখ্যাটি লিখুন"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "নতুন প্রোফাইল"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "নতুন লে-আউট"
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "সমান্তরালভাবে ভাগ কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "লম্বভাবে ভাগ কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "_ট্যাব খোল"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "ডিব্যাগ ট্যাব _ওপেন কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "টার্মিনাল _জুম কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "স_কল টার্মিনাল রিস্টোর কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "দলীয়করণ"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "স্ক্রলবার দেখাও"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "এনকোডিংসমূহ"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "ডিফল্ট"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "ব্যবহারকারী কর্তৃক নির্দিষ্ট"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "অন্যান্য এনকোডিং সমূহ"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "%s গ্রুপটি অপসারণ কর"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "ট্যাবে সবগুলো _গ্রুপ কর"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "সকল গ্রুপ অপসারণ কর"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "%s গ্রুপটি বন্ধ কর"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "উইন্ডো"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "%d ট্যাব"

--- a/po/bs.po
+++ b/po/bs.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Marko Dzidic <mdzidic@gmail.com>, 2020\n"
 "Language-Team: Bosnian (https://www.transifex.com/terminator/teams/109338/"
@@ -70,10 +70,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -84,7 +96,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -92,19 +104,35 @@ msgstr ""
 "* Ovi unosi zahtijevaju ili TERMINATOR_UUID varijablu okoline\n"
 "  ili upotrebu --uuid parametra."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 "Terminal UUID u slučaju kada ne postoji u env varijabli TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -113,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Više terminala u jednom prozoru"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Robotizirana budućnost terminala"
 
@@ -358,7 +386,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Terminatorov \"Aktivator rasporeda\""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Raspored"
 
@@ -366,107 +394,115 @@ msgstr "Raspored"
 msgid "Launch"
 msgstr "Pokreni"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Zatvori karticu"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Prikaži verziju programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maksimiziraj prozor"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Neka prozor ispuni ekran"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Onemogući rubove prozora"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Sakrij prozor pri pokretanju"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Navedi naslov prozora"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Postavi preferiranu veličinu i poziciju prozora(pogledaj X man stranicu)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Navedi komandu za izvršavanje u okviru terminala"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr "Koristi ostatak komandne linije za izvršavanje u okviru terminala"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Navedi konfiguracijsku datoteku"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Postavi radni direktorij"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Postavi prilagođenu ikonu prozora (po datoteci ili nazivu)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Postavi prilagođeno WM_WINDOW_ROLE svojstvo prozora"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Pokreni sa datim rasporedom"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Odaberi stavku rasporeda iz liste"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Koristi različit profil od zadanog"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Onemogući DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Omogući informacije o ispravljanju grešaka (duplo za server)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Lista klasa razdvojene zarezom koja ograničava ispravljanje grešaka"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Lista metoda razdvojene zarezom koja ograničava ispravljanje grešaka"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Ukoliko je Terminator već pokrenut samo otvori novu karticu"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -493,7 +529,7 @@ msgstr "Korisničke komande"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "Postavke"
 
@@ -518,12 +554,12 @@ msgid "Enabled"
 msgstr "Omogućeno"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Naziv"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Komanda"
 
@@ -629,7 +665,7 @@ msgid "Escape sequence"
 msgstr "Sekvenca izlaza"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Za sve"
 
@@ -902,250 +938,218 @@ msgid "Tabs scroll buttons"
 msgstr "Dugmad za pomjeranje kartica"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Terminal traka naslova</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Boja fonta:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Pozadina:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Fokusirano"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Neaktivno"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Primanje"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Sakrij veličinu u naslovu"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "Koristi sistemski font"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "Font:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Odabir fonta naslovne trake"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Globalno"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "Koristi sistemski font fiksne širine"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "Font:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Odabir fonta terminala"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "Dozvoli podebljani tekst"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Prikaži naslovnu traku"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Kopiraj pri selekciji"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Karakteri za izbor-po-riječima:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Kursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "Oblik:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Boja:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Treptanje"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Prednji plan"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Pozadina:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal signalizacija</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Ikona naslovne trake"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Treptanje"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Zvučni signal"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Treptanje liste prozora"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Općenito"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "Pokreni komandu kao shell za prijavu"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Pokreni korisničku komandu umjesto shell-a"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Korisnička komanda:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Kada komanda završi:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Prednji plan i pozadina</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "Koristi boje iz teme sistema"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Ugrađene sheme:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Boja teksta:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "Boja pozadine:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Ugrađene sheme:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Paleta boja:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr "Prikaži p_odebljani tekst na svijetlim bojama"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Boje"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "Neprozirno"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Prozirna pozadina"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ništa</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimalno</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Pozadina"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "Pomična traka je:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Pomiči pri ispisu"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Pomiči na pritisak tipke"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Beskonačno pomicanje"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Zadržavanje:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "linija"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Pomicanje"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1156,80 +1160,108 @@ msgstr ""
 "programima. Ovdje su samo kao prelazno rješenje za određene aplikacije i "
 "operativne sisteme u kojima se očekuje drugačiji rad terminala.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "<Backspace> tipka generiše:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "<Delete> tipka generiše:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Kodiranje:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "Vrati na zadane postavke kompatibilnosti"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Kompatibilnost"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Fokusirano"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Neaktivno"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Primanje"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Sakrij veličinu u naslovu"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "Koristi sistemski font"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Odabir fonta naslovne trake"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Tip"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Korisnička komanda:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Radni direktorij:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Rasporedi"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Akcija"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Kombinacija tastera"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Prečice na tastaturi"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Dodatak"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Ovaj dodatak nema konfiguracijske opcije"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Dodaci"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1253,18 +1285,18 @@ msgstr ""
 "korisnike. Ukoliko imate neki prijedlog, molimo Vas da popunite listu želja! "
 "(provjerite Razvoj na lijevoj strani)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Uputstvo"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "O programu"
 
@@ -1497,82 +1529,94 @@ msgid "Ungroup all terminals"
 msgstr "Razgrupiši sve terminale"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Grupiši terminale u kartici"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Grupiši/razgrupiši terminale u kartici"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Razgrupiši terminale u kartici"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Kreiraj novi prozor"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Izvrši umnožavanje novog Terminator procesa"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Forsiraj \"Bez emitovanja\""
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Forsiraj emitovanje na grupu"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Emituj prema svima"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Umetni broj terminala"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Umetni formatiran broj terminala"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Uredi naslov prozora"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Uredi naslov terminala"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Uredi naslov kartice"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Otvori prozor \"Aktivator rasporeda\""
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Prebaci na sljedeći profil"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Prebaci na prethodni profil"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Otvori uputstvo"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Novi profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Novi raspored"
 
@@ -1617,141 +1661,153 @@ msgstr "Kopiraj"
 msgid "_Paste"
 msgstr "Zalijepi"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Podijeli horizontalno"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Podijeli vertikalno"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Otvori karticu"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Otvori karticu \"Ispravljanje grešaka\""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "Zatvori"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "Zumiraj terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Maksimiziraj terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "Vrati sve terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Grupisanje"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Prikaži pomičnu traku"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kodiranja"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Zadano"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Korisnički definisano"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Ostala kodiranja"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "Nova grupa..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "Bez grupe"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Ukloni grupu %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Grupiši sve u kartici"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Razgrupiši sve u kartici"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Ukloni sve grupe"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Zatvori grupu %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Emitovanje svima"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Emitovanje grupi"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Emitovanje ugašeno"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "Podijeli na ovu grupu"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Automatsko čišćenje grupa"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "Dodaj broj terminala"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Dodaj formatiran broj terminala"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Lociranje Shell-a neuspješno"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Pokretanje Shell-a neuspješno:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Promijeni naslov prozora"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Unesite novi naslov za Terminator prozor..."
 
@@ -1855,11 +1911,34 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "prozor"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Terminal traka naslova</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Boja fonta:"
+
+#~ msgid "Color:"
+#~ msgstr "Boja:"
+
+#~ msgid "Foreground"
+#~ msgstr "Prednji plan"
+
+#~ msgid "_Text color:"
+#~ msgstr "Boja teksta:"
+
+#~ msgid "_Background color:"
+#~ msgstr "Boja pozadine:"

--- a/po/ca.po
+++ b/po/ca.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Catalan (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -91,20 +103,36 @@ msgstr ""
 "existeixi\n"
 "  o emprar l'opció --uuid"
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 "El UUID del terminal per quan aquesta informació no està a la variable "
 "d'entorn TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -113,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Diversos terminals en una finestra"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "El futur robot de terminals"
 
@@ -354,7 +382,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -362,49 +390,49 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "pestanya"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Tancar pestanya"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Mostra la versió del programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Fes que la finestra ocupi tota la pantalla"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Inhabilita les vores de la finestra"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Amaga la finestra a l'inici"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Especifica un títol per a la finestra"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Establir la mida i la posició preferides de la finestra(veure pàgina man de "
 "X)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Especifica una ordre a executar dins del terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -412,64 +440,72 @@ msgstr ""
 "Fes servir la resta de la línia d'ordres com a ordre a executar dins del "
 "terminal, i els seus arguments"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Especificar el fitxer de configuració"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Estableix el directori de treball"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 "Establir una icona personalitzada per la finestra(mitjançant un fitxer o nom)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Estableix una propietat WM_WINDOW_ROLE personalitzada a la finestra"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Utilitza un perfil diferent per defecte"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Inhabilia el DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 "Habilita la informació de depuració (dos vegades per al servidor de "
 "depuració)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Llista separada amb comes de les classes on es limita la depuració"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Llista separada amb comes dels mètodes on es limita la depuració"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 "Si el Terminator ja s'està executant, nomès has d'obrir una pestanya nova"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -496,7 +532,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferències"
 
@@ -521,12 +557,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Ordre"
 
@@ -632,7 +668,7 @@ msgid "Escape sequence"
 msgstr "Seqüència d'escapament"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Tot"
 
@@ -905,251 +941,219 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Tipus de lletra:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Utilitza el tipus de lletra d'amplada fixa del sistema"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Tipus de lletra:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Trieu un tipus de lletra de terminal"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Permet text en negreta"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Mostra la barra de títol"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Copiar en seleccionar"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Caràcters de _selecció per paraula:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Campana del Terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Icona de la barra de títol"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Ràfega visual"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Xiulet audible"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "General"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 "E_xecuta una ordre personalitzada en comptes del meu intèrpret d'ordres"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Or_dre personalitzada:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Quan l'ordre _surt:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Primer pla i fons</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Utilitza els colors del tema del sistema"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Esq_uemes integrats:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Color del _text:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "Color del _fons:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "_Esquemes integrats:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "_Paleta de colors:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Colors"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "Color _sòlid"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Fons _transparent"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Cap</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Màxim</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Fons"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "La _barra de desplaçament és:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Desplaçament en _mostrar"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Desplaçament en _prémer una tecla"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Desplaçament cap enrere infinit"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Desplaçament cap _enrere:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "línies"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Desplaçament"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1161,80 +1165,108 @@ msgstr ""
 "certes aplicacions i sistemes operatius que esperen un comportament diferent "
 "del terminal.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "La tecla de _retrocés genera:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "La tecla de _suprimir genera:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Reinicia les opcions de compatibilitat a les Opcions per Defecte"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Compatibilitat"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Perfils"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Plantilles"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Assignacions de tecles"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Aquest plugin no te opcions de configuració"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Connectors"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1248,18 +1280,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1492,82 +1524,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Insereix el número del terminal"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Insereix un número de terminal amb coixinet"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Insereix el número del terminal"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Insereix un número de terminal amb coixinet"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nou perfil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Disposició nova"
 
@@ -1612,141 +1656,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Divideix h_oritzontalment"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Divideix v_erticalment"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Obre una pes_tanya"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Obre una pestanya de _depuració"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "A_mplia el terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Recupera tots els terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Agrupament"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Mostra la barra de de_splaçament"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Codificacions"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Predeterminat"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definit per l'usuari"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Altres codificacions"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Suprimeix el grup %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "A_grupa-ho tot en la pestanya"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Suprimeix tots els grups"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Tanca el grup %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "No s'ha pogut trobar cap intèrpret d'ordres"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "No s'ha pogut iniciar l'intèrpret d'ordres:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Reanomenar finestra"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Introdueix un títol nou per a la finestra del Terminator"
 
@@ -1850,11 +1906,22 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "finestra"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Pestanya %d"
+
+#~ msgid "_Text color:"
+#~ msgstr "Color del _text:"
+
+#~ msgid "_Background color:"
+#~ msgstr "Color del _fons:"

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Catalan (Valencian) (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Diversos terminals en una finestra"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,47 +382,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "pestanya"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Tanca la pestanya"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Mostra la versió del programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Fes que la finestra ocupi tota la pantalla"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Inhabilita les vores de la finestra"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Amaga la finestra a l'inici"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Especifica un títol per a la finestra"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Especifica una orde a executar dins del terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -402,62 +430,70 @@ msgstr ""
 "Fes servir la resta de la línia d'ordes com a orde a executar dins del "
 "terminal, i els seus arguments"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Estableix el directori de treball"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Estableix una propietat WM_WINDOW_ROLE personalitzada a la finestra"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Utilitza un perfil diferent per defecte"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Inhabilia el DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 "Habilita la informació de depuració (dos vegades per al servidor de "
 "depuració)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Llista separada amb comes de les classes on es limita la depuració"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Llista separada amb comes dels mètodes on es limita la depuració"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -484,7 +520,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferències"
 
@@ -509,12 +545,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -620,7 +656,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Tot"
 
@@ -893,250 +929,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1144,80 +1148,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Perfils"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1231,18 +1263,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1475,82 +1507,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Insereix el número del terminal"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Insereix un número de terminal amb coixinet"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Insereix el número del terminal"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Insereix un número de terminal amb coixinet"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nou perfil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Disposició nova"
 
@@ -1595,141 +1639,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Divideix h_oritzontalment"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Divideix v_erticalment"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Obri una pes_tanya"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Obri una pestanya de _depuració"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "A_mplia el terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Recupera tots els terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Agrupament"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Mostra la barra de de_splaçament"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Codificacions"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Predeterminat"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definit per l'usuari"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Altres codificacions"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Suprimeix el grup %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "A_grupa-ho tot en la pestanya"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Suprimeix tots els grups"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Tanca el grup %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "No s'ha pogut trobar cap intèrpret d'ordes"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "No s'ha pogut iniciar l'intèrpret d'ordes:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1833,11 +1889,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "finestra"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Pestanya %d"

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Central Kurdish (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Czech (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -83,7 +95,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -91,20 +103,36 @@ msgstr ""
 "* Tyto položky vyžadují buď proměnnou prostředí TERMINATOR_UUID,\n"
 "  nebo použití volby --uuid."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 "Nikde se neopakující identifikátor (UUID) terminálu když není v proměnné "
 "prostředí TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminátor"
 
@@ -113,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Vícero terminálů v jednom okně"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Robotická budoucnost terminálů"
 
@@ -360,7 +388,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Spouštěč uspořádání v Terminátor"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Uspořádání"
 
@@ -368,49 +396,49 @@ msgstr "Uspořádání"
 msgid "Launch"
 msgstr "Spustit"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "panel"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Zavřít panel"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Zobrazit verzi aplikace"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximalizovat okno"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Vyplnit oknem obrazovku"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Zrušit ohraničení okna"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Skrýt okno při startu"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Zadat titulek okna"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Nastavit upřednostňovanou velikost a polohu okna (viz manuálová stránka "
 "zobrazovacího X serveru)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Zadat příkaz k provedení v terminálu"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -418,60 +446,68 @@ msgstr ""
 "Použít zbytek příkazového řádku jako příkaz a jeho argumenty k vykonání v "
 "terminálu"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Stanovit soubor s nastavením"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Nastavit pracovní složku"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Nastavit oknu uživatelskou ikonu (podle souboru nebo názvu)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Nastavit uživatelskou WM_WINDOW_ROLE vlastnost okna"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Spustit se zadaným uspořádáním"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Vybrat uspořádání ze seznamu"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Použít jiný profil jako výchozí"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Vypnout DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Povolit ladící informace (dvakrát pro ladící server)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Čárkou oddělovaný seznam tříd na které ladění omezit"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Čárkou oddělovaný seznam metod na které ladění omezit"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Pokud je Terminátor už spuštěný, jen otevřít nový panel"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -498,7 +534,7 @@ msgstr "_Uživatelské příkazy"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Vlastnosti"
 
@@ -523,12 +559,12 @@ msgid "Enabled"
 msgstr "Zapnuto"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Název"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Příkaz"
 
@@ -634,7 +670,7 @@ msgid "Escape sequence"
 msgstr "Escape sekvence"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Vše"
 
@@ -907,250 +943,218 @@ msgid "Tabs scroll buttons"
 msgstr "Tlačítka posuvníku panelů"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Titulek terminálu</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Barva písma:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Pozadí:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Zaměřeno"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Nečinné"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Přijímající"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Nezobrazovat v titulku velikost"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "Po_užít systémové písmo"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Písmo:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Zvolte písmo pro titulní lištu"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Společné"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "Po_užívat systémové písmo s pevnou šířkou"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Písmo:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Zvolte písmo terminálu"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "Povolit _tučný text"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Zobrazit pruh s titulkem"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Kopírovat při výběru"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Znaky pro výběr _slov:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Ukazatel</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Podoba:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Barva:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Blikat"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Popředí"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Pozadí:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Pípání terminálu</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Ikona pruhu s titulkem"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Problikávání"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Slyšitelné zvukové znamení"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Blikání seznamu oken"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Obecné"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Spustit příkaz jako přihlašovací shell"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "S_pustit vlastní příkaz místo mého shellu"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "_Uživatelský příkaz:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Po skonč_ení příkazu:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Popředí a pozadí</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "Po_užívat barvy systémového motivu"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Zabudovaná sché_mata:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Barva _textu:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Barva pozadí:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Zabudovaná _schémata:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "P_aleta barev:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Barvy"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Jednolitá barva"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Průhledné pozadí"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Žádný</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Největší</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Pozadí"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "Zobrazení po_suvníku:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "P_osouvat při výstupu"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Posouvat při stisku _klávesy"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Pamatovat si vše zpět"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "_Pamatovat si:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "řádků"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Posouvání"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1162,80 +1166,108 @@ msgstr ""
 "některé aplikace a operační systémy očekávají jiné chování terminálu.</i></"
 "small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Klávesa _Backspace vytváří:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Klávesa _Delete vytváří:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Kódování znaků:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "V_rátit nastavení kompatibility na výchozí"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Kompatibilita"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Zaměřeno"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Nečinné"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Přijímající"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Nezobrazovat v titulku velikost"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "Po_užít systémové písmo"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Zvolte písmo pro titulní lištu"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profily"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Typ"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Uživatelský příkaz:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Pracovní adresář:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Rozvržení"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Akce"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Klávesová zkratka"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Klávesové zkratky"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Zásuvný modul"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Tento zásuvný modul nemá žádné volby pro nastavení"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Zásuvné moduly"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1258,18 +1290,18 @@ msgstr ""
 "směrech o funkce užitečné pro správce systémů a další uživatele. Pokud máte "
 "nějaké návrhy, nahlaste nám je! (viz vlevo odkaz Vývoj)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Příručka"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "O aplikaci"
 
@@ -1502,82 +1534,94 @@ msgid "Ungroup all terminals"
 msgstr "Zrušit seskupení všech terminálů"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Seskupit terminály v panelu"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Seskupit / zrušit seskupení terminálů v panelu"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Zrušit seskupení terminálů v panelu"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Vytvořit nové okno"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Vytvořit nový proces Terminátor"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Nevysílat stisky kláves do více terminálů"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Vysílat stisky kláves do skupiny"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Vysílat stisky kláves všem"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Zadejte číslo terminálu"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Zadejte celé číslo terminálu"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Upravit titulek okna"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Upravit titulek terminálu"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Upravit titulek panelu"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Otevřít okno spuštěče rozvržení"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Přepnout na následující profil"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Přepnout na předchozí profil"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Otevřít příručku"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nový profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nové rozvržení"
 
@@ -1622,141 +1666,153 @@ msgstr "_Kopírovat"
 msgid "_Paste"
 msgstr "_Vložit"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Rozdělit v_odorovně"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Rozdělit svisl_e"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Otevří_t panel"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Otevřít panel la_dění"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Zavřít"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Změnit přiblížení terminálu"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximalizovat terminál"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "Obnovit všechny te_rminály"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Seskupování"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Zobrazit po_suvník"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kódování znaků"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Výchozí"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Uživatelem určené"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Ostatní kódování"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "_Nová skupina…"
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Nic"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Odstranit skupinu %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Seskupit všechny v panelech"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Zr_ušit seskupení v panelu"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Odstranit všechny skupiny"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Zavřít skupinu %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Vysíl_at vše"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "_Skupina pro vysílání"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Vysílání vypnut_o"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "Rozdělit do této _skupiny"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Automati_cky čistit skupiny"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "Zadejte číslo term_inálu"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Zadejte celé číslo terminálu"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Nedaří se najít shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Nedaří se spustit příkazový řádek:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Přejmenovat okno"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Zadejte nový název pro okno s Terminátor…"
 
@@ -1860,11 +1916,34 @@ msgstr "Psí"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "okno"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Panel %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Titulek terminálu</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Barva písma:"
+
+#~ msgid "Color:"
+#~ msgstr "Barva:"
+
+#~ msgid "Foreground"
+#~ msgstr "Popředí"
+
+#~ msgid "_Text color:"
+#~ msgstr "Barva _textu:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Barva pozadí:"

--- a/po/da.po
+++ b/po/da.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Danish (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -90,18 +102,34 @@ msgstr ""
 "* Disse indgange kræver enten 'TERMINATOR_UUID environment var',\n"
 "  eller '--uuid' tilvalget."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "Terminal UUID for når ikke i 'env var TERMINATOR_UUID'"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -110,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Flere terminaler i et vindue"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Fremtiden for robotterminaler"
 
@@ -351,7 +379,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Terminator Layout Launcher"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Udseende"
 
@@ -359,47 +387,47 @@ msgstr "Udseende"
 msgid "Launch"
 msgstr "Kør"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "faneblad"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Luk faneblad"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Vis program version"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maksimér vinduet"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Få vinduet til at fylde hele skærmen"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Deaktivér vindueskanter"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Skjul vinduet ved opstart"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Specificér en titel til vinduet"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Sæt den foretrukne størrelse og position af vinduet(se X man page)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Angiv en kommando som skal udføres inde i terminalen"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -407,60 +435,68 @@ msgstr ""
 "Brug resten af kommandolinien som en kommando til udførsel inde i "
 "terminalen, og dennes argumenter (/tilvalg)"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Angiv en konfigurationsfil"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Sæt terminalens arbejdsmappe"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Vælg et brugerdefineret ikon til vinduet (fra fil eller navn)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Vælg et brugerdefineret VM_WINDOW_ROLE egenskab på vinduet"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Kør med det givne layout"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Vælg et layout fra en liste"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Brug en anden profil som standard"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Deaktivér DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Aktivér fejlsøgningsinformation"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Kommasepareret liste over klasser at begrænse fejlsøgning til"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Kommasepareret liste over metoder at begrænse fejlsøgning til"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Hvis Terminator allerede er åben, blot åbn en ny fane"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -487,7 +523,7 @@ msgstr "_Brugertilpassede kommandoer"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Indstillinger"
 
@@ -512,12 +548,12 @@ msgid "Enabled"
 msgstr "Aktiveret"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Navn"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Kommando"
 
@@ -623,7 +659,7 @@ msgid "Escape sequence"
 msgstr "Undslip sekvens"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Alle"
 
@@ -896,250 +932,218 @@ msgid "Tabs scroll buttons"
 msgstr "Faneblads rulleknapper"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Teminal Titellinje</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Skriftfarve:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Baggrund:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Fokuseret"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Inaktiv"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Modtagene"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Skjul størrelse fra titel"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Brug systemskrittypen"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Skrifttype:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Vælg en titellinje skrifttype"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "Benyt _systemets fastbredde-skrifttype"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Skrifttype:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Vælg en terminalskrifttype"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Tillad fed tekst"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Vis titellinje"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Kopiér ved selektion"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "_Ordmarkeringstegn:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Markør</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Form"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Farve:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Blink"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Baggrund:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal klokke</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Titellinje ikon"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Visuelt blink"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Hørbart bip"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Vinduesliste blink"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Generelt"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Kør kommando som en logindskal"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Kør en brugerdefineret kommando i stedet for min kommandoskal"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Brugerdefineret kommando:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Når kommando _slutter:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Forgrund og baggrund</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Benyt farver fra systemtemaet"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Indbyggede skemaer:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Tekstfarve:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Baggrundsfarve:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Indbyggede _skemaer:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Farvep_alet:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Farver"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Ensfarvet"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Gennemsigtig baggrund"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ingen</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimal</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Baggrund"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Rullebjælken er:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Rul ned ved _uddata"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Rul ned ved _tastetryk"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Uendelig tilbagerulning"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Til_bagerulning:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "linjer"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Rulning"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1152,80 +1156,108 @@ msgstr ""
 "programmer og styresystemer, som forventer anderledes terminalopførsel.</i></"
 "small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "_Backspace-tast genererer:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "_Delete-tast genererer:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Nulstil kompatibilitetsindstillinger til standardværdier"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Fokuseret"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Inaktiv"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Modtagene"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Skjul størrelse fra titel"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Brug systemskrittypen"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Vælg en titellinje skrifttype"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiler"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Type"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Tilpasset kommando:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Arbejdsmappe:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Layouts"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Handling"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Genvejstast"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Genvejstaster"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Udvidelsesmodul"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Dette udvidelsesmodul har ingen konfigurationsmuligheder"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Udvidelsesmoduler"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1251,18 +1283,18 @@ msgstr ""
 "Hvis du har nogen forslag, så indgiv gerne ønskeliste fejl! (se til venstre "
 "for Udvikler link)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Manualen"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Om"
 
@@ -1495,82 +1527,94 @@ msgid "Ungroup all terminals"
 msgstr "Opdel alle terminaler"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Gruppér terminaler i faneblad"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Gruppér/opdel terminaler i faneblad"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Opdel terminaler i faneblad"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Opret et nyt vindue"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Skab ny Terminator proces"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Udsend ikke tastetryk"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Udsend tastetryk til gruppe"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Udsend tastetryk til alle"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Indsæt terminalnummer"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Indsæt forøget terminalnummer"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Redigér vinduestitel"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Redigér terminaltitel"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Redigér fanebladstitel"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Åbn layout kørselsvindue"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Skift til næste profil"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Skift til forrige profil"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Åbn manualen"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Ny profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nyt layout"
 
@@ -1615,141 +1659,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Del _Vandret"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Del _Lodret"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Åbn _Fane"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Åbn _Fejlsøgning Fane"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zoom terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Ma_ksimér terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Genskab alle terminaler"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Gruppering"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Vis _rullebjælke"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Tegnsæt"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Standard"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Brugerdefineret"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Andre Tegnsæt"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "N_y gruppe"
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Ingen"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Fjern gruppen %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_ruppér alle i fane"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Opde_l alle i faneblad"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Fjern alle grupper"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Luk gruppen %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Udsend _alle"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Udsend _gruppe"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Udsend _off"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "O_pdel til denne gruppe"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Autoop_ryd grupper"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Indsæt terminalnummer"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Indsæt forøget terminalnummer"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Kan ikke finde en kommandofortolker"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Kan ikke starte skal:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Omdøb vindue"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Indtast en ny titel for Terminator vinduet..."
 
@@ -1853,11 +1909,31 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "vindue"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Faneblad %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Teminal Titellinje</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Skriftfarve:"
+
+#~ msgid "Color:"
+#~ msgstr "Farve:"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Tekstfarve:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Baggrundsfarve:"

--- a/po/de.po
+++ b/po/de.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Markus Frosch <markus@lazyfrosch.de>, 2021\n"
 "Language-Team: German (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -83,7 +95,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -91,18 +103,34 @@ msgstr ""
 "* Diese Einträge benötigen entweder die TERMINATOR_UUID-Umgebungsvariable\n"
 "  oder die Option --uuid muss verwendet werden."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "Terminal UUID falls nicht in Umgebungsvariable TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -111,7 +139,7 @@ msgid "Multiple terminals in one window"
 msgstr "Mehrere Terminals in einem Fenster"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Die Roboterzukunft der Terminals"
 
@@ -368,7 +396,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Terminator-Anordnungsstarter"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Anordnung"
 
@@ -376,48 +404,48 @@ msgstr "Anordnung"
 msgid "Launch"
 msgstr "Starten"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "Reiter"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Reiter schließen"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Programmversion anzeigen"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Fenster maximieren"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Fenster im Vollbildmodus anzeigen"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Fensterrahmen ausschalten"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Fenster beim Start verbergen"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Titel für das Fenster festlegen"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Die bevorzugte Größe und Position des Fensters festlegen (siehe X man page)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Befehl festlegen, welcher im Terminal ausgeführt werden soll"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -425,66 +453,74 @@ msgstr ""
 "Den Rest der Befehlszeile als Befehl zusammen mit seinen Argumenten im "
 "Terminal ausführen"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Config-Datei festlegen"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr "Eine partielle json-config-Datei festlegen"
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Das Arbeitsverzeichnis festlegen"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 "Ein benutzerdefiniertes Symbol für das Fenster festlegen (über Datei oder "
 "Name)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Die Fenstereigenschaft WM_WINDOW_ROLE manuell festlegen"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Mit der gegebenen Anordnung starten"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Anordnung aus einer Liste auswählen"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Ein anderes Profil als Standard verwenden"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "D-Bus deaktivieren"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 "Debugging-informationen ausgeben (zweimal, um den Debugging-Server zu "
 "starten)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 "Komma separierte Liste von Klassen, auf die das Debugging beschränkt wird"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 "Komma getrennte Liste von Funktionen, auf die die Fehlersuche beschränkt wird"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Wenn Terminator bereits läuft, einen neuen Reiter öffnen"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -511,7 +547,7 @@ msgstr "_Benutzerdefinierte Befehle"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Einstellungen"
 
@@ -536,12 +572,12 @@ msgid "Enabled"
 msgstr "Aktiviert"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Name"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Befehl"
 
@@ -647,7 +683,7 @@ msgid "Escape sequence"
 msgstr "Escape-Sequenz"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Alle"
 
@@ -920,250 +956,218 @@ msgid "Tabs scroll buttons"
 msgstr "Reiterscrolltasten"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Terminal-Titelleiste</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Schriftfarbe:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Hintergrund:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Fokussiert"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Inaktiv"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Empfangen"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr "Titelleiste unten (Neustart erfordelich)"
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Größe im Titel verstecken"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Systemschriftart verwenden"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Schriftart:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Schriftart für die Titelleiste auswählen"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Systemschriftart mit fester Breite verwenden"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Schriftart:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Terminal-Schriftart auswählen"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Fettschrift erlauben"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Titelleiste anzeigen"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Bei Auswahl kopieren"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Strg+Mausrad-Zoom deaktivieren"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "_Zeichenfolgen auswählen:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Zeiger</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Form:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Farbe:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Blinken"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Vordergrund"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Hintergrund:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal-Glocke</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Titelleistensymbol"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Visuelles aufblitzen"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Akustisches Signal"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Fensterliste aufblitzen"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Allgemein"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Befehl in Login-Shell ausführen"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "_Benutzerdefinierten Befehl ausführen, anstatt meiner Shell"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "_Benutzerdefinierter Befehl:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "_Wenn der Befehl beendet wird:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Vorder- und Hintergrund</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Farben vom Systemthema verwenden"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "_Integrierte Schemata:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Textfarbe:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Hintergrundfarbe:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Farbpalette</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Integrierte _Schemata:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "_Farbpalette:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr "_Zeige Fettschrift in hellen Farben"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Farben"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Einfarbig"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Transparenter Hintergrund"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr "Datei wählen"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Keine</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximal</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Hintergrund"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Bildlaufleiste ist:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "_Bildlauf bei Ausgabe"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "_Bildlauf bei Tastendruck"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Unbegrenzter Verlauf"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "_Verlauf:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "Zeilen"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Bildlauf"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1175,80 +1179,108 @@ msgstr ""
 "Verfügung, um problematische Anwendungen oder Betriebssysteme zu umgehen, "
 "die ein anderes Terminal-Verhalten erwarten.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "_Rücktaste erzeugt:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "_Entfernen-Taste erzeugt:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Zeichensatz:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Kompatibilitätseinstellungen auf Standardwerte zurücksetzen"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Kompatibilität"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Fokussiert"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Inaktiv"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Empfangen"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Größe im Titel verstecken"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Systemschriftart verwenden"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Schriftart für die Titelleiste auswählen"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profile"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Art"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Benutzerdefinierter Befehl:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Arbeitsverzeichnis:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Anordnungen"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Aktion"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Tastenbelegung"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Tastenbelegungen"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Zusatzmodul"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Dieses Zusatzmodul hat keine Konfigurationsoptionen"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Zusatzmodule"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1267,11 +1299,11 @@ msgstr ""
 "Terminals in Gittern (Tabs sind die meist verbreitete Methode, die "
 "Terminator ebenfalls unterstützt."
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Das Handbuch"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
@@ -1281,7 +1313,7 @@ msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs/"
 "Verbesserungen</a>"
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Über"
 
@@ -1514,82 +1546,94 @@ msgid "Ungroup all terminals"
 msgstr "Alle Terminals trennen"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Terminals im Reiter gruppieren"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Terminals im Reiter gruppieren/trennen"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Terminals im Reiter trennen"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Neues Fenster erstellen"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Neuen Terminator-Prozess starten"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Tastenanschläge nicht senden"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Tastenanschläge an Gruppe senden"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Tastaturereignisse an alle senden"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Terminal-Nummer einfügen"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Terminal-Nummer einfügen (auffüllen)"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Fenstertitel bearbeiten"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Terminaltitel bearbeiten"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Reitertitel bearbeiten"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Anordnungsstarterfenster öffnen"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Zum nächsten Profil wechseln"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Zum vorherigen Profil wechseln"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr "Einstellungs-Fenster öffnen"
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Handbuch öffnen"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Neues Profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Neue Anordnung"
 
@@ -1634,141 +1678,153 @@ msgstr "_Kopieren"
 msgid "_Paste"
 msgstr "_Einfügen"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "_Horizontal teilen"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "_Vertikal teilen"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "_Reiter öffnen"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "_Debuggingreiter öffnen"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Schließen"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Terminal vergrößern"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "_Terminal maximieren"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Alle Terminals wiederherstellen"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Gruppierung"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "_Bildlaufleiste anzeigen"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr "_Anordnungen …"
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Zeichenkodierungen"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Standard"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Benutzerdefiniert"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Weitere Zeichenkodierungen"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "Neue Gruppe …"
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Keine"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Gruppe %s entfernen"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Alle im Reiter gruppieren"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Gruppe im Reiter auflösen"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Alle Gruppen entfernen"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Gruppe %s schließen"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "_Alles senden"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "_Gruppe senden"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "_Senden aus"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "_In diese Gruppe teilen"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Gruppen automatisch aufräumen"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Terminal-Nummer einfügen"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "_Terminal-Nummer einfügen (auffüllen)"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Es konnte keine Shell gefunden werden"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Shell kann nicht gestartet werden:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Fenster umbenennen"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Neuen Titel für das Terminator-Fenster eingeben …"
 
@@ -1872,14 +1928,37 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "Fenster"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Reiter %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Terminal-Titelleiste</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Schriftfarbe:"
+
+#~ msgid "Color:"
+#~ msgstr "Farbe:"
+
+#~ msgid "Foreground"
+#~ msgstr "Vordergrund"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Textfarbe:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Hintergrundfarbe:"
 
 #~ msgid "Version: 2.0.1"
 #~ msgstr "Version: 2.0.1"

--- a/po/el.po
+++ b/po/el.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Greek (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,24 +94,40 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -108,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Πολλαπλά τερματικά σε ένα παράθυρο"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -349,7 +377,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Διάταξη"
 
@@ -357,48 +385,48 @@ msgstr "Διάταξη"
 msgid "Launch"
 msgstr "Εκτέλεση"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "στηλοθέτης"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Κλείσιμο καρτέλας"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Προβολή έκδοσης προγράμματος"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Μεγιστοποίηση του παραθύρου"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Κάντε το παράθυρο γεμίζει την οθόνη"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Απενεργοποίηση ορίων παραθύρου"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Απόκρυψη παραθύρου στην εκκίνηση"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Ορισμός τίτλου για το παράθυρο"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Ορισμός προτιμώμενου μέγεθους και θέσης του παραθύρου (βλ. τη σελίδα X man)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Ορισμός εντολής προς εκτέλεση στο τερματικό"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -406,65 +434,73 @@ msgstr ""
 "Χρησιμοποιήστε το υπόλοιπο της γραμμής εντολών ως μία εντολή για εκτέλεση "
 "εντός του τερματικού σταθμού, καθώς και τα επιχειρήματά του"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Όρισμός του καταλόγου εργασίας"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Ορίστε μια προσαρμοσμένη WM_WINDOW_ROLE ιδιοκτησίας στο παράθυρο"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Επιλογή διάταξης από τη λίστα"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Χρήση ενός διαφορετικού προφίλ σαν προεπιλεγμένο"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Απενεργοποίηση DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 "Ενεργοποίηση πληροφοριών εντοπισμού σφαλμάτων (δύο φορές για αποσφαλμάτωσης "
 "διακομιστή)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 "Λίστα χωρισμένη με κόμμα από τους κλάδους να περιορίσουν τον εντοπισμό "
 "σφαλμάτων σε"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 "Διαχωρίζονται με κόμμα λίστα μεθόδους για τον περιορισμό αποσφαλμάτωσης να"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Εάν το Terminator εκτελείται ήδη, απλά ανοίξτε μια νέα καρτέλα"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -491,7 +527,7 @@ msgstr "Προσαρμοσμένες εντολές"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Προτιμήσεις"
 
@@ -516,12 +552,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Όνομα"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Εντολή"
 
@@ -627,7 +663,7 @@ msgid "Escape sequence"
 msgstr "Ακολουθία διαφυγής"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Όλα"
 
@@ -900,250 +936,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Χρώμα γραμματοσειράς:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Φόντο:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Γίνεται λήψη"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Γραμματοσειρά:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Προφίλ"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Χρήση της γραμματοσειράς σταθερού πλάτους του συστήματος"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Γραμματοσειρά:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Επιλογή γραμματοσειράς τερματικού"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Να επιτρέπεται η χρήση έντονου κειμένου"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Εμφάνιση μπάρας τίτλων"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Αντιγραφή στην επιλογή"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Δρομέας</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Σχήμα"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Χρώμα:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Φόντο:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Γενικά"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Προσκήνιο και παρασκήνιο</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Χρώμα _κειμένου:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Χρώμα παρασκηνίου:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Παλέτα</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Πα_λέτα χρωμάτων:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Χρώματα"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Συμπαγές χρώμα"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Διαφανές παρασκήνιο"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Φόντο"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1151,80 +1155,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Συμβατότητα"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Γίνεται λήψη"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Προφίλ"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Συνδυασμοί πλήκτρων"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Το πρόσθετο δεν έχει επιλογές παραμετροποίησης"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Πρόσθετα"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1238,18 +1270,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1482,82 +1514,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Εισάγετε τον αριθμό τερματικού"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Εισαγωγή επενδυμένη αριθμό τερματικού"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Εισάγετε τον αριθμό τερματικού"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Εισαγωγή επενδυμένη αριθμό τερματικού"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Νέο Προφίλ"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Νέα Διάταξη"
 
@@ -1602,141 +1646,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Ο_ριζόντιος  διαχωρισμός"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Κά_θετος διαχωρισμός"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Άνοιγμα _Καρτέλας"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Άνοιγμα καρτέλας αποσφαλμάτωσης"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Προσέγγιση τερματικού"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "Απο_κατάσταση όλων των τερματικών"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Ομαδοποίηση"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Εμφάνισε _την  μπάρα κύλισης"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Κωδικοποιήσεις"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Προκαθορισμένο"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Ορισμένο από τον χρήστη"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Άλλες Κωδικοποιήσεις"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Διαγραφή της ομάδας %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Ομάδα όλα στην καρτέλα"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Διαγραφή όλων των ομάδων"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Κλείσιμο της ομάδας %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Αδυναμία εξεύρεσης περιβάλλοντος"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Αδύνατη η εκκίνηση κελύφους:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Μετονομασία παραθύρου"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Πληκτρολόγηση νέου τίτλου για το παράθυρο του Terminator..."
 
@@ -1840,11 +1896,28 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "παράθυρο"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Καρτέλα %d"
+
+#~ msgid "Font color:"
+#~ msgstr "Χρώμα γραμματοσειράς:"
+
+#~ msgid "Color:"
+#~ msgstr "Χρώμα:"
+
+#~ msgid "_Text color:"
+#~ msgstr "Χρώμα _κειμένου:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Χρώμα παρασκηνίου:"

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: English (Australia) (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -90,18 +102,34 @@ msgstr ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "Terminal UUID for when not in env var TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -110,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Multiple terminals in one window"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "The robot future of terminals"
 
@@ -351,7 +379,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Terminator Layout Launcher"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Layout"
 
@@ -359,47 +387,47 @@ msgstr "Layout"
 msgid "Launch"
 msgstr "Launch"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Close Tab"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Display program version"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximize the window"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Make the window fill the screen"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Disable window borders"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Hide the window at startup"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Specify a title for the window"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Set the preferred size and position of the window(see X man page)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Specify a command to execute inside the terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -407,60 +435,68 @@ msgstr ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Specify a config file"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Set the working directory"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Set a custom icon for the window (by file or name)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Set a custom WM_WINDOW_ROLE property on the window"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Launch with the given layout"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Select a layout from a list"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Use a different profile as the default"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Disable DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Enable debugging information (twice for debug server)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Comma separated list of classes to limit debugging to"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Comma separated list of methods to limit debugging to"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "If Terminator is already running, just open a new tab"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -487,7 +523,7 @@ msgstr "_Custom Commands"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferences"
 
@@ -512,12 +548,12 @@ msgid "Enabled"
 msgstr "Enabled"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Name"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Command"
 
@@ -623,7 +659,7 @@ msgid "Escape sequence"
 msgstr "Escape sequence"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "All"
 
@@ -896,250 +932,218 @@ msgid "Tabs scroll buttons"
 msgstr "Tabs scroll buttons"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Terminal Titlebar</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Focused"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Receiving"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1147,80 +1151,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Focused"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Receiving"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiles"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1234,18 +1266,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1478,82 +1510,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Insert terminal number"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Insert padded terminal number"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Insert terminal number"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Insert padded terminal number"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "New Profile"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "New Layout"
 
@@ -1598,141 +1642,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Split H_orizontally"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Split V_ertically"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Open _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Open _Debug Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zoom terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restore all terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Grouping"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Show _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Encodings"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Default"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "User defined"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Other Encodings"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Remove group %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_roup all in tab"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Remove all groups"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Close group %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Unable to find a shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Unable to start shell:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1836,11 +1892,19 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "window"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Terminal Titlebar</b>"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: English (Canada) (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Multiple terminals in one window"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,47 +382,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Close Tab"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Display program version"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Make the window fill the screen"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Disable window borders"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Hide the window at startup"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Specify a title for the window"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Specify a command to execute inside the terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -402,60 +430,68 @@ msgstr ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Set the working directory"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Set a custom WM_WINDOW_ROLE property on the window"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Use a different profile as the default"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Disable DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Enable debugging information (twice for debug server)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Comma separated list of classes to limit debugging to"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Comma separated list of methods to limit debugging to"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -482,7 +518,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferences"
 
@@ -507,12 +543,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -618,7 +654,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "All"
 
@@ -891,250 +927,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1142,80 +1146,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiles"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1229,18 +1261,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1473,82 +1505,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Insert terminal number"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Insert padded terminal number"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Insert terminal number"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Insert padded terminal number"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "New Profile"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "New Layout"
 
@@ -1593,141 +1637,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Split H_orizontally"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Split V_ertically"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Open _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Open _Debug Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zoom terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restore all terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Grouping"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Show _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Encodings"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Default"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "User defined"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Other Encodings"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Remove group %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_roup all in tab"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Remove all groups"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Close group %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Unable to find a shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Unable to start shell:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1831,11 +1887,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "window"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -90,18 +102,34 @@ msgstr ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "Terminal UUID for when not in env var TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -110,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Multiple terminals in one window"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "The robot future of terminals"
 
@@ -355,7 +383,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Terminator Layout Launcher"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Layout"
 
@@ -363,47 +391,47 @@ msgstr "Layout"
 msgid "Launch"
 msgstr "Launch"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Close Tab"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Display program version"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximise the window"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Make the window fill the screen"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Disable window borders"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Hide the window at startup"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Specify a title for the window"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Set the preferred size and position of the window(see X man page)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Specify a command to execute inside the terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -411,60 +439,68 @@ msgstr ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Specify a config file"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Set the working directory"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Set a custom icon for the window (by file or name)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Set a custom WM_WINDOW_ROLE property on the window"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Launch with the given layout"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Select a layout from a list"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Use a different profile as the default"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Disable DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Enable debugging information (twice for debug server)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Comma separated list of classes to limit debugging to"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Comma separated list of methods to limit debugging to"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "If Terminator is already running, just open a new tab"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -491,7 +527,7 @@ msgstr "_Custom Commands"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferences"
 
@@ -516,12 +552,12 @@ msgid "Enabled"
 msgstr "Enabled"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Name"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Command"
 
@@ -627,7 +663,7 @@ msgid "Escape sequence"
 msgstr "Escape sequence"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "All"
 
@@ -900,250 +936,218 @@ msgid "Tabs scroll buttons"
 msgstr "Tabs scroll buttons"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Terminal Titlebar</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Font colour:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Background:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Focused"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Inactive"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Receiving"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Hide size from title"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Use the system font"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Font:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Choose A Titlebar Font"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profile"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Use the system fixed width font"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Font:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Choose A Terminal Font"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Allow bold text"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Show titlebar"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Copy on selection"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Select-by-_word characters:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Shape:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Colour:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Blink"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Background:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal bell</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Titlebar icon"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Visual flash"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Audible beep"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Window list flash"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "General"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Run command as a login shell"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Ru_n a custom command instead of my shell"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Custom co_mmand:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "When command _exits:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Foreground and Background</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Use colours from system theme"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Built-in sche_mes:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Text colour:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Background colour:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Palette</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Built-in _schemes:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Colour p_alette:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Colours"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Solid colour"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Transparent background"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>None</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Background"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Scrollbar is:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Scroll on _output"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Scroll on _keystroke"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Infinite Scrollback"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Scroll_back:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "lines"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Scrolling"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1155,80 +1159,108 @@ msgstr ""
 "applications and operating systems that expect different terminal behaviour."
 "</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "_Backspace key generates:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "_Delete key generates:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Encoding:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Reset Compatibility Options to Defaults"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Compatibility"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Focused"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Inactive"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Receiving"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Hide size from title"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Use the system font"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Choose A Titlebar Font"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiles"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Type"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profile:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Custom command:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Working directory:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Layouts"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Action"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Keybinding"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Keybindings"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "This plug-in has no configuration options"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1252,18 +1284,18 @@ msgstr ""
 "users. If you have any suggestions, please file wishlist bugs! (see left for "
 "the Development link)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "The Manual"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "About"
 
@@ -1496,82 +1528,94 @@ msgid "Ungroup all terminals"
 msgstr "Ungroup all terminals"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Group terminals in tab"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Group/Ungroup terminals in tab"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Ungroup terminals in tab"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Create a new window"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Spawn a new Terminator process"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Don't broadcast key presses"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Broadcast key presses to group"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Broadcast key events to all"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Insert terminal number"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Insert padded terminal number"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Edit window title"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Edit terminal title"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Edit tab title"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Open layout launcher window"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Switch to next profile"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Switch to previous profile"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Open the manual"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "New Profile"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "New Layout"
 
@@ -1616,141 +1660,153 @@ msgstr "_Copy"
 msgid "_Paste"
 msgstr "_Paste"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Split H_orizontally"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Split V_ertically"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Open _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Open _Debug Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Close"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zoom terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximise terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restore all terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Grouping"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Show _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Encodings"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Default"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "User defined"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Other Encodings"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "N_ew group..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_None"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Remove group %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_roup all in tab"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Ungro_up all in tab"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Remove all groups"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Close group %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Broadcast _all"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Broadcast _group"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Broadcast _off"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "_Split to this group"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Auto_clean groups"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Insert terminal number"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Insert _padded terminal number"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Unable to find a shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Unable to start shell:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Rename Window"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Enter a new title for the Terminator window..."
 
@@ -1854,11 +1910,34 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "window"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Terminal Titlebar</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Font colour:"
+
+#~ msgid "Color:"
+#~ msgstr "Colour:"
+
+#~ msgid "Foreground"
+#~ msgstr "Foreground"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Text colour:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Background colour:"

--- a/po/eo.po
+++ b/po/eo.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Esperanto (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminatoro"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Pluraj terminaloj en unu fenestro"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "langeto"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Fermi langeton"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Montri version de programaro"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Specifi titolon por la fenestro"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Specifi komandon plenumontan ene de la terminalo"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Malŝalti DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Se Terminatoro jam estas funkcianta, nur malfermi novan langeton"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Agordoj"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Komando"
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Ĉiuj"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Tiparo:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Tiparo:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Elektu tiparon de la terminalo"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Permesi dikan tekston"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Kursoro</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Ĝenerala"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Propra ko_mando:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Kiam komando _ekzistas:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Malfono kaj Fono</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Uzi kolorojn de la sistema etoso"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Tekstkoloro:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Fonkoloro:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Koloraro</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Kolorp_aletro:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Koloroj"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Travidebla fono"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Neniu</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimuma</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Fono"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "linioj"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "_Retropaŝoklavo generas:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "_Forigklavo generas:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Kongrueco"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiloj"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Ĉi tiu kromprogramo ne havas agordajn opciojn"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Kromprogramoj"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nova profilo"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Dividi _Horizontale"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Dividi _Vertikale"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Malfermu _Langeton"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Pligrandigi terminalon"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Grupado"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kodoprezentoj"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Agordita de la uzanto"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Alia kodoprezentoj"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Forigi grupon %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_rupigi ĉiujn en langeto"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Forigi ĉiujn grupojn"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Fermi grupon %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Ne troveblas terminalon"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Ne startigeblas la terminalon"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Renomi fenestron"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Enigu novan titolon por la Terminatora fenestro"
 
@@ -1829,11 +1885,22 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "fenestro"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Langeto %d"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Tekstkoloro:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Fonkoloro:"

--- a/po/es.po
+++ b/po/es.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Pedro Flor <pedro.flor@gmail.com>, 2021\n"
 "Language-Team: Spanish (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -83,7 +95,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -92,20 +104,36 @@ msgstr ""
 "exista\n"
 "  o que la opción --uuid sea empleada"
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 "La UUID del terminal para cuando esta información no está en la variable de "
 "entorno TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -114,7 +142,7 @@ msgid "Multiple terminals in one window"
 msgstr "Múltiples terminales en una ventana"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "El futuro robot de terminales"
 
@@ -371,7 +399,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Lanzador de Disposición de Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Diseño"
 
@@ -379,48 +407,48 @@ msgstr "Diseño"
 msgid "Launch"
 msgstr "Lanzar"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "pestaña"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Mostrar la versión del programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximizar ventana"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Ajustar la ventana para que llene la pantalla"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Desactivar los bordes de la ventana"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Ocultar la ventana al inicio"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Especificar un título para la ventana"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Establecer tamaño y posición preferidas para la ventana (ver el manual de X)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Especificar un comando a ejecutar dentro del terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -428,65 +456,73 @@ msgstr ""
 "Usar el resto de la línea de órdenes como una orden y los argumentos "
 "necesarios para ejecutarse dentro de la terminal"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Especificar un archivo de configuración"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr "Especificar un archivo configuración parcial json"
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Establecer el directorio de trabajo"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 "Establecer un icono personalizado para la ventana (por archivo o nombre)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Establecer una propiedad WM_WINDOW_ROLE personalizada en la ventana"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Lanza con el siguiente diseño"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Seleccionar un diseño de una lista"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Usar un perfil diferente como predeterminado"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Desactivar DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 "Activar información de depuración (el doble para servidor de depuración)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Lista separada por comas de clases a la limitar la depuración"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Lista separada por comas de métodos para delimitar su depuración"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Si Terminator se está ejecutando, abrir una nueva pestaña"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
 msgstr ""
 "Si Terminator ya está ejecutándose, sólo tienes que desbloquear todas las "
 "ventanas ocultas"
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
+msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
 msgid "Watch for _activity"
@@ -512,7 +548,7 @@ msgstr "_Comandos Personalizados"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferencias"
 
@@ -537,12 +573,12 @@ msgid "Enabled"
 msgstr "Activado"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Nombre"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Comando"
 
@@ -648,7 +684,7 @@ msgid "Escape sequence"
 msgstr "Secuencia de escape"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Todo"
 
@@ -921,250 +957,218 @@ msgid "Tabs scroll buttons"
 msgstr "Botones para cambiar de pestañas"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Barra titulo Terminal</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Color de letra:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Fondo:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Enfocado"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Inactivo"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Recibiendo"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr "Barra de título en la parte inferior (Requiere reinicio)"
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "No mostrar el tamaño en el título"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Usar fuente del sistema"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Tipografía:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Elija tipo de letra para la Barra de Titulo"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Perfil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Usar la tipografía de ancho fijo del sistema"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Tipografía:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Elija una tipografía de terminal"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Permitir texto resaltado"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Mostrar barra de título"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Copia de la selección"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Deshabilitar Ctrl + zoom de la rueda del ratón"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Selección de caracteres por _palabra:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "Forma (_Shape):"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Color:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Parpadeo"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "primer término"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Fondo:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Campana del terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Icono de la barra de título"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Destello visual"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Pitido audible"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Destello lista de ventana"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "General"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Ejecutar el comando como un intérprete de conexión"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Ejec_utar un comando personalizado en vez de mi intérprete"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Co_mando personalizado:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Cuando la orden  _termina:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Frente y Fondo</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Usar colores del tema del sistema"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Esque_mas incluidos:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Color del _texto:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Color de fondo:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Esquemas_incluidos:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "P_aleta de colores:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr "Mostrar texto b_old en colores brillantes"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Colores"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "Color _sólido"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Fondo _transparente"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr "Imagen de Fondo"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr "Archivo de Imagen de fondo:"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr "Elegir archivo"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr "S_hade de fondo:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ninguno</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Máximo</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Fondo de pantalla"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "La _barra de desplazamiento está:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Desplazar en la _salida"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Desplazar al pulsar _teclas"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Desplazamiento infinito"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "_Desplazar hacia atrás:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "líneas"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Desplazamiento"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1176,81 +1180,109 @@ msgstr ""
 "ciertas aplicaciones y sistemas operativos que esperan un comportamiento "
 "diferente del terminal.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "La tecla «_Retroceso» genera:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "La tecla «_Suprimir» genera:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Codificación:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 "_Reiniciar las opciones de compatibilidad a los valores predeterminados"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Compatibilidad"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Enfocado"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Inactivo"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Recibiendo"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "No mostrar el tamaño en el título"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Usar fuente del sistema"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Elija tipo de letra para la Barra de Titulo"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Perfiles"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Tipo"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Perfil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Comando personalizado:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Carpeta de trabajo:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Diseños"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Acción"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Combinación de teclas"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Asociaciones de teclas"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Complementos"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Este plugin no tiene opciones de configuración"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1276,11 +1308,11 @@ msgstr ""
 "por favor repórtalas en nuestro archivo de lista de deseos y de errores (ver "
 "a la izquierda para el enlace de Desarrollo)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "EL Manual"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
@@ -1290,7 +1322,7 @@ msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs/"
 "Mejoras</a>"
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Acerca de"
 
@@ -1523,82 +1555,94 @@ msgid "Ungroup all terminals"
 msgstr "Desagrupar todos los terminales"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Agrupar terminales en pestaña"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Agrupar/Desagrupar terminales en pestaña"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Desagrupar terminales en pestaña"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Crea una ventana nueva"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Lanzar un nuevo proceso de Terminator"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "No difundir las teclas presionadas"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Difundir las teclas presionadas al grupo"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Difundir las teclas presionadas a todos"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Insertar número de terminal"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Insertar número de terminal separado del margen"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Editar titulo de ventana"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Editar título del terminal"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Editar título de la pestaña"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Abrir ventana de lanzador de disposición"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Cambiar al siguiente perfil"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Cambiar a perfil previo"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr "Abrir la ventana de Preferencias"
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Abrir el manual"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Perfil nuevo"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nuevo Diseño"
 
@@ -1643,141 +1687,153 @@ msgstr "_Copiar"
 msgid "_Paste"
 msgstr "_Pegar"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Dividir h_orizontalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Dividir v_erticalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Abrir Pes_taña"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Abrir Pestaña de _Depuración"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Cerrar"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Agrandar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Maximizar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restaurar todas las terminales"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Agrupamiento"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr "Volver a ejecutar comando"
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Mostrar barra de de_splazamiento"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr "_Diseños..."
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Codificaciones"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Predeterminado"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definido por el usuario"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Otras codificaciones"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "Nu_evo grupo..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Ninguno"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Eliminar grupo %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Ag_rupar todos en una solapa"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Desagr_upar todo en pestaña"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Eliminar todos los grupos"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Cerrar grupo %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Difundir todo (_all)"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Difundir al _grupo"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Difusión desactivada (_off)"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "Dividir en éste grupo (_Split)"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Autolimpiar grupos (_clean)"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Insertar número de terminal"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Insertar número de terminal de relleno (_padded)"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Imposible encontrar una terminal"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Imposible arrancar la terminal:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Renombrar ventana"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Introduzca un nuevo título para la ventana de Terminator..."
 
@@ -1881,14 +1937,37 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "ventana"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Solapa %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Barra titulo Terminal</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Color de letra:"
+
+#~ msgid "Color:"
+#~ msgstr "Color:"
+
+#~ msgid "Foreground"
+#~ msgstr "primer término"
+
+#~ msgid "_Text color:"
+#~ msgstr "Color del _texto:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Color de fondo:"
 
 #~ msgid "Version: 2.0.1"
 #~ msgstr "Versión: 2.0.1"

--- a/po/et.po
+++ b/po/et.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Estonian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Mitu terminaali ühes aknas"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tabulaator"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Saki sulgemine"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Näita programmi versiooni"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Täida ekraan aknaga"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Keela akna ääred"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Peida aken käivitamisel"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Täpne pealkiri terminalile"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Täpne käsklus et käivitada terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr "Kasuta ülejäänud käsurida ja argumente et käivitada  käsk terminalis"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Töökataloogi määramine"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Sea kohandatud WM_WINDOW_ROLE omadus aknale"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Kasuta teist profiili tavalise sättena"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Keela DBUS"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Luba veaanalüüsi informatsioon  (mitmekordne veaanalüüsi serveril )"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Koma eraldab nimekirja klassidest veaanalüüsi limiidi"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Koma edaldab nimekirjast veaanalüüsi limiidi meetod"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Eelistused"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Kõik"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiilid"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Sisesta terminali number"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Sisesta terminali number"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Uus profiil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Uus kujundus"
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Poolita H_orisontaalselt"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Poolita V_ertikaalselt"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Ava vaheleht"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Ava veaanalüüsi vaheleht"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Suurenda terminaali"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Taasta kõik terminalid"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Rühmitamine"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Näita _kerimisriba"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kodeeringud"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Vaikimisi"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Kasutaja määratav"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Muud kodeeringud"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Eemalda %s grupp"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_rupeeri kõik vahelehed"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Eemalda kõik gruppid"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Sulge %s grupp"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Ei leitud shell-i"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Ei suudetud käivitada shell-i"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "aken"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Vaheleht %d"

--- a/po/eu.po
+++ b/po/eu.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Hainbat terminal leiho bakarrean"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,47 +382,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "fitxa"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Itxi fitxa"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Bistaratu programaren bertsioa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Behartu leihoa pantaila betetzera"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Desgaitu leihoaren ertzak"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Ezkutatu leihoa abiaraztean"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Zehaztu leihoaren izenburua"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Ezarri hobetsitako leihoaren tamaina eta kokapena (ikusi X man orria)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Zehaztu terminal barruan exekutatzeko komando bat"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -402,62 +430,70 @@ msgstr ""
 "Erabili komando-lerroaren gainerakoa terminal barruan exekutatzeko komando "
 "bat bezala, bere argumentuekin"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Zehaztu konfigurazio-fitxategi bat"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Ezarri laneko direktorioa"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 "Ezarri leihoarentzako ikono pertsonalizatu bat (fitxategi edo izenaren "
 "arabera)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Ezarri WM_WINDOW_ROLE propietate pertsonalizatua leihoan"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Erabili beste profil bat lehenetsi bezala"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Desgaitu DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Gaitu arazketa informazioa (bi aldiz arazketa zerbitzariarentzat)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Komaz banandutako klase zerrenda arazketa mugatzeko"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Komaz banandutako metodoen zerrenda arazketa mugatzeko"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Terminator dagoeneko martxan badago, ireki fitxa berri bat"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -484,7 +520,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Hobespenak"
 
@@ -509,12 +545,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Komandoa"
 
@@ -620,7 +656,7 @@ msgid "Escape sequence"
 msgstr "Ihes-sekuentzia"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Guztiak"
 
@@ -893,250 +929,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Letra-tipoa:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Globala"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profila"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Erabili sistemaren zabalera finkoko letra-tipoa"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Letra-tipoa:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Aukeratu terminalaren letra-tipoa"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Onartu testu lodia"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Erakutsi izenburu-barra"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Kopiatu hautatzean"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "_Hitz gisa hautatzeko karaktereak:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Kurtsorea</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal kanpaia</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Izenburu-barraren ikonoa"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Distira bisuala"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Txistu entzungarria"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Leiho zerrenda distira"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Orokorra"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Exekutatu komandoa saioa hasteko shell gisa"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "E_xekutatu komando pertsonalizatua shell-aren ordez"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Ko_mando pertsonalizatua:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Ko_mandoak amaitzen duenean:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Aurreko eta atzeko planoa</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "Erabili _sistemaren gaiaren koloreak"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "_Eskema inkorporatuak:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Testuaren kolorea:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Atzeko planoaren kolorea:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Eskema _inkorporatuak:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Kolore-_paleta:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Koloreak"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Kolore solidoa"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Atzeko plano _gardena"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Bat ere ez</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximoa</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Atzeko planoa"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Korritze-barraren posizioa:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Korritu _irteeran"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Korritu _tekla sakatutakoan"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Atzera korritze infinitua"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "_Atzera korritu:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "lerro"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Korritzea"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1148,80 +1152,108 @@ msgstr ""
 "aplikazio eta sistema eragilerekin lan egin ahal izateko bakarrik eskaintzen "
 "dira.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "'_Atzera-tekla' sakatutakoan:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "'_Ezabatu' tekla sakatutakoan:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Berrezarri bateragarritasun-aukerak lehenetsietara"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Bateragarritasuna"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profilak"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Diseinuak"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Laster-teklak"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Plugin honek ez dauka konfigurazioko aukerarik"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Pluginak"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1235,18 +1267,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1479,82 +1511,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Idatzi terminal zenbakia"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Idatzi marjinatik aldendutako terminalaren zenbakia"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Idatzi terminal zenbakia"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Idatzi marjinatik aldendutako terminalaren zenbakia"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Profil berria"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Diseinu berria"
 
@@ -1599,141 +1643,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Zatitu _horizontalki"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Zatitu _bertikalki"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Ireki _fitxa"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Ireki _arazketa fitxa"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Egin zoom terminalean"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Leheneratu terminal guztiak"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Taldekatzea"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Erakutsi _korritze-barra"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kodeketak"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Lehenetsia"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Erabiltzaileak definitua"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Beste kodeketak"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Ezabatu taldea %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "_Taldekatu guztiak fitxa batean"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Kendu talde guztiak"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Itxi taldea %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Ezin izan da shell-ik topatu"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Ezin izan da shell-ik abiarazi:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Berrizendatu leihoa"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Sartu Terminator leihoaren izenburu berria..."
 
@@ -1837,11 +1893,22 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "leihoa"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Fitxa %d"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Testuaren kolorea:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Atzeko planoaren kolorea:"

--- a/po/fa.po
+++ b/po/fa.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Persian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "پایانه ای uuid برای  زمانی TERMINATOR_UUID در محیط متغییر باشد"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "ترمیناتور"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "ربات اینده ای پایانه است"
 
@@ -347,7 +375,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -355,106 +383,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "جهش"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "بستن زبانه"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "نمایش نگارش برنامه"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "مخفی نمودن پنجره در Startup"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "تعیین عنوان برای پنجره"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "پوشه‌ی کاری را تنظیم کنید"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "استفاده از پروفایلی دیگر به عنوان پیش‌فرض"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "غیرفعال سازی DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -481,7 +517,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_ترجیحات"
 
@@ -506,12 +542,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -617,7 +653,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "همگی"
 
@@ -890,250 +926,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1141,80 +1145,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1228,18 +1260,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1472,82 +1504,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
-msgstr "پایانه در زبانه گروه / اخراج شده از گروه"
+msgid "Group/Ungroup terminals in window"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
-msgstr "اخراج شده از گروه پایانه ها در زبانه"
+msgid "Ungroup terminals in window"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
+msgid "Group/Ungroup terminals in tab"
+msgstr "پایانه در زبانه گروه / اخراج شده از گروه"
+
+#: ../terminatorlib/prefseditor.py:169
+msgid "Ungroup terminals in tab"
+msgstr "اخراج شده از گروه پایانه ها در زبانه"
+
+#: ../terminatorlib/prefseditor.py:170
+msgid "Create a new window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "ایجاده پردازش های جدیدپاینه"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "کلید فشار را تکرار نکن"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "کلید فشار را در گروه تکرار نکن"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "رویدادهای کلیدی را برای همه پخش کن"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "درج شماره پایانه"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "درح عدد خالی در پایانه"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "ویرایش پنجره عنوان"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "ویرایش عنوان پایانه"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "ویرایش عنوان زبانه"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "بازکردن طرح پنجره ای اجرا شده"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "سوئیچ به پروفایل بعدی"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "سوئیچ به پروفایل قبلی"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "تنظیمات جدید"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "طرح بندی جدید"
 
@@ -1592,141 +1636,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "تقسیم به صورت افـــــقی"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "تقسیم به صورت عمودــــــي"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "بازکردن ـ زبانه"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "بازکردن - زبانه ای رفع اشکال"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "ـ بزرگــنمایه پایانه"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "بـــه حداکثــر رساندن پایانه"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_ بازگرداندن همه ای پایانه ها"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "نمایش-نوارسکرول"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "کدگذاری‌ها"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "پیش‌فرض"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "تعریف‌شده توسط کاربر"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "ج-دید گروه....."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "حذف گروه %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "گ-روه همه در زبانه"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "اخراج از گروه همه در زبانه"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "حذف تمامی گروه‌ها"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "بستن گروه %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "پخش-همه"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "پخش-گروه"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "پخش-خاموش"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "ـتقسیم این گروه"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "خودکار-گروها تمیزکن"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "ـ درج عدد به پایانه"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "درج-عدد خالی در پایانه"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "پیدا کردن پوسته شکست خورد"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "اجرای پوسته شکست خورد"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "تغییرنام پنجره"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "یک نام جدید برای پنجره پایانه ( Terminator) وارد کنید"
 
@@ -1830,11 +1886,16 @@ msgstr "پی اس ای"
 msgid "Omega"
 msgstr "اومگا"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "پنجره"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "زبانه %d"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Finnish (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Useita päätteitä yhdessä ikkunassa"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,47 +382,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "sarkain"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Sulje välilehti"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Näytä ohjelman versio"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Tee ikkuna näytön kokoiseksi"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Poista ikkuna rajojen"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Piilota ikkuna käynnistettäessä"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Määritä otsikon ikkuna"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Määritä terminaalissa suoritettava komento"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -402,62 +430,70 @@ msgstr ""
 "Käytä loput komentoriviä komento suorittaa sisälle terminaaliin ja sen "
 "perustelut"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Aseta työkansio"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Aseta mukautettu WM_WINDOW_ROLE kiinteistön ikkuna"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Käytä eri profiilin oletukseksi"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Poista DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Ota debuggaustietoja (kahdesti debug-palvelin)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Pilkuilla eroteltu luettelo luokkien raja virheenkorjauksen ja"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 "Pilkuilla eroteltu luettelo menetelmistä, joilla rajoitetaan virheenkorjaus "
 "ja"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -484,7 +520,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Asetukset"
 
@@ -509,12 +545,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -620,7 +656,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Kaikki"
 
@@ -893,250 +929,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1144,80 +1148,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiilit"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1231,18 +1263,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1475,82 +1507,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Syötä päätteen numero"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Lisää sisennetty pääte numero"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Syötä päätteen numero"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Lisää sisennetty pääte numero"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Uusi profiili"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Uusi pohja"
 
@@ -1595,141 +1639,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Jaa _Vaakasuunnassa"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Jaa _Pystysuunnassa"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Avaa _välilehti"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Avaa _Vianjäljitysvälilehti"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Kasvata pääte-näkymää"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Palauta kaikki päätteet"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Ryhmittely"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Näytä _vierityspalkki"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Merkistöt"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Oletus"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Käyttäjän määrittelemä"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Muut merkistöt"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Poista ryhmä %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "R_yhmitä kaikki välilehdessä"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Poista kaikki ryhmät"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Sulje ryhmä %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Komentotulkkia ei löydy"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Komentotulkkia ei voitu käynnistää:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1833,11 +1889,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "ikkuna"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Välilehti %d"

--- a/po/fo.po
+++ b/po/fo.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Faroese (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Lat teigin aftur"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Vís forritsútgáva"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Ógilda Dbus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Stillingar"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Alt"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nýggj uppsetan"
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Vís _skrulliteig"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Strika bólkin %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Lat bólkin %s aftur"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Teigur %d"

--- a/po/fr.po
+++ b/po/fr.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Samuël Weber/GwendalD <samuel.weber@normalesup.org>, 2020\n"
 "Language-Team: French (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -83,7 +95,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -91,20 +103,36 @@ msgstr ""
 "* Ces entrées requièrent soit la variable d'environnement TERMINATOR_UUID,\n"
 "  soit l'option --uuid doit être utilisée."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 "Terminal UUID utilisée lorsqu'il n'est pas dans la variable d'environnement "
 "TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -113,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Permet d'avoir plusieurs terminaux en une seule fenêtre"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Le futur robot des terminaux."
 
@@ -371,7 +399,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Lanceur de dispositions de Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Disposition"
 
@@ -379,47 +407,47 @@ msgstr "Disposition"
 msgid "Launch"
 msgstr "Lancer"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "onglet"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Fermer l'onglet"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Afficher la version du programme"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximiser la fenêtre"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Mettre la fenêtre en plein écran"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Désactiver les bordures de fenêtre"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Masquer la fenêtre au démarrage"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Spécifier un titre pour la fenêtre"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Définir la taille et la position de la fenêtre (voir X man page)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Spécifier une commande à exécuter dans le terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -427,63 +455,71 @@ msgstr ""
 "Utiliser le reste de la ligne de commande en tant que commande à exécuter "
 "dans le terminal (avec ses arguments)"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Spécifier un fichier de configuration"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr "Spécifier un fichier json de configuration partiel"
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Définir le répertoire de travail"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Définir une icône personnalisée pour la fenêtre (par nom ou fichier)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Définir une propriété WM_WINDOW_ROLE à la fenêtre"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Lancer avec la disposition donnée"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Sélectionner une disposition depuis une liste"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Utiliser un autre profil en tant que valeur par défaut"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Désactiver DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 "Activer l'information de débogage (deux fois pour le serveur de débogage)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 "Liste de classes auxquelles limiter le débogage (séparées par des virgules)"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 "Liste de méthodes auxquelles limiter le débogage (séparées par des virgules)"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Si Terminator est déjà lancé, ouvrir seulement un nouvel onglet"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -510,7 +546,7 @@ msgstr "_Commandes personnalisées"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Préférences"
 
@@ -535,12 +571,12 @@ msgid "Enabled"
 msgstr "Activées"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Nom"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Commande"
 
@@ -646,7 +682,7 @@ msgid "Escape sequence"
 msgstr "Séquence d'échappement"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Tous"
 
@@ -919,250 +955,218 @@ msgid "Tabs scroll buttons"
 msgstr "Ascenseur des onglets"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Barre de titre du terminal</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Couleur de la police de caractères :"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Arrière-plan :"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Actif"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Inactif"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Réception"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr "Barre de titre en bas (nécessite un redémarrage)"
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Masquer la taille du titre"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Utiliser la police de caractères système"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Police de caractères :"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Choisissez une police de caractères pour la barre de titre"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Utiliser la police à chasse fixe du système"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Police de caractères :"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Choisir la police de caractères du terminal"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Activer le texte en gras"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Afficher la barre de titre"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Copier la sélection"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Désactiver le zoom Ctrl+roulette"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Sélectionner par caractères des _mots"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Curseur</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Forme :"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Couleur :"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Clignotement"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Premier plan"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Arrière-plan :"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Bip du terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Icône de la barre de titre"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Flash visuel"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Bip sonore"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Liste de fenêtres instantanée"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Général"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Lancer la commande en tant que shell de connexion"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Exécuter une comma_nde personnalisée au lieu de mon shell"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Co_mmande personnalisée :"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Quand la commande se _termine :"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Premier et arrière plans</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Utiliser les couleurs du thème système"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "_Palettes prédéfinies :"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Couleur du _texte :"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Couleur d'arrière-plan :"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Palette</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Pa_lettes prédéfinies :"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "P_alette de couleurs :"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr "Afficher les textes en gras en couleurs vives"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Couleurs"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "Couleur _unie"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Arrière-plan _transparent"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr "Choisir un fichier"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Aucun</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Arrière-plan"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "La _barre de défilement est :"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Défilement sur la _sortie"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Défilement sur _pression d'une touche"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Défilement infini"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Défilement récursif :"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "lignes"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Défilement"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1174,80 +1178,108 @@ msgstr ""
 "fonctionner certaines applications et systèmes d'exploitation qui attendent "
 "un comportement du terminal différent.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "La touche « _Retour arrière » émet :"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "La touche « _Suppr » émet :"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Codage des caractères :"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Réinitialiser les options de compatibilité aux valeurs par défaut"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Compatibilité"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Actif"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Inactif"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Réception"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Masquer la taille du titre"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Utiliser la police de caractères système"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Choisissez une police de caractères pour la barre de titre"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profils"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Type"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil :"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Commande personnalisée :"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Dossier de travail :"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Dispositions"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Action"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Raccourci clavier"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Raccourcis clavier"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Greffon"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Ce greffon n'a pas d'options de configuration"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Greffons"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1273,11 +1305,11 @@ msgstr ""
 "vous avez des suggestions, merci de remplir un bug de souhait! (regardez a "
 "gauche pour le lien de développement)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Le manuel"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
@@ -1288,7 +1320,7 @@ msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Améliorations</a>"
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "À propos"
 
@@ -1521,82 +1553,94 @@ msgid "Ungroup all terminals"
 msgstr "Dégrouper tous les terminaux"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Grouper les terminaux dans un onglet"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Grouper/dégrouper les terminaux dans un onglet"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Dégrouper les terminaux de l'onglet"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Créer une nouvelle fenêtre"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Démarrer un nouveau processus Terminator"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Ne pas diffuser les appuis de touche"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Diffuser les appuis de touche au groupe"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Diffuser les évènements de touche à tous"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Insérer le numéro du terminal"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Insérer le numéro du terminal, avec des zéros"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Modifier le titre de la fenêtre"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Modifier le titre du terminal"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Modifier le titre de l'onglet"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Ouvrir la fenêtre du lanceur de diposition"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Basculer sur le profil suivant"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Basculer sur le profil précédent"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr "Ouvrir les préférences"
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Ouvrir le manuel"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nouveau profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nouvel agencement"
 
@@ -1641,141 +1685,153 @@ msgstr "Co_pier"
 msgid "_Paste"
 msgstr "C_oller"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Diviser h_orizontalement"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Diviser v_erticalement"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Ouvrir un ongle_t"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Ouvrir un onglet de _débogage"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Quitter"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zoomer le terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximiser le terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restaurer tous les terminaux"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Regroupement"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Afficher la barre de défilement"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr "_Organisations..."
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Codages"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Valeur par défaut"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Défini par l'utilisateur"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Autres  codages"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "Nouv_eau groupe..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "Aucu_n"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Supprimer le groupe %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Tout reg_rouper dans l'onglet"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Tout dégro_uper dans un onglet"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Supprimer tout les groupes"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Fermer le groupe %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Diffuser _tout"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Diffuser au _groupe"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Diffusion désactivée"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "_Scinder vers ce groupe"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Netto_yer automatiquement les groupes"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Insérer le numéro du terminal"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Insérer le _numéro du terminal"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Impossible de trouver un shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Impossible de démarrer le shell :"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Renommer la fenêtre"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Saisir un nouveau titre pour la fenêtre Terminator..."
 
@@ -1879,14 +1935,37 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Oméga"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "fenêtre"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Onglet %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Barre de titre du terminal</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Couleur de la police de caractères :"
+
+#~ msgid "Color:"
+#~ msgstr "Couleur :"
+
+#~ msgid "Foreground"
+#~ msgstr "Premier plan"
+
+#~ msgid "_Text color:"
+#~ msgstr "Couleur du _texte :"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Couleur d'arrière-plan :"
 
 #~ msgid "Version: 2.0.1"
 #~ msgstr "Version : 2.0.1"

--- a/po/fy.po
+++ b/po/fy.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Western Frisian (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "H_orizontaal splitse"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "V_ertikaal splitse"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Irish (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -80,24 +92,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -106,7 +134,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -347,7 +375,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -355,106 +383,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -481,7 +517,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -506,12 +542,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -617,7 +653,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -890,250 +926,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1141,80 +1145,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1228,18 +1260,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1472,82 +1504,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1592,141 +1636,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1830,11 +1886,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Galician (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminador"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Múltiples terminales nunha ventá"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,47 +382,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "lapela"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Pechar lapela"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Mostrar a versión do programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Axustar a xanela á pantalla"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Desactivar contornos das xanelas"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Ocultar a xanela ao iniciar"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Especificar un título para a xanela"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Especificar un comando a executar dentro do terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -402,60 +430,68 @@ msgstr ""
 "Utilizar o resto da liña de comandos e os seus argumentos como o comando a "
 "executar no terminal"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Especifique un ficheiro de configuración"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Definir o directorio de traballo"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Estableza un icono personalizado para o diálogo (por ficheiro ou nome)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Definir unha propiedade WM_WINDOW_ROLE personalizada na xanela"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Empregar como patrón un perfil diferente"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Deshabilitar DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Activar información de depuración (duas veces para o servidor)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Clases separadas por vírgulas para limitar a depuración a"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Métodos separados por vírgulas para limitar a depuración a"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Se Terminator xa está en execución, pode abrir un novo separador"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -482,7 +518,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferencias"
 
@@ -507,12 +543,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -618,7 +654,7 @@ msgid "Escape sequence"
 msgstr "Secuencia de escape"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Todo"
 
@@ -891,250 +927,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1142,80 +1146,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Perfís"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1229,18 +1261,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1473,82 +1505,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Insesrtar número de terminal"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Instertar número de terminal separado da marxe"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Insesrtar número de terminal"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Instertar número de terminal separado da marxe"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Novo perfil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nova capa"
 
@@ -1593,141 +1637,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Dividir H_orizontalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Dividir V_erticalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Abrir _lapela"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Abrir lapela de _depuración"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Dar zoom o terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restaurar todos os terminais"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Agrupamento"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Amosar _barra de desprazamento"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Codificacións"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Predefinido"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definida polo usuario"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Outras codificacións"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Grupo %s borrado"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "A_grupar nunha lapela"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Borrar todos os grupos"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Pechar grupo %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Incapaz de atopar unha consola"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Incapaz de arrincar a consola:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1831,11 +1887,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "xanela"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Lapela %d"

--- a/po/he.po
+++ b/po/he.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>, 2020\n"
 "Language-Team: Hebrew (https://www.transifex.com/terminator/teams/109338/"
@@ -70,10 +70,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -84,7 +96,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -92,19 +104,35 @@ msgstr ""
 "* רשומות אלו דורשות שימוש במשתנה הסביבה TERMINATOR_UUID,\n"
 "  או באפשרות ‎--uuid."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 "מזהה ייחודי של מסוף (UUID) כאשר לא משתמשים במשתנה הסביבה TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -113,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "מסופים מרובים בחלון אחד"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "העתיד הרובוטי של המסופים"
 
@@ -361,7 +389,7 @@ msgid "Terminator Layout Launcher"
 msgstr "משגר פריסת Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "פריסה"
 
@@ -369,107 +397,115 @@ msgstr "פריסה"
 msgid "Launch"
 msgstr "הפעלה"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "לשונית"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "סגירת לשוניות"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "הצגת גרסת התכנית"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "הגדלת החלון לגמרי"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "מילוי המסך בחלון הזה"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "השבתת גבולות החלון"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "הסתרת החלון בהפעלה"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "נא לציין כותרת לחלון"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "הגדרת הגודל והמיקום המועדפים של החלון (בעמוד ה־man של X)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "ציון פקודה להרצה במסוף"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 "אפשר להשתמש בשאר שורת הפקודה כהנחייה להפעלת פקודה בתוך המסוף עם המשתנים שלה"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "ציון קובץ ההגדרות"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr "ציון קובץ json הגדרות חלקי"
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "הגדרת תיקיית העבודה"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "הגדרת סמל מותאם לחלון (לפי קובץ או שם)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "הגדרת מאפיין WM_CLASS מותאם בחלון"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "הפעלה עם הפריסה שסופקה"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "בחירת פריסה מהרשימה"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "להשתמש בפרופיל אחר כבררת המחדל"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "השבתת DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "הפעלת פרטי ניפוי שגיאות (פעמיים לשרת ניפוי שגיאות)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "רשימה מופרדת בפסיקים של מחלקות שאליהן להגביל את ניפוי השגיאות"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "רשימה מופרדת בפסיקים של שיטות שאליהן להגביל את ניפוי השגיאות"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "אם Terminator כבר מופעל, פשוט לפתוח עוד לשונית"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -496,7 +532,7 @@ msgstr "_פקודות מותאמות אישית"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "ה_עדפות"
 
@@ -521,12 +557,12 @@ msgid "Enabled"
 msgstr "מופעל"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "שם"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "פקודה"
 
@@ -632,7 +668,7 @@ msgid "Escape sequence"
 msgstr "רצף סליקה"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "הכול"
 
@@ -905,250 +941,218 @@ msgid "Tabs scroll buttons"
 msgstr "כפתורי גלילת לשוניות"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>שורת הכותרת של המסוף</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "צבע גופן:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "רקע:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "ממוקד"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "בלתי פעיל"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "מקבל"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr "פס כותרת בתחתית (דורש הפעלה מחדש)"
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "הסתרת הגודל מהכותרת"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "להשתמש בגופן המ_ערכת"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_גופן:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "בחירת גופן לשורת הכותרת"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "גלובלי"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "פרופיל"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "להשתמש בגופן ברוחב ה_אחיד של המערכת"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_גופן:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "נא לבחור גופן למסוף"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "ל_אפשר גופן מודגש"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "הצגת שורת כותרת"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "העתקה בעת הבחירה"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "השבתת Ctrl+גלגלת עכבר לתקריב"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "תווים לבחירה ל_פי מילה:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>סמן</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_צורה:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "צבע:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "הבהוב"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "חזית"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "רקע:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>פעמון מסוף</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "סמל בשורת הכותרת"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "הבזק חזותי"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "צפצוף"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "הבזק ברשימת החלונות"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "כללי"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "ה_רצת פקודה כמעטפת כניסה"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "ה_רצת פקודה מותאמת אישית במקום המעטפת שלי"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "_פקודה מותאמת אישית:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "כאשר הפקודה מ_סתיימת:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>חזית ורקע</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "להשתמש ב_צבעים מערכת העיצוב של המערכת"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "_סכמות מובנות:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "צבע ה_טקסט:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "צבע ה_רקע:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>ערכת צבעים</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "_סכמות מובנות:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "_ערכות צבעים:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr "הצגת טקסט מו_דגש בצבעים בהירים"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "צבעים"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "צבע _אחיד"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "רקע _שקוף"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr "בחירת קובץ"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>ללא</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>הכי הרבה</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "רקע"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "פס ה_גלילה מופיע:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "גלילה עם _פלט"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "גלילה עם ה_קלדה"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "היסטוריית מסוף אינסופית"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "היס_טוריית מסוף:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "שורות"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "גלילה"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1159,80 +1163,108 @@ msgstr ""
 "להתנהג באופן חריג.  הן כאן רק כדי לאפשר לך לעקוף כל מיני יישומים ומערות "
 "הפעלה שמצפים להתנהגות שונה ממסוף.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "מק_ש Backspace מייצר:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "מ_קש Delete מייצר:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "קידוד:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_איפוס אפשרויות התאימות לבררות המחדל"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "תאימות"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "ממוקד"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "בלתי פעיל"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "מקבל"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "הסתרת הגודל מהכותרת"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "להשתמש בגופן המ_ערכת"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "בחירת גופן לשורת הכותרת"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "פרופילים"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "סוג"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "פרופיל:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "פקודה בהתאמה אישית:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "תיקיית עבודה:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "פריסות"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "פעולה"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "צירוף מקשים"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "צירופי מקשים"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "תוסף"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "לתוסף זה אין אפשרויות להגדרה"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "תוספים"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1254,11 +1286,11 @@ msgstr ""
 "עבור מנהלי מערכת ומשתמשים אחרים. אם יש לך הצעות, נא להגיש תקלה לרשימת "
 "המשאלות! (בקישור לפיתוח משמאל) "
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "המדריך"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
@@ -1268,7 +1300,7 @@ msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">תקלות / "
 "שיפורים</a>"
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "על אודות"
 
@@ -1501,82 +1533,94 @@ msgid "Ungroup all terminals"
 msgstr "פירוק כל המסופים"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "קיבוץ המסופים ללשונית"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "קיבוץ/פירוק המסופים בלשונית"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "פירוק המסופים בלשונית"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "יצירת חלון חדש"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "הפעלת תהליך Terminator חדש"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "לא לשדר לחיצות מקשים"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "שידור לחיצות מקשים לקבוצה"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "שידור אירועי מקשים לכולם"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "הוספת מספר מסוף"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "הוספת מספר מסוף מרופד"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "עריכת כותרת החלון"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "עריכת כותרת המסוף"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "עריכת כותרת הלשונית"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "פתיחת חלון משגר פריסה"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "מעבר לפרופיל הבא"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "מעבר לפרופיל הקודם"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr "פתיחה בחלון ההעדפות"
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "פתיחת המדריך"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "פרופיל חדש"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "פריסה חדשה"
 
@@ -1621,141 +1665,153 @@ msgstr "ה_עתקה"
 msgid "_Paste"
 msgstr "ה_דבקה"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "פיצול או_פקית"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "פיצול א_נכית"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "פתיחת _לשונית"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "פתיחת לשונית _ניפוי שגיאות"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_סגירה"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "התק_רבות למסוף"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "ה_גדלת מסוף"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_שחזור כל המסופים"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "קיבוץ"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "הצגת _פס גלילה"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr "_פריסות…"
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "קידודים"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "בררת מחדל"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "בהגדרת המשתמש"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "קידודים אחרים"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "קבוצה _חדשה…"
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_ללא"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "הסרת הקבוצה %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "_קיבוץ הכול בלשונית"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "_פירוק כל מי שבלשונית"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "הסרת כל הקבוצות"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "סגירת הקבוצה %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "לשדר ל_כולם"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "_קבוצת שידור"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "_כיבוי השידור"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "_פיצול הקבוצה הזו"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "ל_נקות קבוצות אוטומטית"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "הו_ספת מספר מסוף"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "הוספת מספר מסוף מרופ_ד"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "לא ניתן למצוא מעטפת"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "לא ניתן להפעיל מעטפת:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "שינוי שם חלון"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "נא להקליד כותרת חדשה לחלון ה־Terminator…"
 
@@ -1859,14 +1915,37 @@ msgstr "פסי"
 msgid "Omega"
 msgstr "אומגה"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "חלון"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "לשונית %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>שורת הכותרת של המסוף</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "צבע גופן:"
+
+#~ msgid "Color:"
+#~ msgstr "צבע:"
+
+#~ msgid "Foreground"
+#~ msgstr "חזית"
+
+#~ msgid "_Text color:"
+#~ msgstr "צבע ה_טקסט:"
+
+#~ msgid "_Background color:"
+#~ msgstr "צבע ה_רקע:"
 
 #~ msgid "Version: 2.0.1"
 #~ msgstr "גרסה: 2.0.1"

--- a/po/hi.po
+++ b/po/hi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Hindi (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "टर्मिनेटर"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "एक विंडो में अनेक  टर्मिनल"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "टर्मिनल सँख्यां डालें"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "टर्मिनल सँख्यां डालें"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/hr.po
+++ b/po/hr.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Markus Frosch <markus@lazyfrosch.de>, 2021\n"
 "Language-Team: Croatian (https://www.transifex.com/terminator/teams/109338/"
@@ -71,10 +71,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -85,7 +97,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -93,18 +105,34 @@ msgstr ""
 "* Ovi unosi zahtijevaju TERMINATOR_UUID varijablu okruženja,\n"
 "  ili se mora koristiti --uuid."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "UUID terminala, kad nije u TERMINATOR_UUID varijabli okruženja"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -113,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Višebrojni terminali u jednom prozoru"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Robotska budućnost terminala"
 
@@ -366,7 +394,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Pokretanje rasporeda Terminatora"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Raspored"
 
@@ -374,48 +402,48 @@ msgstr "Raspored"
 msgid "Launch"
 msgstr "Pokreni"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "kartica"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Zatvori karticu"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Prikaži verziju programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Rastvori prozor"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Rastvori prozor na veličinu ekrana"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Deaktiviraj rubove prozora"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Sakrij prozor pri pokretanju"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Odredi naslov prozora"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Postavi željenu veličinu i položaj prozora (pogledaj X stranicu priručnika)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Odredi naredbu za izvršavanje unutar terminala"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -423,60 +451,68 @@ msgstr ""
 "Koristi ostatak naredbenog retka kao naredbu za izvršavanje unutar terminala "
 "i njezine argumente"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Odredi datoteku konfiguracije"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr "Odredi djelomičnu json-datoteku konfiguracije"
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Postavi radnu mapu"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Postavi prilagođenu ikonu za prozor (prema datoteci ili nazivu)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Postavi prilagođeno WM_WINDOW_ROLE svojstvo na prozor"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Pokreni sa zadanim rasporedom"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Odaberi jedan raspored iz popisa"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Koristi jedan drugi profil kao standardni"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Deaktiviraj DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Aktiviraj informacije ispravljanja grešaka (dvaput za poslužitelja)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Zarezom odvojen popis klasa za ograničavanje uklanjanja grešaka na"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Zarezom odvojen popis metoda za ograničavanje uklanjanja grešaka na"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Ako je Terminator već pokrenut, jednostavno otvori novu karticu"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -503,7 +539,7 @@ msgstr "Prilagođene _naredbe"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Postavke"
 
@@ -528,12 +564,12 @@ msgid "Enabled"
 msgstr "Aktivirano"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Naziv"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Naredba"
 
@@ -639,7 +675,7 @@ msgid "Escape sequence"
 msgstr "Slijed kontrolnog znaka"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Sve"
 
@@ -912,250 +948,218 @@ msgid "Tabs scroll buttons"
 msgstr "Gumbovi klizača kartica"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Traka naslova terminala</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Boja fonta:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Pozadina:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Fokusirana"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Neaktivna"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Primajuća"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr "Traka naslova dolje (program se mora ponovo pokrenuti)"
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Sakrij veličinu iz naslova"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Koristi font sustava"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Font:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Odaberi font za traku naslova"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Globalno"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Koristi font fiksne širine sustava"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Font:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Odaberi font za terminal"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Dopusti podebljani tekst"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Prikaži traku naslova"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Kopiraj pri odabiru"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Deaktiviraj zumiranje pomoću „Ctrl+okretanje kotačića miša”"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Niz znakova _za označivanje:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Pokazivač</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Oblik:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Boja:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Titranje"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Prednja"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Pozadina:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Zvono terminala</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Ikona u traci naslova"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Vizualni bljesak"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Zvučni signal"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Zabljesni popis prozora"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Opće"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Pokreni naredbu kao ljusku prijave"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Pokreni prilagođenu _naredbu umjesto moje ljuske"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Prilagođena na_redba:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Kad naredba _završi:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Prednja i stražnja boja</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Koristi boje iz teme sustava"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Ugrađene she_me:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Boja teksta:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Boja pozadine:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Ugrađene _sheme:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Paleta b_oja:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr "Prikaži p_odebljani tekst svijetlim bojama"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Boje"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Puna boja"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Prozirna pozadina"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr "Odaberi datoteku"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Bez</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimalno</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Pozadina"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Klizna traka je:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Kliži pri _rezultatu"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Kliži pri _pritiskanju tipke"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Beskonačna povijest"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Po_vijest:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "redaka"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Klizanje"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1167,80 +1171,108 @@ msgstr ""
 "određenim programima i operacijskim sustavima, koji očekuju drugačiji rad "
 "terminala.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Tipka _backspace generira:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Tipka _delete generira:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Kodiranje:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Postavi opcije kompatibilnosti na standardne vrijednosti"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Kompatibilnost"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Fokusirana"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Neaktivna"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Primajuća"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Sakrij veličinu iz naslova"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Koristi font sustava"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Odaberi font za traku naslova"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Vrsta"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Prilagođena naredba:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Radna mapa:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Rasporedi"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Radnja"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Tipkovnički prečac"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Tipkovnički prečaci"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Priključak"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Ovaj priključak nema opcija za konfiguraciju"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Priključci"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1263,11 +1295,11 @@ msgstr ""
 "korisnim funkcijama za administratore sustava i za ostale korisnike. "
 "Prijedlozi se mogu dodati u popis želja! (vidi lijevo poveznicu „Razvoj”)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Priručnik"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
@@ -1277,7 +1309,7 @@ msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Greške i "
 "poboljšanja</a>"
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Informacije"
 
@@ -1510,82 +1542,94 @@ msgid "Ungroup all terminals"
 msgstr "Razdvoji sve terminale"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Grupiraj terminale u kartici"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Grupiraj/Razdvoji terminale u kartici"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Razdvoji terminale u kartici"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Stvori novi prozor"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Pokreni novi proces Terminatora"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Ne šalji pritiskanje tipki"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Šalji pritiskanje tipki grupi"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Šalji događaje tipki svima"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Umetni broj terminala"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Umetni broj terminala s predstavljenom nulom"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Uredi naslov prozora"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Uredi naslov terminala"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Uredi naslov kartice"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Otvori prozor pokretanja rasporeda"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Prebaci na sljedeći profil"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Prebaci na prethodni profil"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr "Otvori prozor postavki"
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Otvori priručnik"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Novi profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Novi raspored"
 
@@ -1630,141 +1674,153 @@ msgstr "_Kopiraj"
 msgid "_Paste"
 msgstr "_Umetni"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Rastavi _vodoravno"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Rastavi _okomito"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Otvori _karticu"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Otvori _debug karticu"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Zatvori"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zumiraj terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Rast_vori terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Obnovi sve terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Grupiranje"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Prikaži _kliznu traku"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr "_Rasporedi …"
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kodiranja"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Standardno"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Korisnički određeno"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Ostala kodiranja"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "N_ova grupa …"
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Ništa"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Ukloni grupu %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_rupiraj sve u kartici"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Razdvoji sve _u kartici"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Ukloni sve grupe"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Zatvori grupu %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Šalji svim_a"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Šalji _grupi"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Slanje isključen_o"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "_Rastavi u ovu grupu"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Auto_matski ukloni grupe"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Umetni broj terminala"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Umetni _broj terminala s predstavljenom nulom"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Nije moguće pronaći ljusku"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Nije moguće pokrenuti ljusku:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Preimenuj prozor"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Upiši novi naslov za prozor Terminatora …"
 
@@ -1868,14 +1924,37 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "prozor"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Kartica %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Traka naslova terminala</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Boja fonta:"
+
+#~ msgid "Color:"
+#~ msgstr "Boja:"
+
+#~ msgid "Foreground"
+#~ msgstr "Prednja"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Boja teksta:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Boja pozadine:"
 
 #~ msgid "Version: 2.0.1"
 #~ msgstr "Verzija: 2.0.1"

--- a/po/hu.po
+++ b/po/hu.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Hungarian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Több terminál egy ablakban"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "A terminálok robot jövője"
 
@@ -348,7 +376,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Elrendezés"
 
@@ -356,106 +384,114 @@ msgstr "Elrendezés"
 msgid "Launch"
 msgstr "Indítás"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "lap"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Lap bezárása"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "A program verziójának megjelenítése"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Az ablak töltse ki a képernyőt"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Ablakkeret eltávolítása"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Ablak elrejtése indításkor"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Ablak címének megadása"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Az ablak méretének kívánt mérete és pozíciója (lásd az X man oldalát)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Parancs megadása a terminálon belüli futtatáshoz"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Konfigurációs fájl megadása"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "A munkakönyvtár beállítása"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Egyedi ikon beállítása az ablaknak (fájllal vagy névvel)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Egyedi WM_WINDOW_ROLE tulajdonság beállítása az ablakon"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Indítás adott elrendezéssel"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Válassz egy elrendezést a listából"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Másik profil használata alapértelmezettként"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "DBus lekapcsolása"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Hibakeresési információk engedélyezése (kétszer hibakereső szervernek)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Ha már fut a Terminátor, akkor csak új fület nyisson"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -482,7 +518,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -507,12 +543,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Parancs"
 
@@ -618,7 +654,7 @@ msgid "Escape sequence"
 msgstr "Escape szekvencia"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Összes"
 
@@ -891,250 +927,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Globális"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Válassza ki a terminál betűkészletét"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Címsor megjelenítése"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Kurzor beállításai</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminál csengő</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Címsorbeli ikon"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Látható villanás"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Általános"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Parancs futtatása bejelentkezési parancsértelmezőként"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Rendszertéma színeinek használata"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Beépített sé_mák:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Szövegszín:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Háttérszín:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paletta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Beépített _sémák:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Háttér"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1142,80 +1146,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1229,18 +1261,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1473,82 +1505,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1593,141 +1637,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Felosztás _vízszintesen"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Felosztás _függőlegesen"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "_Lap megnyitása"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Hibakereső fül megnyitása"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "Terminál nagyítása"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Gördítő_sáv megjelenítése"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kódolások"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Egyéb Kódolások"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Minden csoport eltávolítása"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Parancsértelmező nem található"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1831,11 +1887,22 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "ablak"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "_Text color:"
+#~ msgstr "_Szövegszín:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Háttérszín:"

--- a/po/hy.po
+++ b/po/hy.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Armenian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Մի քանի տերմինալ մեկ պատուհանում"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/ia.po
+++ b/po/ia.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Interlingua (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,24 +94,40 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -108,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Plure terminales in un fenestra"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Le robot futur del terminales"
 
@@ -349,7 +377,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Disposition"
 
@@ -357,106 +385,114 @@ msgstr "Disposition"
 msgid "Launch"
 msgstr "Lancear"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "scheda"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Clauder scheda"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Monstrar le version del programma"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximisar le fenestra"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Facer plenar le schermo al fenestra"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Celar le fenestra al comenciamento"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Specificar un file de configuration"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Eliger un strato ex un lista"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -483,7 +519,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferentias"
 
@@ -508,12 +544,12 @@ msgid "Enabled"
 msgstr "Activate"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Nomine"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Commando"
 
@@ -619,7 +655,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Toto"
 
@@ -892,250 +928,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Inactive"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profilo"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Color:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Palpebrar"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "General"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Colores"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Fundo"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "lineas"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Rolar"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1143,80 +1147,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Inactive"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Typo"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profilo:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Action"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1230,18 +1262,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "A  proposito"
 
@@ -1474,82 +1506,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nove profilo"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1594,141 +1638,153 @@ msgstr "_Copiar"
 msgid "_Paste"
 msgstr "Collar (_P)"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Clauder"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Gruppar"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Predefinite"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1832,11 +1888,19 @@ msgstr ""
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "fenestra"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Scheda %d"
+
+#~ msgid "Color:"
+#~ msgstr "Color:"

--- a/po/id.po
+++ b/po/id.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Indonesian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -90,18 +102,34 @@ msgstr ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "Terminal UUID for when not in env var TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -110,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Banyak terminal dalam satu window"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "The robot future of terminals"
 
@@ -351,7 +379,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Terminator Layout Launcher"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Tata Letak"
 
@@ -359,49 +387,49 @@ msgstr "Tata Letak"
 msgid "Launch"
 msgstr "Luncurkan"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Tutup Tab"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Tampilkan versi program"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maksimalkan jendela"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Buat agar window memenuhi layar"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Nonaktifkan batas window"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Sembunyikan jendela saat mulai"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Tentukan judul untuk jendela"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Tetapkan ukuran dan posisi yang diinginkan dari jendela(lihat halaman manual "
 "X)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Tentukan perintah untuk mengeksekusi didalam terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -409,60 +437,68 @@ msgstr ""
 "Gunakan jeda dari baris perintah sebagai perintah untuk mengeksekusi di "
 "dalam termunal dan argumennya"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Tentukan file konfigurasi"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Menentukan direktori kerja"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Tentukan ikon lazim untuk window (oleh file atau nama)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Tentukan properti WM_WINDOW_ROLE pada jendela"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Launch with the given layout"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Select a layout from a list"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Gunakan profil berbeda sebagai standar"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Nonaktifkan DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Aktifkan informasi debug (dua kali untuk server debug)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "kelas yang dipisahkan dengan koma untuk membatasi debug"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "metode yang dipisahkan dengan koma untuk membatasi debug"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Jika Terminator telah dijalankan, coba buka tab baru"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -489,7 +525,7 @@ msgstr "_Custom Commands"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferensi"
 
@@ -514,12 +550,12 @@ msgid "Enabled"
 msgstr "Aktifkan"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Nama"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Perintah"
 
@@ -625,7 +661,7 @@ msgid "Escape sequence"
 msgstr "Escape sequence"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Semuanya"
 
@@ -898,250 +934,218 @@ msgid "Tabs scroll buttons"
 msgstr "Tabs scroll buttons"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Terminal Titlebar</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Warna huruf:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Latar belakang:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Focused"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Tidak aktif"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Menerima"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Hide size from title"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Use the system font"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Huruf:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Choose A Titlebar Font"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Gunakan lebar font sistem"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Huruf:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Pilih huruf untuk terminal"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "Perbolehk_an teks tebal"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Tampilkan titlebar"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Salin pada pilihan"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Pilih karakter _kata:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Shape:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Warna:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Berkedip"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Latar Depan"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Latar belakang:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal bell</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "ikon Titlebar"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Flash visual"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Terdengar beep"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Window list flash"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Umum"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Jalankan perintah dalam shell login"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Jalankan perintah tertent_u dan bukan shell"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Perintah ta_mbahan:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Saat perintah s_elesai dijalankan:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Latar Depan dan Latar Belakang</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "G_unakan warna dari tema sistem"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Ske_ma bawaan:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Warna _teks:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "Warna latar _belakang:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Skema-_skema bawaan:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "P_alet warna:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Warna"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "warna _Solid"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Latar belakang _transparan"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Nihil</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimal</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Latar belakang"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Scrollbarnya:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Gulung saat ada _keluaran"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Gulung pada saat tombol _ditekan"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Gulung balik tak terbatas"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Gulung _balik:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "baris"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Menggulung"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1153,80 +1157,108 @@ msgstr ""
 "beberapa aplikasi dan sistem operasi tertentu yang memiliki perilaku berbeda "
 "pada aplikasi terminalnya.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Tom_bol backspace membangkitkan:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Tombol _delete membangkitkan:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Pengkodean:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Kembalikan pilihan kompatibilitas ke nilai bawaan"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Kompatibilitas"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Focused"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Tidak aktif"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Menerima"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Hide size from title"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Use the system font"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Choose A Titlebar Font"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Jenis"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Custom command:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Working directory:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Tata Letak"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Aksi"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Kaitan tombol"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Pengaya"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Plugin ini tidak memiliki pilihan konfigurasi"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1250,18 +1282,18 @@ msgstr ""
 "users. If you have any suggestions, please file wishlist bugs! (see left for "
 "the Development link)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "The Manual"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Tentang"
 
@@ -1494,82 +1526,94 @@ msgid "Ungroup all terminals"
 msgstr "Ungroup all terminals"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Group terminals in tab"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Group/Ungroup terminals in tab"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Ungroup terminals in tab"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Buat jendela baru"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Spawn a new Terminator process"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Don't broadcast key presses"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Broadcast key presses to group"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Broadcast key events to all"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "SIsipkan nomor terminal"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Masukkan nomor padded terminal"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Edit window title"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Edit terminal title"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Edit tab title"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Open layout launcher window"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Switch to next profile"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Switch to previous profile"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Buka manual"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Profile Baru"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Tampilan Baru"
 
@@ -1614,141 +1658,153 @@ msgstr ""
 msgid "_Paste"
 msgstr "Tem_pel"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Pecah secara H_orisontal"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Pecah secara V_ertikal"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Buka _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Buka tab _Debug"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "Tutup"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Perbesar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximize terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Kembalikan semua terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Pengelompokan"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Tunjukkan _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Pengodean"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Baku"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Ditetapkan pengguna"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Pengkodean Lainnya"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "N_ew group..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Nihil"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Hapus grup %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "K_elompokan semua dalam tab"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Ungro_up all in tab"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Hapus semua grup"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Tutup grup %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Broadcast _all"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Broadcast _group"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Broadcast _off"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "_Split to this group"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Auto_clean groups"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Insert terminal number"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Insert _padded terminal number"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Tidak dapat menemukan sebuah shell."
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Tidak dapat menjalankan shell:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Namai jendela"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Masukkan judul baru untuk terminal"
 
@@ -1852,11 +1908,34 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "jendela"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Terminal Titlebar</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Warna huruf:"
+
+#~ msgid "Color:"
+#~ msgstr "Warna:"
+
+#~ msgid "Foreground"
+#~ msgstr "Latar Depan"
+
+#~ msgid "_Text color:"
+#~ msgstr "Warna _teks:"
+
+#~ msgid "_Background color:"
+#~ msgstr "Warna latar _belakang:"

--- a/po/is.po
+++ b/po/is.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Icelandic (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Margar útstöðvar í einum glugga"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "flipi"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Loka Flipa"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Sýna forritsútgáfu"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Lætur gluggann fylla skjáinn"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Slökkva á gluggaskilum"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Fela gluggann við ræsingu"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Setja nafn á gluggann"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Setja inn skipun til að keyra í útstöðinni"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Skilgreina starfandi möppu"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Stilla sérsniðinn WM_WINDOW_ROLE-eiginleika á gluggann"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Nota aðra uppsetningu sem sjálfgefna"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Slökkva á DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Kjörstillingar"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Allir"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Uppsetning"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Settu inn númer útstöðvar"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Settu inn númer útstöðvar"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Ný Uppsetning"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nýtt Snið"
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Deila _Lárétt"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Deila Lóðré_tt"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Opna fl_ipa"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Hópun"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Sýna _skrunslá"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kóðanir"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Sjálfgefið"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Skilgreint af notanda"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Aðrar kóðanir"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Fjarlægja hóp %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "_Hópa allar í flipa"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Fjarlægja alla hópa"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Loka hóp %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Getur ekki fundið skel"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Getur ekki ræst skel:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "gluggi"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Flipi %d"

--- a/po/it.po
+++ b/po/it.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Italian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -90,18 +102,34 @@ msgstr ""
 "* Queste entrate richiedono l'uso o della var d'ambiente di TERMINATOR_UUID "
 "o dell'optione --uuid."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -110,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Molteplici terminali un una sola finestra"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Il futuro robot dei terminali"
 
@@ -351,7 +379,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Disposizione"
 
@@ -359,49 +387,49 @@ msgstr "Disposizione"
 msgid "Launch"
 msgstr "Esegui"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "scheda"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Chiudi scheda"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Visualizza la versione del programma"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Massimizzare la finestra"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Ingrandisce la finestra a schermo intero"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Disabilita i bordi della finestra"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Nasconde la finestra all'avvio"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Specifica un titolo per la finestra"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Imposta la posizione e la dimensione della finestra (consultare la pagina "
 "d'aiuto di X)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Specifica un comando da eseguire nel terminale"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -409,60 +437,68 @@ msgstr ""
 "Usa il resto della riga di comando come un comando da eseguire nel terminale "
 "e i suoi argomenti"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Specifica un file di configurazione"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Imposta la directory di lavoro"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Imposta un'icona personalizzata per la finestra (per file o nome)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Imposta una proprietà WM_WINDOW_ROLE personalizzata alla finestra"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Lanciare con una disposizione determinata"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Selezionare una disposizione da una lista"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Usa un profilo differente come predefinito"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Disabilita DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Abilita informazioni di debug (due volte per fare il debug del server)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Elenco separato da virgole delle classi alle quali limitare il debug"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Elenco separato da virgole dei metodi ai quali limitare il debug"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Se Terminator è già in esecuzione, apre una nuova scheda"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -489,7 +525,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "Preferen_ze"
 
@@ -514,12 +550,12 @@ msgid "Enabled"
 msgstr "Attivato"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Nome"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Comando"
 
@@ -625,7 +661,7 @@ msgid "Escape sequence"
 msgstr "Sequenza di escape"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Tutti"
 
@@ -898,250 +934,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Colore del carattere:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "Tipo di _carattere"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Globali"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profilo"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Usare il tipo di carattere a larghezza fissa di sistema"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "Tipo di _carattere"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Scegliere un carattere"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "Consentire il testo in gr_assetto"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Mostrare la barra del titolo"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Copiare con la selezione"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Cara_tteri selezionabili come parola:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursore</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Colore:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Avviso</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Icona nella barra del titolo"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Segnale luminoso"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Segnale acustico"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Illuminazione elenco finestre"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Generali"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Eseguire il comando come una shell di login"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Ese_guire un comando personalizzato invece della shell"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Co_mando personalizzato:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "_Quando il comando termina:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Primo piano e sfondo</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "Usare i colori del te_ma di sistema"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Schemi i_ncorporati:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Colore del _testo:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "Colore di _sfondo:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Tavolozza</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "_Schemi incorporati:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Tavolo_zza dei colori:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Colori"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Tinta unita"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Sfondo _trasparente"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Nessuna</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Massima</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Sfondo"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "Barra di _scorrimento:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Sco_rrere in presenza di output"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "S_correre alla pressione dei tasti"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Illimitato"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Sc_orrimento all'indietro:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "righe"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Scorrimento"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1153,80 +1157,108 @@ msgstr ""
 "applicazioni e sistemi operativi che si aspettano un diverso funzionamento "
 "del terminale.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Il tasto _Backspace genera:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Il tasto _Canc genera:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Ripristina valori predefiniti per opzioni di compatibilità"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Compatibilità"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Cartella di lavoro:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Disposizioni"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Associazione tasti"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Questo plugin non ha opzioni di configurazione"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Plugin"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1240,18 +1272,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1484,82 +1516,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
+msgid "Don't broadcast key presses"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:173
+msgid "Broadcast key presses to group"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:174
+msgid "Broadcast key events to all"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Inserisci il numero del terminale"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Inserire il numero di terminale"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Modifica il titolo della finestra"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Modifica il titolo del terminale"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Modifica il titolo della scheda"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Passa al profilo successivo"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Passa al profilo precedente"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Apri il manuale"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nuovo profilo"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nuova disposizione"
 
@@ -1604,141 +1648,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Dividi o_rizzontalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Dividi v_erticalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Apri _scheda"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Apri scheda _debug"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Ingrandisci terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Ripristina tutti i terminali"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Raggruppamento"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Mostra _barra di scorrimento"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Codifiche"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Predefinito"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definito dall'utente"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Altre codifiche"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Rimuovi gruppo %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Ra_ggruppa tutto nella scheda"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Rimuovi tutti i gruppi"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Chiudi gruppo %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Impossibile trovare una shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Impossibile avviare la shell:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Rinomina finestra"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Inserisci un nuovo titolo per la finestra di Terminator..."
 
@@ -1842,11 +1898,28 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "finestra"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Scheda %d"
+
+#~ msgid "Font color:"
+#~ msgstr "Colore del carattere:"
+
+#~ msgid "Color:"
+#~ msgstr "Colore:"
+
+#~ msgid "_Text color:"
+#~ msgstr "Colore del _testo:"
+
+#~ msgid "_Background color:"
+#~ msgstr "Colore di _sfondo:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Japanese (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "複数の端末を一つのウインドウに"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "レイアウト"
 
@@ -354,106 +382,114 @@ msgstr "レイアウト"
 msgid "Launch"
 msgstr "実行"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "タブ"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "タブを閉じる"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "バージョンを表示"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "ウインドウを画面全体に表示"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "ウインドウの枠を表示しない"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "最小化して起動"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "ウインドウのタイトルを指定"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "ウィンドウの大きさと位置をセット( X man page 参照)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "端末内で実行するコマンドを指定する"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr "端末で実行するコマンドと引数を指定する"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "設定ファイルを指定する"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "作業用ディレクトリを指定する"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "ウインドウのカスタムアイコンを設定する(名前またはファイル)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "ウインドウにカスタムWM_WINDOW_ROLE値を設定する"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "指定したレイアウトで実行"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "リストからレイアウトを選ぶ"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "デフォルト以外のプロファイルを使用"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "DBusを無効化"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "デバッグ情報を出力"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "デバッグ対象のクラスをカンマで区切って指定"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "デバッグ対象のメソッドをカンマで区切って指定"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Terminator が起動していたら新しいタブを開きます"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr "カスタムコマンド(_C)"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "設定(_P)"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "コマンド"
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr "Escape sequence"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "全て"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>ターミナルタイトルバー</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "フォント色:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "背景:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "受信中"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "システムフォントを使う(_U)"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "フォント(_F):"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "一般"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "プロファイル"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "システムの固定幅フォントを使う(_U)"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "フォント(_F):"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "端末フォントの選択"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "太字フォントを有効にする(_A)"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "タイトルバー表示"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "選択をコピー"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "単語単位で選択する文字(_W):"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>カーソル</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "色:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "背景:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>端末のベル</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "タイトルバー・アイコン"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "画面の点滅"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "ビープ音"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "ウィンドウリスト点滅"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "一般"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "ログイン・シェルを実行(_R)"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "ログイン・シェルではなくカスタムコマンドを実行(_n)"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "カスタムコマンド(_m):"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "exitコマンドの動作(_e):"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>文字と背景</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "システムテーマを使う(_U)"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "既定の設定(_m):"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "文字の色(_T):"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "背景色(_B):"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>パレット</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "既定の設定(_s):"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "カラーパレット(_a):"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "色"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "単色(_S)"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "背景を透過(_T)"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>なし</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>最大</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "背景"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "スクロールバー(_S):"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "出力でボトムにスクロール(_k)"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "キー入力でボトムにスクロール(_k)"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "無限のスクロールバック"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "スクロールバック(_b):"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "行"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "スクロール"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1144,80 +1148,108 @@ msgstr ""
 "OS 上で異なった動作になってしまう問題を解決するために提供されています。</i></"
 "small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "[BS] キーが生成するコード(_B):"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "[DEL] キーが生成するコード(_D):"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "互換性オプションを既定値に戻す(_R)"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "互換性"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "受信中"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "システムフォントを使う(_U)"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "プロファイル"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "プロファイル:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "作業ディレクトリ:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "レイアウト"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "キーバインド"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "キーの割り当て"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "プラグイン"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "このプラグインにオプション設定はありません"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "プラグイン"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1231,18 +1263,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "情報"
 
@@ -1475,82 +1507,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "端末番号を挿入"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
-msgstr "ウィンドウタイトルを編集"
-
-#: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Broadcast key events to all"
 msgstr ""
 
+#: ../terminatorlib/prefseditor.py:175
+msgid "Insert terminal number"
+msgstr "端末番号を挿入"
+
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
-msgstr ""
+msgid "Edit window title"
+msgstr "ウィンドウタイトルを編集"
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "新しいプロファイル"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "新しいレイアウト"
 
@@ -1595,141 +1639,153 @@ msgstr "コピー(_C)"
 msgid "_Paste"
 msgstr "貼り付け(_P)"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "水平で分割(_O)"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "垂直で分割(_E)"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "タブを開く(_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "デバッグタブを開く(_D)"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "閉じる(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "端末をズーム(_Z)"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "全ての端末を復元(_R)"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "グループ化"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "スクロールバーを表示(_S)"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "エンコーディング"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "既定値"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "ユーザ定義"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "その他のエンコーディング"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "グループ%sを解除"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "全てのタブをグループ化(_r)"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "全てのグループ化を解除"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "グループ%sを閉じる"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "シェルが見つかりません"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "シェルを起動できません:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "ウィンドウ名の変更"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "新しいウィンドウのタイトルを入力..."
 
@@ -1833,11 +1889,31 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "ウィンドウ"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "タブ%d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>ターミナルタイトルバー</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "フォント色:"
+
+#~ msgid "Color:"
+#~ msgstr "色:"
+
+#~ msgid "_Text color:"
+#~ msgstr "文字の色(_T):"
+
+#~ msgid "_Background color:"
+#~ msgstr "背景色(_B):"

--- a/po/jv.po
+++ b/po/jv.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Javanese (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Akeh terminal ning sak jendelo"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Tutup Tab"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Nampilno versine program"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "ngGawe jendelone fill layar"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Rak nganggo pinggiran jendelo"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Delikno jendelone pas startup"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Spesifike sakwijine judul kanggo jendelo"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "atur ukuran sik dipilih karo posisine jendela(delok halaman man X )"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Rinciane sakwijine printah kanggo eksekusi ning njerone terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "pilih file config"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Seteli arah tujuane kerjo"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Seteli sakwijine kustom WM_WINDOW_ROLE properti nok jendelone"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Gunakno sing bedo seko profil sak ugi gawane"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Rak nganggo DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Gunakno debugging informasi (twice kanggo debug server)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Koma dipisahke garis seko kelase nok limite debugging ring"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Koma dipisahke garis seko metode-metode nok limite debugging ring"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Bahan-acuan"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Kabeh"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Profil anyar"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Totoruang anyar"
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Dibagi H_orisonatl"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Dibagi V_ertikal"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Buka _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Buka Tab _Debug"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zum terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Mbalekno kabeh terminal-terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Ngelompokake"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Tampilake _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Nggawe Sandi"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Gawan-asline"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Pengguno didefinisikno"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Nggawe Sandi liyane"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "ngGuwaki kelompok %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_roup kabeh ning tab"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "ngGuwaki kabeh kelompok %s"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Nutupe kelompok %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Ora iso nemokake sell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "jendela"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/ka.po
+++ b/po/ka.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Georgian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "მრავალი ტერმინალები ერთ ფანჯარაში"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,47 +382,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "ჩანართი"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "ჩანართის დახურვა"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "გამოტანის პროგრამის ვერსია"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "მარკა ფანჯარა შეავსეთ ეკრანზე"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "გამორთე ფანჯარა საზღვრები"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "დამალვა ფანჯარა დან ჩატვირთვის"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "მიუთითეთ სათაური ფანჯარა"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "მიუთითეთ ბრძანება შესრულდეს შიგნით ტერმინალი"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -402,60 +430,68 @@ msgstr ""
 "გამოიყენეთ დანარჩენი ბრძანების როგორც ბრძანება შესრულდეს შიგნით ტერმინალის "
 "და მისი არგუმენტები"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "კომპლექტი სამუშაო დირექტორია"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "კომპლექტის საბაჟო WM_WINDOW_ROLE ქონების ფანჯარა"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "გამოყენება სხვადასხვა პროფაილი როგორც ნაგულისხმევი"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "გამორთე DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "ჩართე გამართვის ინფორმაციის (ორჯერ გამართვის სერვერი)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "მძიმეებით სია კლასების შეზღუდვა გამართვის რომ"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "მძიმეებით სია მეთოდების შეზღუდოს გამართვის რომ"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -482,7 +518,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -507,12 +543,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -618,7 +654,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -891,250 +927,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1142,80 +1146,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1229,18 +1261,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1473,82 +1505,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "ახალი პროფილი"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "ახალი განლაგება"
 
@@ -1593,141 +1637,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1831,11 +1887,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/kk.po
+++ b/po/kk.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Kazakh (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Терминатор"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Бір терезе ішінде көптік терминалдар"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "табуляция"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Баптаулар"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Барлық"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Профильдер"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Терминал нөмірін басып шығару"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Сандық пернетақтадан консольды санды енгізу"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Терминал нөмірін басып шығару"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Сандық пернетақтадан консольды санды енгізу"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Жаңа профиль"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Жаңа қабат"
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Терезені көлбеу бөлу"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Терезені тігінен бөлу"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "Терминалды _ұлғайту"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "Барлық терминалдарды бастапқы _қалпыға әкелу"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Топтастыру"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "_Жылжыту жолағын көрсету"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Кодылау"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Қалыпты"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Пайдаланушымен анықталған"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Басқа кодылау"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "%s тобын жою"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Барлық топтарды жою"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "%s тобын жабу"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Қабықшаны табу мүмкін емес"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Қабықшаны ашу мүмкін емес:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "терезе"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Korean (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "터미네이터"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "창 하나에 터미널 여러 개 쓰기"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "터미널이 지배하는 미래 세상"
 
@@ -350,7 +378,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "형태"
 
@@ -358,106 +386,114 @@ msgstr "형태"
 msgid "Launch"
 msgstr "실행"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "탭"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "탭 닫기"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "프로그램 버전을 표시합니다"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "창 최대화"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "창으로 화면을 채웁니다"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "창테두리를 감춥니다"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "시작시 창을 감춥니다"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "창 제목을 지정합니다"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "윈도우의 크기와 위치를 조정하세요. (X man 페이지 참고)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "터미널 안에서 실행할 명령을 지정합니다"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr "명령행의 나머지 부분을 터미널 안에서 실행할 명령 및 인자로 사용합니다"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "설정파일을 지정합니다"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "현재 디렉터리를 설정합니다"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "윈도우에 사용자 정의 아이콘 설정"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "창의 WM_WINDOW_ROLE 속성을 설정합니다"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "기본으로 다른 프로파일을 사용합니다"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "DBus를 비활성화 합니다"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "정보를 디버깅 활성화 합니다 (디버그 서버를 위해선 두 번 지정)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "디버깅을 제한할 클래스들의 쉼표 구분 목록"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "디버깅을 제한할 메소드들의 쉼표 구분 목록"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "만약 Terminator가 이미 실행중이라면, 새 탭을 여는것을 추천합니다"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -484,7 +520,7 @@ msgstr "사용자 정의 명령들"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "환경 설정(_P)"
 
@@ -509,12 +545,12 @@ msgid "Enabled"
 msgstr "사용"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "이름"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "명령"
 
@@ -620,7 +656,7 @@ msgid "Escape sequence"
 msgstr "이스케이프 시퀀스"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "전체"
 
@@ -893,250 +929,218 @@ msgid "Tabs scroll buttons"
 msgstr "탭 스크롤 버튼"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>터미널 제목</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "글자색:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "배경:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "활성"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "비활성"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "수신 중"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "제목에 크기 감추기"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "시스템 글꼴 사용"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "글꼴(_F):"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "제목 글꼴 선택"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "일반설정"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "프로파일"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "시스템 고정폭 글꼴 사용(_U)"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "글꼴(_F):"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "터미널 글꼴 선택"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "굵은 글씨 허용(_A)"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "제목 보이기"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "선택하면 클립보드로"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "단어 단위 선택 문자(_W):"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>커서</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "모양:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "색상:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "깜박이기"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "글자색"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "배경:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>터미널 벨</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "제목 아이콘"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "화면 깜빡거림"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "비프 음"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "창 목록 깜빡거림"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "일반 설정"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "로그인 쉘로 명령 실행(_R)"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "쉘 대신에 사용자 지정 명령 실행(_N)"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "사용자 지정 명령(_M):"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "명령이 끝날 때(_E):"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>글자색 및 바탕색</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "시스템 테마 색 사용(_U)"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "내장 색상표(_M):"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "글자색(_T):"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "배경색(_B):"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>팔레트</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "내장 색상표(_S):"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "색상표(_A)"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "색상"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "단색(_S)"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "투명 배경"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>없음</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>최대</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "배경"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "스크롤 막대 위치(_S):"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "출력이 있으면 스크롤(_O)"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "키를 누르면 스크롤(_K)"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "무제한 스크롤"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "스크롤 범위(_B):"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "줄"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "스크롤"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1147,80 +1151,108 @@ msgstr ""
 "수도 있습니다. 다음 옵션은 터미널 기능을 다르게 이용하는 일부 프로그램과 운영"
 "체제의 문제를 피해가는 기능일 뿐입니다.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "백스페이스 키를 누르면(_B):"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Delete 키를 누르면(_D):"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "인코딩:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "호환성 옵션을 기본값으로 되돌림(_R)"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "호환성"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "활성"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "비활성"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "수신 중"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "제목에 크기 감추기"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "시스템 글꼴 사용"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "제목 글꼴 선택"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "프로파일"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "유형"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "프로파일:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "사용자 지정 명령:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "작업 디렉터리:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "레이아웃"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "동작"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "단축키"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "키 설정"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "플러그인"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "이 플러그인은 옵션 설정이 없음"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "플러그인"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1234,18 +1266,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "설명서"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "소개"
 
@@ -1478,82 +1510,94 @@ msgid "Ungroup all terminals"
 msgstr "모든 터미널을 그룹 해제"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "탭 내의 터미널들을 그룹 지정"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "탭 내의 터미널들을 그룹 지정/해제"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "탭 내의 터미널들을 그룹 해제"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "새 창 만들기"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "새로운 터미네이터 프로세스 생성"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "동시 입력 하지 않기"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "그룹에 동시 입력"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "전체에 동시 입력"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "터미널 번호 붙여넣기"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "0으로 채운 터미널 번호 붙여넣기"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "창 제목 편집"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "터미널 제목 편집"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "탭 제목 편집"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "레이아웃 런처 창 열기"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "다음 프로파일로"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "이전 프로파일로"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "설명서 열기"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "새 프로파일"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "새 레이아웃"
 
@@ -1598,141 +1642,153 @@ msgstr "복사(_C)"
 msgid "_Paste"
 msgstr "붙여넣기(_P)"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "상하로 나누기(_O)"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "좌우로 나누기(_E)"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "탭 열기(_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "디버깅 탭 열기(_D)"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "닫기(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "터미널 확대(_Z)"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "터미널 최대화(_X)"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "전체 터미널 복원(_R)"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "그룹화"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "스크롤 막대 표시(_S)"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "인코딩"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "기본"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "사용자 정의"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "기타 인코딩"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "새 그룹(_E)"
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "소속 없음"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "그룹 %s 지우기"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "탭 안의 모두를 그룹으로(_G)"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "탭 안의 모두를 그룹 해제(_U)"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "모든 그룹 지우기"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "그룹 %s 닫기"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "전체에게 동시 입력(_A)"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "그룹에 동시 입력(_G)"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "동시 입력 끄기(_O)"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "나눌 때 이 그룹으로(_S)"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "빈 그룹 자동 제거(_C)"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "터미널 번호 붙여넣기(_I)"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "0으로 채운 터미널 번호 붙여넣기(_P)"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "셸을 찾을 수 없음"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "셸을 시작할 수 없음:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "윈도우 이름 바꾸기"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "터미네이터 창의 새 제목을 입력하세요..."
 
@@ -1836,11 +1892,34 @@ msgstr "지빠귀"
 msgid "Omega"
 msgstr "곤줄박이"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "창"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "탭 %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>터미널 제목</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "글자색:"
+
+#~ msgid "Color:"
+#~ msgstr "색상:"
+
+#~ msgid "Foreground"
+#~ msgstr "글자색"
+
+#~ msgid "_Text color:"
+#~ msgstr "글자색(_T):"
+
+#~ msgid "_Background color:"
+#~ msgstr "배경색(_B):"

--- a/po/ku.po
+++ b/po/ku.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Kurdish (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Bicihkirin"
 
@@ -354,106 +382,114 @@ msgstr "Bicihkirin"
 msgid "Launch"
 msgstr "Destpêke"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Hilpekinê Dade"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Pencereyê mezintirîn bike"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Vebijark"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr "Çalake"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Nav"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Ferman"
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Giştî"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Rengê nivîsê:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Rûerd:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Neçalak"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Tê wergirtin"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Cureyê nivîsê:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Gerdûnî"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profîl"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "Bi curenivîsan re peytandiya pergalê bi kar bîne"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Cureyê nivîsê:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Ji Bo Termînalê Curenivîsekê Hilbijêre"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Destûrê bide nivîsa stûr"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Rûerd:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Neçalak"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Tê wergirtin"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,19 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Font color:"
+#~ msgstr "Rengê nivîsê:"

--- a/po/la.po
+++ b/po/la.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Latin (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/lt.po
+++ b/po/lt.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Lithuanian (https://www.transifex.com/terminator/teams/109338/"
@@ -70,10 +70,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -81,24 +93,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -107,7 +135,7 @@ msgid "Multiple terminals in one window"
 msgstr "Keli terminalai viename lange"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -348,7 +376,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -356,47 +384,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "kortelė"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Užverti kortelę"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Rodyti programos versiją"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Užpildyti langu ekraną"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Išjungti langų kraštines"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Paslėpti langą paleidimo metu"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Nurodyti pavadinimą langui"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Nurodykite komandą, kurią norite paleisti terminalo viduje"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -404,60 +432,68 @@ msgstr ""
 "Naudoti likusią komandų eilutę ir jos argumentus kaip komandą paleidimui "
 "terminalo viduje"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Nurodyti darbinį aplanką"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Nurodyti pasirinktiną WM_WINDOW_ROLE nustatymą langui"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Naudoti skirtingą profilį kaip numatytąjį"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Išjungti DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Įjungti derinimo informaciją (du kartus derinimo tarnybinei stočiai)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Kableliu atskirtas klasių, apribotų derinimui, sąrašas"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Kableliu atskirtas metodų, apribotų derinimui, sąrašas"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -484,7 +520,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Nustatymai"
 
@@ -509,12 +545,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -620,7 +656,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Visi"
 
@@ -893,250 +929,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1144,80 +1148,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiliai"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1231,18 +1263,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1475,82 +1507,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Įterpti terminalo numerį"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Įterpti dengtą terminalo numerį"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Įterpti terminalo numerį"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Įterpti dengtą terminalo numerį"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Naujas profilis"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Naujas išdėstymas"
 
@@ -1595,141 +1639,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Padalinti H_orizontaliai"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Padalinti V_ertikaliai"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Atverti _kortelę"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Atverti _derinimo kortelę"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Padidinti terminalą"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Atkurti visus terminalus"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Grupavimas"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Rodyti _slinkties juostą"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Koduotės"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Numatytoji"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Naudotojo nustatyta"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Kitos koduotės"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Šalinti grupę %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_rupuoti visus kortelėje"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Pašalinti visas grupes"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Uždaryti grupę %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Nepavyksta rasti komandų interpretatoriaus"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Nepavyksta paleisti komandų interpretatoriaus:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1833,11 +1889,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "langas"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Kortelė %d"

--- a/po/lv.po
+++ b/po/lv.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Latvian (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -80,24 +92,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -106,7 +134,7 @@ msgid "Multiple terminals in one window"
 msgstr "Daudzi termināļi vienā logā"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -347,7 +375,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -355,106 +383,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Aizvērt cilni"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -481,7 +517,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Iestatījumi"
 
@@ -506,12 +542,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -617,7 +653,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Visi"
 
@@ -890,250 +926,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1141,80 +1145,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1228,18 +1260,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1472,82 +1504,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Ievietot termināļa numuru"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Ievietot atdalītu temināļa numuru"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Ievietot termināļa numuru"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Ievietot atdalītu temināļa numuru"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Jauns profils"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Jauns slānis"
 
@@ -1592,141 +1636,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Pārdalīt h_orizontāli"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Sadalīt v_ertikāli"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Atvērt _Cilni"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Atvērt atkļū_došanas cilni"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Tuvināt termināli"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "Atjaunot visus te_rmināļus"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Grupēšana"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Rādīt ritjo_slu"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kodējumi"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Noklusētais"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Lietotāja definēts"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Citi kodējumi"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Dzēst grupu %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_rupēt visu cilnē"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Dzēst visas grupas"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Aizvērt grupu %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Nav iespējams atrast čaulu"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Nav iespējams palaist čaulu:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1830,11 +1886,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "logs"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Cilne %d"

--- a/po/mk.po
+++ b/po/mk.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Macedonian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Терминатор"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Повеќе терминали во еден прозорец"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "табулатор"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Затвори јазиче"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Опции"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Сѐ"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Профили"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Внесете број на терминал"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Внесете број на терминал"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Нов профил"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Нов распоред"
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Подели хо_ризонтално"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Подели вер_тикално"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Отвори _јазиче"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Отвори _јазиче за отстранување грешки"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_зумирај терминал"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Врати ги сите терминали"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Групирање"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Покажи _лизгач"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Шифрирања"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Стандардно"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Кориснички дефенирано"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Други шифрирања"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Избриши ја групата %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Г_рупирај ги сите во табови"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Избриши ги сите групи"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Затвори група %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Неспособен да најде обвивка"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "прозорец"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Табот %d"

--- a/po/ml.po
+++ b/po/ml.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Malayalam (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "ടെര്‍മിനേറ്റര്‍"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "ഒരു ജാലകത്തില്‍ ഒന്നിലധികം ടെര്‍മിനലുകള്‍"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "ലേഔട്ട്"
 
@@ -354,106 +382,114 @@ msgstr "ലേഔട്ട്"
 msgid "Launch"
 msgstr "തുടങ്ങുക"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "ടാബ്"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "റ്റാബ് അടയ്‍ക്കുക"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "പ്രോഗ്രാം പതിപ്പ് കാണിക്കുക"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "ജാലകം വലുതാക്കുക"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "ജാലകം സ്ക്രീനില്‍ നിറക്കുക"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "ജാലകത്തിന്റെ അതിരുകള്‍ ഇല്ലാതാക്കുക"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "ജാലകം സ്റ്റാര്‍ട്ടപ്പ് വേളയില്‍ ഒളിപ്പിക്കുക"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "ജാലകത്തിന്  പേര്  കൊടുക്കുക"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "ജാലകത്തിന്  ഉചിതമായ വലിപ്പവും സ്ഥലവും നൽകുക"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "റ്റെർമിനലിനുല്ലിൽ ഓടിക്കാനുള്ള കമാൻഡ് നല്കുക"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "കോണ്ഫിഗ് ഫയൽ നിർദേശിക്കുക"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "പ്രവര്‍ത്തനത്തിലുള്ള തട്ടു് സജ്ജമാക്കുക"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "പുതിയ പ്രൊഫൈല്‍"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Marathi (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/ms.po
+++ b/po/ms.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Malay (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -90,18 +102,34 @@ msgstr ""
 "* Masukan ini memerlukan sama ada pembolehubah persekitaran\n"
 "   TERMINATOR_UUID,  atau pilihan --uuid mesti digunakan."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "UUID terminal bila tidak berada dalam  env var TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -110,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Kesemua terminal dalam satu tetingkap"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Terminal dari robot masa hadapan"
 
@@ -351,7 +379,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Pelancar Bentangan Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Bentangan"
 
@@ -359,48 +387,48 @@ msgstr "Bentangan"
 msgid "Launch"
 msgstr "Lancar"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Tutup Tab"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Papar versi program"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Jadikan tetingkap mengisi skrin"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Lumpuhkan sempadan tetingkap"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Sembunyikan tetingkap pada permulaan"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Tentukan tajuk tetingkap"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Tetapkan saiz dan kedudukan tetingkap yang dikehendaki(rujuk halaman man X)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Tentukan perintah untuk lakukan didalam terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -408,60 +436,68 @@ msgstr ""
 "Guna baki baris perintah sebagai perintah untuk lakukan didalam terminal, "
 "dan argumennya"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Nyatakan fail konfig"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Tetapkan direktori kerja"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Tetapkan ikon suai untuk tetingkap (mengikut fail atau nama)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Tetapkan ciri WM_WINDOW_ROLE suai bagi tetingkap"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Lancar dengan bentangan yang diberii"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Pilih satu bentangan menerusi senarai"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Guna profil berbeza sebagai lalai"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Lumpuhkan DBas"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Benarkan maklumat penyahpepijatan (dua kali untuk pelayan nyahpepijat)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Koma dipisahkan senarai kelas untuk hadkan penyahpepijatan"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Koma dipisahkan senarai kaedah untuk hadkan penyahpepijatan"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Jika Terminator sudah berjalan, hanya buka tab baru"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -488,7 +524,7 @@ msgstr "Perintah _Suai"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Keutamaan"
 
@@ -513,12 +549,12 @@ msgid "Enabled"
 msgstr "Dibenarkan"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Nama"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Perintah"
 
@@ -624,7 +660,7 @@ msgid "Escape sequence"
 msgstr "Jujukan Esc"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Semua"
 
@@ -897,250 +933,218 @@ msgid "Tabs scroll buttons"
 msgstr "Butang tatal tab"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Palang Tajuk Terminal</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Warna fon:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Latar Belakang:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Terfokus"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Tidak Aktif"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Penerimaan"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Sembunyi saiz dari tajuk"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "G_una fon sistem"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Fon:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Pilih Fon Palang Tajuk"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Sejagat"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Guna fon lebar-tetap sistem"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Fon:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Pilih Fon Terminal"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Benarkan teks tebal"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Papar palang tajuk"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Salin ke pemilihan"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Aksara _dipilih-ikut-perkataan:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Kursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Bentuk:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Warna:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Kelip"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Latar Belakang:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "b>Loceng terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Ikon palang tajuk"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Denyar visual"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Bip boleh dengar"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Denyar senarai tetingkap"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Am"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Jalan perintah shell daftar masuk"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Jala_n perintah suai selain daripada shell"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Perintah s_uai:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Bila perintah _tamat:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Latar Hadapan dan Latar Belakang</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Guna warna mengikut tema sistem"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Skema terbina-dalam:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Warna _teks:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "Warna latar _belakang:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "_Skema terbina-dalam:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Warna p_alet:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Warna"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "Warna _tegar"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Latar belakang lutsinar"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Tiada</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Latar belakang"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "Palang tata_l adalah:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Tatal pada _output"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Tatal pada _ketukan kekunci"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Tatal Kembali Tak Terhingga"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Tatar _kembali:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "baris"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Penatalan"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1152,80 +1156,108 @@ msgstr ""
 "sekitar aplikasi dan sistem operasi tertentu yang mempunyai perilaku "
 "terminal yang berbeza.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Kekunci _Backspace menjana:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Kekunci _Del menjana:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Tetap semula pilihan keserasian kepada Lalai"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Keserasian"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Terfokus"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Tidak Aktif"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Penerimaan"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Sembunyi saiz dari tajuk"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "G_una fon sistem"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Pilih Fon Palang Tajuk"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Jenis"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Perintah suai:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Direktori kerja:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Bentangan"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Tindakan"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Pengikatan kekunci"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Pengikatan kekunci"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Pemalam"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Pemalam ini tidak mempunyai pilihan konfigurasi"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Pemalam"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1250,18 +1282,18 @@ msgstr ""
 "apa juag cadangan, sila failkan pepijat senarai idaman! (sila rujuk ke "
 "pautan Pembangunan)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Panduan"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Perihal"
 
@@ -1494,82 +1526,94 @@ msgid "Ungroup all terminals"
 msgstr "Nyahkumpul semua terminal"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Kumpul terminal dalam tab"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Kumpul/Nyahkumpul terminal dalam tab"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Nyahkumpul terminal dalam tab"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Cipta tetingkap baharu"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Wujudkan proses Terminator baharu"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Jangan siarkan ketukan kekunci"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Siarkan ketukan kekunci ke kumpulan"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Siarkan peristiwa kekunci kepada semua"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Sisip nombor terminal"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Sisip nombor terminal beralas"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Sunting tajuk tetingkap"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Buka tetingkap pelancar bentangan"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Tukar ke profil berikutnya"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Tukar ke profil terdahulu"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Buka panduan"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Profil Baru"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Bentangan Baru"
 
@@ -1614,141 +1658,153 @@ msgstr "Sa_lin"
 msgid "_Paste"
 msgstr "Tam_pal"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Bahagikan secara Mencancang"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "bahagikan secara Mendatar"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Buka _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Buka _Debug Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Tutup"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Besarkan terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Pulih semua terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Pengumpulan"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Papar _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Mengenkodkan"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Lalai"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Ditakrif pengguna"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Pengenkodan Lain"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "Kumpulan _baharu..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Tiada"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Buang kumpulan %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "K_umpul semua dalam tab"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "N_yahkumpul semua dalam tab"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Buang semua kumpulan"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Tutup kumpulan %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Siar semu_a"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Siar _kumpulan"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Siaran _mati"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "_Pisah ke kumpulan ini"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Auto-k_osongkan kumpulan"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "S_isip bilangan terminal"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Sisip bilangan terminal ter_padat"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Gagal mencari shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Tidak boleh mulakan shell:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Nama Semula Tetingkap"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Masukkan tajuk baru untuk tetingkap Terminator..."
 
@@ -1852,11 +1908,31 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "tetingkap"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Palang Tajuk Terminal</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Warna fon:"
+
+#~ msgid "Color:"
+#~ msgstr "Warna:"
+
+#~ msgid "_Text color:"
+#~ msgstr "Warna _teks:"
+
+#~ msgid "_Background color:"
+#~ msgstr "Warna latar _belakang:"

--- a/po/nb.po
+++ b/po/nb.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Norwegian Bokmål (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,24 +94,40 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -108,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Flere terminaler i ett vindu"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -349,7 +377,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -357,48 +385,48 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "fane"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Lukk fane"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Vis programversjon"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "La vinduet fylle skjermen"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Skru av vinduskanter"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Skjul vindu ved oppstart"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Spesifiser en tittel for vinduet"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Velg foretrukket størrelse og posisjon for vinduet (se «man»-siden for X)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Oppgi en kommando som skal utføres i terminalen"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -406,60 +434,68 @@ msgstr ""
 "Bruk resten av kommandolinja som en kommando som - inkludert argumenter - "
 "skal kjøres i terminalen"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Spesifiser en konfigurasjonsfil"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Velg arbeidskatalog"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Gi vinduet selvvalgt ikon (ved fil eller navn)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Gi vinduet selvvalgt verdi for WM_WINDOW_ROLE"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Bruk en annen profil som standard"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Deaktiver DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Aktiver feilsøkingsinformasjon (to ganger for feilsøkingstjener)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Kommaseparert liste over klasser som feilsøkinga skal begrenses til"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Kommaseparert liste over metoder som feilsøkinga skal begrenses til"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Åpne en ny fane hvis Terminator allerede kjører"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -486,7 +522,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Innstillinger"
 
@@ -511,12 +547,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Kommando"
 
@@ -622,7 +658,7 @@ msgid "Escape sequence"
 msgstr "Escape-sekvens"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Alle"
 
@@ -895,250 +931,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Skrifttype:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Globalt"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Bruk systemets skrift med fast bredde"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Skrifttype:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Velg en skrifttype for terminalen"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Tillat uthevet tekst"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Vis tittellinje"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Kopier ved utvalg"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Velg-etter-_ord tegn:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Markør</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Varsellyd i terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Ikon i tittelinje"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Visuelt blink"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Hørbart pip"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Vindusliste blink"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Generelt"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Kjør kommandoen som et innloggingsskall"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Kjør sel_vvalgt kommando i stedet for skallet"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Selvvalgt ko_mmando:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Når kommandoen _avslutter:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Forgrunn og bakgrunn</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "Br_uk farger fra systemtemaet"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Innebygde oppsett:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Tekstfarge:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Bakgrunnsfarge:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Palett</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Innebygde opp_sett:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Fargep_alett:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Farger"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Helfylt farge"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Gjennomsik_tig bakgrunn"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ingen</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Rullefeltet er:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Rull når noe skjer i terminalen"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Rull ned ved tastetry_kk"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Uendelig tilbakerulling"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Til_bakerulling:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "linjer"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Rulling"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1151,80 +1155,108 @@ msgstr ""
 "terminaler fungerer annerledes enn dette programmet gjør som standard.</i></"
 "small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Rettetasten genererer:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "_Delete-tasten genererer:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Sett kompatibilitetsalternativene til standard"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiler"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Utforminger"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Tastaturbindinger"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Dette programtillegget har ingen tilgjengelige brukervalg"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Programtillegg"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1238,18 +1270,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1482,82 +1514,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Sett inn terminal nummer"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Sett inn utfylt terminalnummer"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Sett inn terminal nummer"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Sett inn utfylt terminalnummer"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Ny Profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Ny Side"
 
@@ -1602,141 +1646,153 @@ msgstr "_Kopier"
 msgid "_Paste"
 msgstr "_Lim inn"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Splitt H_orisontalt"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Splitt V_ertikalt"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Åpne _Fane"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Åpne :Debug Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zoom inn på terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Gjenoppta alle terminaler"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Gruppering"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Vis _rullefelt"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Tegnkodinger"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Standard"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Brukerdefinert"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Andre tegnkodinger"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Fjern gruppe %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_ruppe alle i tab"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Fjern alle grupper"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Lukk gruppe %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Klarer ikke å finne et skall"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Kan ikke starte shell:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Gi nytt navn til vinduet"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Skriv en ny tittel på Terminator-vinduet..."
 
@@ -1840,11 +1896,22 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "vindu"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Tekstfarge:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Bakgrunnsfarge:"

--- a/po/nl.po
+++ b/po/nl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Dutch (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -83,7 +95,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -91,18 +103,34 @@ msgstr ""
 "* Deze items vereisen ofwel TERMINATOR_UUID omgeving var,\n"
 "  of de --uuid optie moet gebruikt worden."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "Terminal UUID voor wanneer niet in env var TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -111,7 +139,7 @@ msgid "Multiple terminals in one window"
 msgstr "Meerdere terminals in één venster"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "De robottoekomst van terminals"
 
@@ -356,7 +384,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Lay-out van de Terminator-starter"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Lay-out"
 
@@ -364,48 +392,48 @@ msgstr "Lay-out"
 msgid "Launch"
 msgstr "Voer uit"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tabblad"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Tabblad sluiten"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Versienummer van het programma weergeven"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximaliseer het venster"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Laat het venster het hele scherm vullen"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Vensterranden uitschakelen"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Het venster verborgen opstarten"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Geef een titel voor het venster"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "De gewenste grootte en positie van het venster instellen (zie X man pagina)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Geef een commando om in een Terminal uit te voeren"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -413,60 +441,68 @@ msgstr ""
 "Gebruik de rest van de opdrachtregel om als opdracht uit te voeren in de "
 "Terminal en zijn argumenten"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Specifieer een config bestand"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Werkmap instellen"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Stel een aangepast icoon voor het venster in (door bestand of naam)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Stel een eigen WM_WINDOW_ROLE in voor het venster"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Start op met de gegeven lay-out"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Kies een lay-out uit de lijst"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Gebruik een ander profiel dan standaard ingesteld"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "DBus Uitschakelen"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Debuginformatie aanzetten (twee maal voor serverdebug)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Kommagescheiden lijst van klassen als limiet om te debuggen"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Kommagescheiden lijst van methoden als limiet om te debuggen"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Als Terminator al wordt uitgevoerd, open dan een nieuwe tabblad"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -493,7 +529,7 @@ msgstr "_Eigen Commando's"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Voorkeuren"
 
@@ -518,12 +554,12 @@ msgid "Enabled"
 msgstr "Ingeschakeld"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Naam"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Commando"
 
@@ -629,7 +665,7 @@ msgid "Escape sequence"
 msgstr "Escape-reeks"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Alle"
 
@@ -902,250 +938,218 @@ msgid "Tabs scroll buttons"
 msgstr "Scrollknoppen op tabbladen"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Titelbalk van terminal</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Tekstkleur:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Achtergrond:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Gefocust"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Inactief"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Bezig met ontvangen"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Grootte verbergen in titel"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "Systeemlettertype _gebruiken"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Lettertype:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Kies een lettertype voor de titelbalk"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Globaal"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profiel"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "Standaard vaste _breedte-lettertype gebruiken"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Lettertype:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Kies een terminalvenster-lettertype"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Vetgedrukte tekst toestaan"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Titelbalk weergeven"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Kopiëren wanneer tekst wordt geselecteerd"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "_Selecteer-op-woord tekens:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Vorm:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Kleur:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Knipperen"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Voorgrond"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Achtergrond:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminalbel</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Titelbalkpictogram"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Visuele flits"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Hoorbare pieptoon"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Vensterlijst-flits"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Algemeen"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "Opdracht _uitvoeren als inlogshell"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Aangepaste opdracht _uitvoeren in plaats van mijn shell"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Aangepaste _opdracht:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Wanneer opdracht _eindigt:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Voor- en achtergrond</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "Kleuren van het s_ysteemthema gebruiken"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "_Ingebouwde schema's:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Tekstkleur:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "Achter_grondkleur:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Kleurenpalet</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Ingebouwde _schema's:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Kleuren_palet:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Kleuren"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Effen kleur"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Transparante achtergrond"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Geen</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Achtergrond"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Schuifbalk is:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "S_chuiven bij nieuwe uitvoer"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Schuiven _bij een toetsaanslag"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Oneindig terugschuiven"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "_Terugschuiven:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "regels"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Verschuiving"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1157,80 +1161,108 @@ msgstr ""
 "toepassingen en besturingssystemen, die een ander terminalgedrag verwachten, "
 "heen kunt werken.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "_Backspace-toets genereert:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "_Delete-toets genereert:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Tekenset:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Compatibiliteitsopties terugzetten op standaardwaarden"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Compatibiliteit"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Gefocust"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Inactief"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Bezig met ontvangen"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Grootte verbergen in titel"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "Systeemlettertype _gebruiken"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Kies een lettertype voor de titelbalk"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profielen"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Soort"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profiel:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Aangepaste opdracht:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Werkmap:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Indelingen"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Actie"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Toetsbinding"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Toetsbindingen"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Plug-in"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Deze plug-in heeft geen configuratieopties"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1255,18 +1287,18 @@ msgstr ""
 "gebrukers. Als je suggesties hebt, gelieve dit te melden in de verlanglijst "
 "bugs! (zie links voor de ontwikkeling link)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "De handleiding"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Over"
 
@@ -1499,82 +1531,94 @@ msgid "Ungroup all terminals"
 msgstr "Alle terminalvenster de-groeperen"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Terminalvensters groeperen op tabblad"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Terminalvensters groepren/de-groeperen op tabblad"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Terminalvensters de-groeperen op tabblad"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Een nieuw venster creëren"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Creër een nieuw Terminator proces"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Zend geen toetsaanslagen uit"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Zend toetsaanslagen uit naar groep"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Broadcast belangrijke gebeurtenissen voor alle"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Terminalnummer invoegen"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Aangevuld terminalnummer invoegen"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Venstertitel wijzigen"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Terminaaltitel wijzigen"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Tabbladtitel Wijzigen"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Schakel over naar volgend profiel"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Schakel over naar vorig profiel"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Handleiding openen"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nieuw profiel"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nieuwe lay-out"
 
@@ -1619,141 +1663,153 @@ msgstr "_Kopiëren"
 msgid "_Paste"
 msgstr "_Plakken"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Splits H_orizontaal"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Splits V_erticaal"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Nieuw _tabblad"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Open_Debug Tabblad"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Sluiten"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "Terminal in_zoomen"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Terminaal ma_ximaliseren"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "Alle terminals he_rstellen"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Groepering"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Laat scroll balk zien"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Tekensets"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Standaard"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Aangepast"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Andere tekensets"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "N_ieuwe groep..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Geen"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Groep %s verwijderen"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_roepeer alle terminals in het tabblad"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Alle groepen opheffen"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Sluit groep %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Broadcast _alle"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "uitzend_groep"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "uitzenden_af"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "_Splits naar deze groep"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Auto-opschonen groepen"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_voeg terminal nummer in"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Geen shell gevonden"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Kan shell niet starten:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Hernoem venster"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1857,11 +1913,34 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "venster"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Tabblad %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Titelbalk van terminal</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Tekstkleur:"
+
+#~ msgid "Color:"
+#~ msgstr "Kleur:"
+
+#~ msgid "Foreground"
+#~ msgstr "Voorgrond"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Tekstkleur:"
+
+#~ msgid "_Background color:"
+#~ msgstr "Achter_grondkleur:"

--- a/po/nn.po
+++ b/po/nn.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Norwegian Nynorsk (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Splitt H_orisontalt"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Splitt V_ertikalt"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/oc.po
+++ b/po/oc.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Occitan (post 1500) (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Permet d'aver mantun terminal dins una sola fenèstra"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Presentacion"
 
@@ -354,106 +382,114 @@ msgstr "Presentacion"
 msgid "Launch"
 msgstr "Aviar"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tabulacion"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Tampar l'onglet"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Aficha la version del programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximiza la fenèstra"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Met la fenèstra en mòde ecran complet"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Desactiva los bòrds de la fenèstra"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Amaga la fenèstra a l'aviada"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Especifica un títol per la fenèstra"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Definís lo repertòri de trabalh"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Aviar amb la disposicion donada"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Seleccionar una disposicion dempuèi una lista"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Desactiva DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferéncias"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Tot"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Perfils"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Inserir lo numèro de terminal"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Inserir lo numèro de terminal"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Perfil novèl"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Agençament novèl"
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Devesir _orizontalament"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Devesir v_erticalament"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Dobrir un ongle_t"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zoomar lo terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restablir totes los terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Regropament"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Far veire la barra de desfilament"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Encodatges"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Per defaut"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definit per l'utilizaire"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Autres  Encodatges"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Suprimir lo grop %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Ag_ropar dins un sol tablèau"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Suprimir totes los gropes"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Tampar lo grop %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Impossible de trobar un shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "fenèstra"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Tablèu %d"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Markus Frosch <markus@lazyfrosch.de>, 2021\n"
 "Language-Team: Polish (https://www.transifex.com/terminator/teams/109338/"
@@ -71,10 +71,22 @@ msgid "Set the title of a parent tab"
 msgstr "Zmień tytuł karty nadrzędnej"
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -85,7 +97,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -93,19 +105,35 @@ msgstr ""
 "* Te opcje wymagają albo zmiennej środowiskowej TERMINATOR_UUID,\n"
 "  albo opcja --uuid musi zostać użyta."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 "Terminal UUID jeśli nie znajduje się w zmiennej środowiskowej TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -114,7 +142,7 @@ msgid "Multiple terminals in one window"
 msgstr "Wiele terminali w jednym oknie"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Robotyczna przyszłość terminali"
 
@@ -367,7 +395,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Uruchamianie układu Terminatora"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Układ"
 
@@ -375,47 +403,47 @@ msgstr "Układ"
 msgid "Launch"
 msgstr "Uruchom"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "karta"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Zamknij kartę"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Pokaż wersję programu"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maksymalizuj okno"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Stwórz okno wypełniające ekran"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Wyłącz obramowanie okna"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Ukryj okno podczas startu"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Podaj tytuł (nazwę) okna"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Ustaw żądany rozmiar i położenie okna (zobacz stronę podręcznika X-ów)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Podaj polecenie do wykonania w terminalu"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -423,62 +451,71 @@ msgstr ""
 "Użyj reszty wiersza poleceń jako polecenie do wykonania w terminalu i jego "
 "argumenty"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Wskaż plik konfiguracyjny"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr "Wskaż częściowy plik konfiguracyjny json"
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Ustaw katalog roboczy"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Ustaw niestandardową ikonę okna (przez archiwum lub plik)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Ustaw niestandardową właściwość okna WM_WINDOW_ROLE"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Uruchom z wybranym układem"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Wybierz układ z listy"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Domyślnie użyj innego profilu"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Wyłącz DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Włącz informacje debuggera  (podwójnie dla serwera debuggera)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Lista oddzielonych przecinkami klas w celu ograniczenia debugowania do"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 "Lista oddzielonych przecinkami metod w celu ograniczenia debugowania do"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Jeśli Terminator jest już uruchomiony, utwórz nową zakładkę"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
-msgstr "Jeśli Terminator już działa w tle, po prostu pokaż wszystkie ukryte okna"
+msgstr ""
+"Jeśli Terminator już działa w tle, po prostu pokaż wszystkie ukryte okna"
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
+msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
 msgid "Watch for _activity"
@@ -504,7 +541,7 @@ msgstr "_Niestandardowe komendy"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferencje"
 
@@ -529,12 +566,12 @@ msgid "Enabled"
 msgstr "Aktywne"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Nazwa"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Polecenie"
 
@@ -640,7 +677,7 @@ msgid "Escape sequence"
 msgstr "Sekwencja sterująca"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Wszystko"
 
@@ -913,250 +950,218 @@ msgid "Tabs scroll buttons"
 msgstr "Przycisk przewijania kart"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Pasek tytułowy terminala</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Kolor czcionki:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Tło:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Aktywny"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Nieaktywny"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Odbieranie"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr "Pasek tytułowy na dole (wymagany restart)"
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Ukryj rozmiar w tytule"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Użyj czcionki systemowej"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Czcionka:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Wybierz czcionkę paska tytułu"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Ogólne"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Systemowa czcionka o stałej szerokości"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Czcionka:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Wybór czcionki terminala"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "Zezwolenie na pogru_biony tekst"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Pokaż pasek tytułowy"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Kopiuj zaznaczone"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Wyłącz zoom za pomocą Ctrl+kółko myszy"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Znaki należące do _słowa przy zaznaczaniu:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Kursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "K_ształt:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Kolor:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Miganie"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Kolor pierwszoplanowy"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Tło:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Dzwonek terminala</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Ikona paska tytułu"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Wizualny rozbłysk"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Sygnał dźwiękowy"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Lista aktywnych okien"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Ogólne"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Uruchomienie w roli powłoki startowej"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Uru_chamia własne polecenie zamiast powłoki"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Własne polecenie:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "_Po zakończeniu polecenia:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Pierwszy plan i tło</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Kolory z motywu systemowego"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "_Wbudowane schematy:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Kolor tekstu:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Kolor tła:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Wbudowane _schematy:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Paleta _kolorów:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr "Pokaż pogrubiony tekst jaskrawymi kolorami"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Kolory"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Jednolity kolor"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Przezroczyste tło"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr "Obraz tła"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr "Plik obrazu tła"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr "Wybierz plik"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Brak</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Tło"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Położenie paska przewijania:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Przewijanie przy pojawieniu się _nowych danych"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Przewijanie przy _naciśnięciu klawisza"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Nieskończone przewijanie"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "_Bufor przewijania:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "linii"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Przewijanie"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1168,80 +1173,108 @@ msgstr ""
 "pewnymi programami i systemami operacyjnymi, które oczekują innego "
 "zachowania się terminala.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Klawisz _Backspace generuje:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Klawisz _Delete generuje:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Kodowanie:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Przywróć domyślne wartości opcji zgodności"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Zgodność"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Aktywny"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Nieaktywny"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Odbieranie"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Ukryj rozmiar w tytule"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Użyj czcionki systemowej"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Wybierz czcionkę paska tytułu"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profile"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Rodzaj"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Niestandardowe polecenie:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Katalog roboczy:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Układy"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Czynność"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Skrót klawiszowy"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Skróty klawiszowe"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Wtyczka"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Ta wtyczka nie ma żadnych opcji konfiguracyjnych"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Wtyczki"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1265,11 +1298,11 @@ msgstr ""
 "Jeśli masz jakieś sugestie, zgłoś błędy na liście życzeń! (link Development "
 "po lewej stronie)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Podręcznik"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
@@ -1279,7 +1312,7 @@ msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Błędy / "
 "Poprawki</a>"
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "O programie"
 
@@ -1512,82 +1545,94 @@ msgid "Ungroup all terminals"
 msgstr "Rozgrupuj wszystkie terminale"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Grupuj terminale w karcie"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Zgrupuj/Rozgrupuj termnale w zakładki"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Rozgrupuj termnale w zakłądki"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Tworzy nowe okno"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Utwórz nowy proces Terminatora"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Nie przekazuj naciśnięć klawiszy"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Przekazuj naciśnięcia klawiszy do grupy"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Nadawaj kluczowe wydarzenia do wszystkich"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Wstaw numer terminala"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Wstaw wyrównany numer terminala"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Edytuj tytuł okna"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Edytuj tytuł terminala"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Edytuj tytuł karty"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Otwórz okno uruchamiania układu"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Przełącz do następnego profilu"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Przełącz do poprzedniego profilu"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr "Otwórz okno preferencji"
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Otwiera podręcznik użytkownika"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nowy profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nowy układ"
 
@@ -1632,141 +1677,153 @@ msgstr "_Kopiuj"
 msgid "_Paste"
 msgstr "Wk_lej"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Podziel w p_oziomie"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Pozdziel w pioni_e"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "O_twórz kartę"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Otwórz kartę _debugowania"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Zamknij"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "Powięks_z terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "_Maksymalizuj terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Przywróć wszystkie terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Grupowanie"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Pokaż _pasek przewijania"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr "Układy..."
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kodowania"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Domyślne"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Zdefiniowane przez użytkownika"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Inne kodowania"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "Nowa grupa..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Brak"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Usuń grupę %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_rupuj wszystko w zakładkach"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Rozgrupuj wszytsko w zakładki"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Usuń wszystkie grupy"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Zamknij grupę %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Nadawanie do wszystkich"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Nadawanie do grupy"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Wyłącz nadawanie"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "Rozdziel do tej grupy"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Automatyczne czyszczenie grup"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "Wprowadź numer terminalu"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Wstaw _wyrównany numer terminala"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Nie można odnaleźć powłoki"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Nie można włączyć powłoki:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Zmiana nazwy okna"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Wpisz nowy tytuł dla okna Terminatora..."
 
@@ -1870,14 +1927,37 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "okno"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Karta %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Pasek tytułowy terminala</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Kolor czcionki:"
+
+#~ msgid "Color:"
+#~ msgstr "Kolor:"
+
+#~ msgid "Foreground"
+#~ msgstr "Kolor pierwszoplanowy"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Kolor tekstu:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Kolor tła:"
 
 #~ msgid "Version: 2.0.1"
 #~ msgstr "Wersja: 2.0.1"

--- a/po/pt.po
+++ b/po/pt.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Portuguese (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -90,18 +102,34 @@ msgstr ""
 "* Estas entradas requerem a variável de ambiente TERMINATOR_UUID\n"
 "   ou a utilização da opção --uuid."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "UUID do terminal se não existir a variável TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -110,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Múltiplos Terminais numa só janela"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "O robô futuro dos terminais"
 
@@ -356,7 +384,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Disposição"
 
@@ -364,47 +392,47 @@ msgstr "Disposição"
 msgid "Launch"
 msgstr "Iniciar"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "separador"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Fechar separador"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Mostrar versão do programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximizar janela"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Ajustar janela ao ecrã"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Desativar contornos das janelas"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Ocultar janela ao iniciar"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Especificar o título da janela"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Definir o tamanho preferido e posição da janela (ver o manual do X)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Especificar o comando a executar no terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -412,60 +440,68 @@ msgstr ""
 "Utilizar o resto da linha de comandos e os seus argumentos como o comando a "
 "executar no terminal"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Especificar um ficheiro de configuração"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Definir diretório de trabalho"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Definir um ícone personalizado para a janela (por ficheiro ou nome)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Definir a propriedade \\\"WM_WINDOW_ROLE\\\" na janela"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Iniciar com a disposição indicada"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Selecione uma disposição da lista"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Utilizar um perfil diferente como padrão"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Desativar DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Ativar informação de depuração (2 vezes para o servidor)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Classes, separadas por vírgulas, para limitar a depuração a"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Métodos, separados por vírgula,s para limitar a depuração a"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Se o Terminator já está em execução, basta abrir um novo separador"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -492,7 +528,7 @@ msgstr "_Comandos personalizados"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferências"
 
@@ -517,12 +553,12 @@ msgid "Enabled"
 msgstr "Ativo"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Nome"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Comando"
 
@@ -628,7 +664,7 @@ msgid "Escape sequence"
 msgstr "Sequência de escape"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Tudo"
 
@@ -901,250 +937,218 @@ msgid "Tabs scroll buttons"
 msgstr "Botões de deslocação dos separadores"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Barra de título do terminal</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Cor do tipo de letra:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Fundo:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Focado"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Inativo"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "A receber"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Ocultar tamanho do título"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Usar tipo de letra do sistema"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Tipo de letra:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Escolha o tipo de letra para o título"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Perfil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Usar tipo de letra de largura fixa do sistema"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Tipo de letra:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Escolha o tipo de letra do terminal"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Permitir texto negrito"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Mostrar barra de título"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Copiar na seleção"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Selecionar _caracteres da palavra:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Forma:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Cor:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Intermitente"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Principal"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Fundo:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Notificação do terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Ícone da barra de título"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Visual"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Notificação sonora"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Intermitência na lista de janelas"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Geral"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "Executa_r comando numa consola"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Executar um coma_ndo personalizado em vez da minha consola"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Co_mando personalizado:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Ao sair do _comando:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Cor principal e secundária</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Usar cores do tema do sistema"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Esque_mas internos:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Cor do _texto:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "Cor de _fundo:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "E_squemas internos:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "P_aleta de cores:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Cores"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "Cor _sólida"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Fundo _transparente"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Nenhum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Máximo</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Fundo"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "Barra de _deslocação é:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Desl_ocar na saída de"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Deslocar ao premir a _tecla"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Deslocação infinita"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Deslocação para _trás:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "linhas"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Deslocação"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1156,80 +1160,108 @@ msgstr ""
 "contornar determinadas aplicações e sistemas operativos que esperam um "
 "comportamento diferente do terminal.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Tecla _Backspace gera:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Tecla _Delete gera:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Codificação:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Reiniciar opções de compatibilidade originais"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Focado"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Inativo"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "A receber"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Ocultar tamanho do título"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Usar tipo de letra do sistema"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Escolha o tipo de letra para o título"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Perfis"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Tipo"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Perfil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Comando personalizado:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Diretório de trabalho:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Disposições"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Ação"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Associação de tecla"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Associação de teclas"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Este plug-in não tem opções de configuração"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1254,18 +1286,18 @@ msgstr ""
 "alguma sugestão, preencha a wishlist de erros.(ver à esquerda o link "
 "Development)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "O Manual"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Acerca"
 
@@ -1498,82 +1530,94 @@ msgid "Ungroup all terminals"
 msgstr "Deagrupar todos os terminais"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Agrupar terminais para um separador"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Agrupar/desagrupar terminais para um separador"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Desagrupar terminais do separador"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Criar nova janela"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Expandir novo processo terminator"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Não difundir pressões de teclas"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Difundir pressões de teclas para o grupo"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Difundir eventos de teclas para tudo"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Inserir número de terminal"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Inserir número do terminal almofadado"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Editar título da janela"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Editar título do terminal"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Editar título do separador"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Trocar para o perfil seguinte"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Trocar para o perfil anterior"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Abrir o manual"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Novo perfil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nova disposição"
 
@@ -1618,141 +1662,153 @@ msgstr "_Copiar"
 msgid "_Paste"
 msgstr "Co_lar"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Dividir h_orizontalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Dividir v_erticalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Abrir _separador"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Abrir separador de _depuração"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "Fe_char"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Ampliar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximizar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restaurar todos os terminais"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Agrupamento"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Mostrar barra de de_slocação"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Codificação"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Padrão"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definido pelo utilizador"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Outras codificações"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "N_ovo grupo..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Nenhum"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Remover o grupo %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Ag_rupar tudo num separador"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Desagr_upar tudo no separador"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Remover todos os grupos"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Fechar o grupo %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Difubdir tod_as"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Difundir _grupo"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Difusã_o desativada"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "_Separar este grupo"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Limpar grupos automati_camente"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Inserir número do terminal"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Incapaz de encontrar a consola"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Incapaz de iniciar a consola:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Renomear janela"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Digite o novo título para a janela Terminator..."
 
@@ -1856,11 +1912,34 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Ómega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "janela"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Separador %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Barra de título do terminal</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Cor do tipo de letra:"
+
+#~ msgid "Color:"
+#~ msgstr "Cor:"
+
+#~ msgid "Foreground"
+#~ msgstr "Principal"
+
+#~ msgid "_Text color:"
+#~ msgstr "Cor do _texto:"
+
+#~ msgid "_Background color:"
+#~ msgstr "Cor de _fundo:"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2021-03-21 10:58-0300\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -81,7 +93,7 @@ msgstr ""
 "Executar um dos seguintes comandos Terminator DBus\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -89,18 +101,34 @@ msgstr ""
 "* Essas entradas requerem um ambiente var TERMINATOR_UUID\n"
 "ou a opção --uuid deve ser utilizada"
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "Terminal UUID para quando não estiver em TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -109,7 +137,7 @@ msgid "Multiple terminals in one window"
 msgstr "Múltiplos terminais em uma janela"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "O robo do futuro dos terminais"
 
@@ -354,7 +382,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Lançador de grupo de terminais"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Layout / Grupo"
 
@@ -362,47 +390,47 @@ msgstr "Layout / Grupo"
 msgid "Launch"
 msgstr "Iniciar"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "aba"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Fechar aba"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Exibir a versão do programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximizar janela"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Fazer com que a janela preencha a tela"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Desativar bordas de janela"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Esconder a janela no início"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Especificar um título para a janela"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Ajustar tamanho e posição preferido da janela(veja man page do X)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Especificar um comando para executar no terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -410,61 +438,69 @@ msgstr ""
 "Usar o resto da linha de comando como um comando a ser executado no "
 "terminal, com seus argumentos."
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Especificar um arquivo de configuração"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Definir o diretório de trabalho"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Indique um ícone personalizado para a janela (por arquivo ou nome)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Configurar uma propriedade WM_WINDOW_ROLE personalizada na janela"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Iniciar com determinado layout/grupo"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Selecionar um layout/grupo de uma lista"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Usar um perfil diferente como padrão"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Desativar o DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 "Ativar informação de depuração (duas vezes para um servidor de depuração)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Lista separada por vírgulas das classes para limitar a depuração"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Lista separada por vírgulas dos métodos para limitar a depuração"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Se o Terminator já estiver sendo executado, apenas abrir nova aba"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -491,7 +527,7 @@ msgstr "_Comandos Personalizados"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferências"
 
@@ -516,12 +552,12 @@ msgid "Enabled"
 msgstr "Habilitado"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Nome"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Comando"
 
@@ -627,7 +663,7 @@ msgid "Escape sequence"
 msgstr "Sequência de escape"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Todos"
 
@@ -900,250 +936,218 @@ msgid "Tabs scroll buttons"
 msgstr "Aba de botões de rolagem"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Barra de Títulos do Terminal</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Cor da fonte:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Fundo:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Foco"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Inativo"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Recebendo"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Esconder tamanho do título"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Utilizar a fonte do sistema"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Fonte:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Escolher Uma Fonte para Barra de Títulos"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Perfil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Usar a fonte  padrão do sistema"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Fonte:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Escolha uma fonte para o terminal"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Permitir texto em negrito"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Mostra barra de título"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Copiar na seleção"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Caracteres para selecionar por p_alavra:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Forma"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Cor:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Piscar"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Primeiro plano"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Fundo:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Som do terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Ícone da barra de título"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Flash visual"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Som audível"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Piscar lista de janela"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Geral"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Executar comando como shell de login"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Executar um coma_ndo personalizado ao invés do shell padrão"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Co_mando personalizado:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Quando o comando _terminar:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Texto e Fundo</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "Usar cores do tema do s_istema"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Es_quemas embutidos:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Cor do _texto:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "Cor do plano de fun_do:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "E_squemas embutidos:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "_Paleta de cores:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Cores"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Cor Sólida"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Fundo Transparente"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Nenhum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Máximo</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Plano de fundo"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Barra de rolagem:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "_Rolar com a saída"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Rolar ao _pressionar teclado"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Navegação Infinita"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "R_olar para trás:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "linhas"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Rolagem"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1155,80 +1159,108 @@ msgstr ""
 "contorne certos aplicativos e sistemas operacionais que esperam um "
 "comportamento diferente do terminal.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Tecla _Backspace gera:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Tecla _Delete gera:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Codificação"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Restaurar padrões para as opções de compatibilidade"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Foco"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Inativo"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Recebendo"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Esconder tamanho do título"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Utilizar a fonte do sistema"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Escolher Uma Fonte para Barra de Títulos"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Perfis"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Tipo"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Perfil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Comando personalizado"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Diretório de trabalho:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Disposições"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Ação"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Associação de tecla"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Associações de teclas"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Esse plug-in não tem opções de configuração"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1252,18 +1284,18 @@ msgstr ""
 "possíveis melhorias na lista de desejo! (Veja a esquerda para o link para "
 "desenvolvimento)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "O Manual"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Sobre"
 
@@ -1496,82 +1528,94 @@ msgid "Ungroup all terminals"
 msgstr "Desagrupar todos os terminais"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Agrupar os terminais em abas"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Agrupar/Desagrupar terminais em aba"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Desagrupar terminais em aba"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Criar uma nova janela"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Gerar um novo processo de terminal"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Não transmitir pressionamento de teclas"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Transmitir pressionamento de teclas para grupo"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Transmitir eventos chave para todos"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Insira o número do terminal"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Insira o número de terminais preenchidos"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Editar título da janela"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Editar título do terminal"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Editar título da guia"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Abrir janela lançador de layout"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Alternar para o próximo perfil"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Alternar para o perfil anterior"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Abrir o manual"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Novo perfil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nova disposição"
 
@@ -1616,141 +1660,153 @@ msgstr "_Copiar"
 msgid "_Paste"
 msgstr "_Colar"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Dividir H_orizontalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Dividir v_erticalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Abrir _aba"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Abrir aba de _depuração"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Fechar"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zoom terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximizar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restaurar todos os terminais"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Agrupando"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Mostrar  _barras de rolagem"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Codificações"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Padrão"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definido pelo usuário"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Outras codificações"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "Novo grupo..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Nenhum"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Remover grupo %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Ag_rupar tudo em uma aba"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Desagru_par todas as abas"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Remover todos grupos"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Fechar grupo %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Transmissão _todos"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Transmissão _grupo"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Transmissão _desativada"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "_Dividir para este grupo"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Limpar _grupos automaticamente"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Inserir número do terminal"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Inserir _monte de números de terminal"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Incapaz de encontrar um shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Incapaz de iniciar o shell:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Renomear janela"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Insira um novo título para a janela do terminal"
 
@@ -1854,11 +1910,34 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "janela"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Aba %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Barra de Títulos do Terminal</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Cor da fonte:"
+
+#~ msgid "Color:"
+#~ msgstr "Cor:"
+
+#~ msgid "Foreground"
+#~ msgstr "Primeiro plano"
+
+#~ msgid "_Text color:"
+#~ msgstr "Cor do _texto:"
+
+#~ msgid "_Background color:"
+#~ msgstr "Cor do plano de fun_do:"

--- a/po/ro.po
+++ b/po/ro.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Romanian (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -83,7 +95,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -91,20 +103,36 @@ msgstr ""
 "* Aceste intrari au nevoie fie de variabila de mediu TERMINATOR_UUID,\n"
 "  fie de optiunea --uuid sa fie setata."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 "UUID al terminalului pentru cazurile in care nu e setat in variabila de "
 "mediu TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -113,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Terminale multiple într-o singură fereastră"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Viitorul robot al terminalelor"
 
@@ -354,7 +382,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -362,47 +390,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Închide tab"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Afișează versiunea programului"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Fereastra să umple ecranul"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Dezactivează conturul ferestrelor"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Ascunde fereastra la pornire"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Specificați un titlu pentru fereastră"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Specificați o comandă pentru a fi executată în terminal"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -410,60 +438,68 @@ msgstr ""
 "Folosește restul liniei de comandă ca un ordin pentru a executa în terminal, "
 "cu argumente"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Definește dosarul de lucru"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Setează o proprietate specifică WM_WINDOW_ROLE ferestrei"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Utilizează un profil diferit ca profil implicit"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Dezactivează DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Permite informații depanatoare (de doua ori pentru serverul depanator)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Listă de clase separată de virgulă pentru a limita depanarea la"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Listă de metode separată de virgulă pentru a limita depanarea la"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -490,7 +526,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Preferințe"
 
@@ -515,12 +551,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -626,7 +662,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Toate"
 
@@ -899,250 +935,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1150,80 +1154,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profile"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1237,18 +1269,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1481,82 +1513,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Introdu numărul de terminal"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Inserează numărul de completare terminal"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Introdu numărul de terminal"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Inserează numărul de completare terminal"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Profil nou"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Mod de aranjare nou"
 
@@ -1601,141 +1645,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Împarte _orizontal"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Împarte v_ertical"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Deschide _tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Deschide tab de _depanare"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "Panoramea_ză terminalul"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Restaurează toate terminalele"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Grupare"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Arată _bara de derulare"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Codificări"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Implicit"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definit de utilizator"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Alte codificări"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Șterge grupul %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_rupează totul in tab"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Șterge toate grupele"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Închide grupa %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Nu s-a găsit niciun shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Imposibil de pornit shell-ul"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1839,11 +1895,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "fereastră"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"

--- a/po/ru.po
+++ b/po/ru.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Russian (https://www.transifex.com/terminator/teams/109338/"
@@ -70,10 +70,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -84,7 +96,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -92,20 +104,36 @@ msgstr ""
 "Эти данные требуют значения переменной окружения TERMINATOR_UUID\n"
 "  или опции --uuid."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 "Стандартный UUID для терминала, если не задан другой в переменной окружения "
 "TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -114,7 +142,7 @@ msgid "Multiple terminals in one window"
 msgstr "Несколько терминалов в одном окне"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Технологии будущего для терминалов"
 
@@ -361,7 +389,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Запуск компоновки Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Компоновка"
 
@@ -369,48 +397,48 @@ msgstr "Компоновка"
 msgid "Launch"
 msgstr "Запустить"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "вкладка"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Закрыть вкладку"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Версия программы"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Развернуь окно"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "На весь экран"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Не показывать границы окна"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Скрыть окно при запуске"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Название для окна"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Установите нужный размер и положение окна (см. справочную страницу Иксов)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Команда для выполнения в терминале"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -418,60 +446,68 @@ msgstr ""
 "Использовать для выполнения в терминале остаток командной строки как команду "
 "и её аргументы"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Укажите файл конфигурации"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Установить рабочий каталог"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Установить пользовательский значок для этого окна (по файлу или имени)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Установить в окне своё свойство WM_WINDOW_ROLE"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Запуск с заданной компоновкой элементов"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Выбор компоновки из списка"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Использовать другой профиль по умолчанию"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Не использовать DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Включить отладочную информацию (дважды для отладки сервера)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Разделенный запятыми список классов для ограничения отладки"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Разделенный запятыми список методов для ограничения отладки"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Если Терминатор уже запущен, просто откройте новую вкладку"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -498,7 +534,7 @@ msgstr "_Свои команды"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Параметры"
 
@@ -523,12 +559,12 @@ msgid "Enabled"
 msgstr "Включено"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Название"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Команда"
 
@@ -634,7 +670,7 @@ msgid "Escape sequence"
 msgstr "Escape-последовательность"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Все"
 
@@ -907,250 +943,218 @@ msgid "Tabs scroll buttons"
 msgstr "Кнопки переключения вкладок"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Название терминала</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Цвет шрифта:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Фон:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "В фокусе"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Неактивный"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Получение"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Убрать размер терминала из заголовка"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Использовать системный шрифт"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Шрифт:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Укажите шрифт заголовка"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Общий"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Профиль"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Использовать системный моноширинный шрифт"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Шрифт:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Выбрать шрифт терминала"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "Р_азрешать полужирный текст"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Показать заголовок"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Копирование на выбор"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Выбор _слов по символам:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Курсор </b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Форма"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Цвет:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Мерцание"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Передний План"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Фон:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Сигнал терминала</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Иконка заголовка"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Видимый сигнал (мигание)"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Звуковой сигнал"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Мигание окном"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Общий"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "За_пускать команду как оболочку входа"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Зап_ускать другую команду вместо моей оболочки"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Пользовательская к_оманда:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "При в_ыходе из команды:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Переднего и заднего плана</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Использовать цвета из системной темы"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Встроенные с_хемы:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Цвет _текста:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Цвет фона:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Палитра</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Встроенные сх_емы:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Цветовая _палитра:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Цвета"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Сплошной цвет"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Прозрачный фон"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Никакой</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Максимально</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Фон"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Полоса прокрутки:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Прокру_чивать при выводе"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Прок_ручивать при нажатии клавиши"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Бесконечная прокрутка"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "О_братная прокрутка:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "строки"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Прокрутка"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1162,80 +1166,108 @@ msgstr ""
 "работать с некоторыми приложениями и операционными ситемами, ожидающими "
 "другого поведения терминала. </i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Клавиша _Backspace генерирует:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Клавиша _Delete генерирует:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Кодировка:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Восстановить параметры совместимости по умолчанию"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Совместимость"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "В фокусе"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Неактивный"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Получение"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Убрать размер терминала из заголовка"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Использовать системный шрифт"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Укажите шрифт заголовка"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Профили"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Тип"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Профиль:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Пользовательская команда:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Рабочий каталог:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Шаблоны"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Действие"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Комбинация клавиш"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Комбинации клавиш"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Надстройка"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Этот плагин не имеет параметров конфигурации"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Модули"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1260,18 +1292,18 @@ msgstr ""
 "либо предложения, пожалуйста озвучьте их на багтрекере (wishlist bugs)! (см. "
 "сайт разработчиков)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Руководство"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Сведения о программе"
 
@@ -1504,82 +1536,94 @@ msgid "Ungroup all terminals"
 msgstr "Разгруппировать все терминалы"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Группировать терминалы во вкладке"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Группировать/разрознить терминалы во вкладке"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Разгруппировать терминалы во вкладке"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Создать новое окно"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Создать новый процесс Terminator'а"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Не транслировать нажатия клавиш"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Транслировать нажатия клавиш в группу терминалов"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Транслировать нажатия клавиш во все терминалы"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Вставить номер терминала"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Вставить номер терминала"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Изменить заголовок окна"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Изменить наименование терминала"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Изменить наименование вкладки"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Открыть окно компоновщика"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Переключиться на следующий профиль"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Переключиться на предыдущий профиль"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Открыть руководство"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Создать профиль"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Новое расположение"
 
@@ -1624,141 +1668,153 @@ msgstr "Копировать"
 msgid "_Paste"
 msgstr "Вст_авить"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Разделить экран г_оризонтально"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Разделить экран в_ертикально"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Открыть _вкладку"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Открыть отла_дочную вкладку"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "За_крыть"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Увеличить терминал"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Раз_вернуть терминал"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "Восстановить все терминалы"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Группирование"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Показать полосу прокрутки"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Кодировки"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "По умолчанию"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Пользовательский"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Другие кодировки"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "Новая гр_уппа..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Ничего"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Удалить группу %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "С_группировать всё во вкладке"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Раз_рознить терминалы во вкладке"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Удалить все группы"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Закрыть группу %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Транслировать во вс_е терминалы"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "Транслировать гру_ппе"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Отключить трансляцию клавиш"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "Поделить на _эту группу"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Автос_тирание у групп"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Добавить номер терминала"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Вставить _номер терминала"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Не удается найти оболочку (shell)"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Не удается запустить оболочку:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Переименование окна"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Введите новое название для окна Terminator..."
 
@@ -1862,11 +1918,34 @@ msgstr "Пси"
 msgid "Omega"
 msgstr "Омега"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "окно"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Вкладка %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Название терминала</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Цвет шрифта:"
+
+#~ msgid "Color:"
+#~ msgstr "Цвет:"
+
+#~ msgid "Foreground"
+#~ msgstr "Передний План"
+
+#~ msgid "_Text color:"
+#~ msgstr "Цвет _текста:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Цвет фона:"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Russian (Russia) (https://www.transifex.com/terminator/"
@@ -70,10 +70,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -81,24 +93,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Терминатор"
 
@@ -107,7 +135,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -348,7 +376,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -356,106 +384,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "таб"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Закрыть вкладку"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -482,7 +518,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -507,12 +543,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -618,7 +654,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -891,250 +927,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1142,80 +1146,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1229,18 +1261,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1473,82 +1505,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1593,141 +1637,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1831,11 +1887,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Sinhala (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "ටර්මිනේටර්"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "එක් වින්ඩෝවක ටර්මිනල් රාශියක්"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "ටැබය"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "ටැබය වසන්න"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "සමස්ත"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "ති_රස්ව කොටස්කිරීම"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "සිර_ස්ව කොටස්කිරීම"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "ටැබය_අරින්න"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "_Debug ටැබය විවෘතකරන්න"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "ටර්මිනලය _විශාලනය"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "ස්ක්‍රෝල්බාරය_පෙන්වන්න"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "කේතීකරණයන්"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "අනෙක් කේතීකරණයන්"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "ෙෂලය සොයාගැනීමට නොහැකිය"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "කවුළුව"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Slovak (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -83,7 +95,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -91,18 +103,34 @@ msgstr ""
 "* Tieto položky vyžadujú buď premennú prostredia TERMINATOR_UUID,\n"
 "  alebo musí byť použitý parameter --uuid."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "Použitý terminálový UUID ak sa nenachádza v premennej TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminátor"
 
@@ -111,7 +139,7 @@ msgid "Multiple terminals in one window"
 msgstr "Viaceré terminály v jednom okne"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Robotická budúcnosť terminálov"
 
@@ -352,7 +380,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Spúšťač rozhraní Terminatora"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Rozloženie"
 
@@ -360,47 +388,47 @@ msgstr "Rozloženie"
 msgid "Launch"
 msgstr "Spustiť"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "karta"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Zatvoriť kartu"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Zobraziť verziu programu"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximalizovať okno"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Vyplniť oknom obrazovku"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Zakázať okraje okna"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Skryť okno pri spustení"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Zadať nadpis pre okno"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Nastavte preferovanú veľkosť a pozíciu okna (pozrite X manuál)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Zadať príkaz na vykonanie vnútri terminálu"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -408,61 +436,69 @@ msgstr ""
 "Použiť zvyšok príkazového riadku ako príkaz na vykonanie vnútri terminálu, a "
 "jeho argumenty"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Zadajte konfiguračný súbor"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Nastaviť pracovný adresár"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Nastaviť vlastnú ikonu okna (podľa súboru alebo názvu)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Nastaviť voliteľnú vlastnosť okna WM_WINDOW_ROLE"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Spustiť s daným rozložením"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Vybrať rozloženie zo zoznamu"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Použiť iný profil ako predvolený"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Zakázať DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 "Zobraziť informáciu odchrobáčkovača (dvojmo pre odchrobáčkovací server)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Zoznam tried oddelených čiarkami pre obmedzenie odchrobáčkovania na"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Zoznam metód oddelených čiarkami pre obmedzenie odchrobáčkovania na"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Ak Terminator je už spustený, otvoriť novú kartu"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -489,7 +525,7 @@ msgstr "_Vlastné príkazy"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Nastavenia"
 
@@ -514,12 +550,12 @@ msgid "Enabled"
 msgstr "Povolené"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Názov"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Príkaz"
 
@@ -625,7 +661,7 @@ msgid "Escape sequence"
 msgstr "Escapovať sekvenciu"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Všetky"
 
@@ -898,250 +934,218 @@ msgid "Tabs scroll buttons"
 msgstr "Tlačidlá posuvníkov kariet"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Titulný pruh terminálu</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Farba písma:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Pozadie:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Aktívne"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Neaktívne"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Príjem"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Skryť veľkosť z názvu"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Použiť systémové písmo"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Písmo:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Vybrať písmo titulku"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Všeobecné"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "Po_užívať systémové písmo s pevnou šírkou"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Písmo:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Vyberte písmo terminálu"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "Povoliť _tučný text"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Ukázať titulkový pruh"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Kopírovať pri výberu"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Znaky pre výber _slov:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Kurzor</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Tvar:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Farba:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Blikanie"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Pozadie:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminálový zvonček</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Ikona v titulkovém pruhu"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Viditeľný pablesk"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Počuteľné zvukové znamenie"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Pablesk zoznamu okien"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Hlavné"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Spustiť príkaz v prihlasovacom shelle"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Sp_ustiť tento program namiesto shellu"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "_Vlastný príkaz:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "Po s_končení príkazu:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Popredie a pozadie</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "Použiť farby _systémovej témy"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Zab_udované schémy:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "F_arba textu:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Farba pozadia:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Za_budované schémy:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Paleta _farieb:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Farby"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Plná farba"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "Prie_hľadné pozadie"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Žiadne</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximálne</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Pozadie"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "Po_suvník je:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "_Rolovať pri výstupe"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Rolovať pri stlačení _klávesu"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Nekonečná pamäť riadkov"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Počet pamätaných _riadkov:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "riadky"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Posúvanie"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1152,80 +1156,108 @@ msgstr ""
 "nebudú fungovať správne. Sú tu iba preto, aby iné aplikácie mohli fungovať v "
 "prípade, že očakávajú iné chovanie terminálu.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Klávesa _Backspace generuje:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Kláves _Delete generuje:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Obnoviť predvolené hodnoty pre voľby kompatibility"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Kompatibilita"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Aktívne"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Neaktívne"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Príjem"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Skryť veľkosť z názvu"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Použiť systémové písmo"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Vybrať písmo titulku"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profily"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Typ"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Vlastný príkaz:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Pracovný adresár:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Rozloženia"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Akcia"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "Klávesová skratka"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Klávesové skratky"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Zásuvný modul"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Tento plugin nemá žiadne možnosti konfigurácie"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Doplnky"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1249,18 +1281,18 @@ msgstr ""
 "používateľov. Ak máte nejaké návrhy, prosím, pošlite vaše želanie do systému "
 "na hlásenie chýb (odkaz na Vývoj nájdete vľavo)."
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Návod"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "O aplikácií"
 
@@ -1493,82 +1525,94 @@ msgid "Ungroup all terminals"
 msgstr "Zrušiť zoskupenie všetkých terminálov"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Zoskupiť terminály v karte"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Zoskupiť/Zrušiť zoskupenie terminálov v karte"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Zrušiť zoskupenie terminálov v karte"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Vytvoriť nové okno"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Spustiť nový proces Terminator"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "Nevysielať stlačenia klávesov"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "Vysielať stlačenia klávesov skupine"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "Vysielať stlačenia klávesov všetkým"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Zadať číslo terminálu"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Vložiť vypchané číslo terminála"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Upraviť názov okna"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Upraviť názov terminálu"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Upraviť názov karty"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Otvoriť okno spúšťača rozložení"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Prepnúť na ďalší profil"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Prepnúť na predošlý profil"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Otvoriť návod"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nový profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nový rozmiestnenie"
 
@@ -1613,141 +1657,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Rozdeliť v_odorovne"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Rozdeliť zvisl_e"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Otvoriť ka_rtu"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Otvoriť kartu La_denie"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Priblížiť terminál"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximalizovať terminál"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "Obnoviť všetky terminály"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Zoskupovanie"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Zobraziť po_suvník"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kódovania"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Predvolené"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Definované užívateľom"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Iné kódovania"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "N_ová skupina..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "Žiade_n"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Odobrať skupinu %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Zoskupiť všetko na karte"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Odsk_upiť všetky v karte"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Odobrať všetky skupiny"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Zatvoriť skupinu %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "Vysiel_ať všetky"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "V_ysielať skupinu"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "Vysielanie _vypnuté"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "Rozdeliť na túto _skupinu"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Automati_cky čistiť skupiny"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "Vložiť číslo term_inálu"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "Vložiť _zarovnané číslo terminálu"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Nepodarilo sa nájsť shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Nepodarilo sa spustiť shell:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Premenovať okno"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Zadajte nový názov pre okno Terminator..."
 
@@ -1851,11 +1907,31 @@ msgstr "Psí"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "okno"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Karta %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Titulný pruh terminálu</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Farba písma:"
+
+#~ msgid "Color:"
+#~ msgstr "Farba:"
+
+#~ msgid "_Text color:"
+#~ msgstr "F_arba textu:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Farba pozadia:"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Slovenian (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,24 +94,40 @@ msgstr ""
 "Poženi katerega izmed naslednjih Terminator DBus ukazov:\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -108,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Več terminalov v enem oknu"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -349,7 +377,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -357,47 +385,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tabulator"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Zapri zavihek"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Pokaži različico programa"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Razširi okno na celoten zaslon"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Onemogoči robove oken"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Skrij okno ob zagonu"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Določi naslov okna"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Določi ukaz za izvedbo znotraj terminala"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -405,60 +433,68 @@ msgstr ""
 "Uporabi preostanek ukazne vrstice in njegove argumente, kot ukaz za izvedbo "
 "znotraj terminala"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Nastavi delovni imenik"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Nastavi WM_WINDOW_ROLE lastnost tega okna"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Izberi drug profil"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Onemogoči DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -485,7 +521,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Nastavitve"
 
@@ -510,12 +546,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -621,7 +657,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Vse"
 
@@ -894,250 +930,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1145,80 +1149,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1232,18 +1264,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1476,82 +1508,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Vstavi številko terminala"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Vstavi številko terminala"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Nov profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Nova postavitev"
 
@@ -1596,141 +1640,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Razdeli H_orizontalno"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Razdeli V_ertikalno"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Odpri _zavihek"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Odpri_"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Povečaj terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Obnovi vse terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Združevanje"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Pokaži _drsnik"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Nabori znakov"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Privzeto"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Uporabniško določeno"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Drugi nabori znakov"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Odstrani skupino %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Zd_ruži vse v zavihku"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Odstrani vse skupine"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Zapri skupino %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Ni možno najti lupine"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Ni možno zagnati lupine:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Preimenuj okno"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1834,11 +1890,16 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "okno"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Zavihek %d"

--- a/po/sq.po
+++ b/po/sq.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Albanian (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Shumë terminale në një dritare"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Mbylle skedën"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Serbian (https://www.transifex.com/terminator/teams/109338/"
@@ -69,10 +69,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -80,24 +92,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Терминатор"
 
@@ -106,7 +134,7 @@ msgid "Multiple terminals in one window"
 msgstr "Више терминала у једном прозору"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -347,7 +375,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -355,47 +383,47 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "језичак"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Затвори језичак"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Приказује издање програма"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Popuni ekran prozorom"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Onemogući granice prozora"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Sakrij prozor na pokretanju"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Unesi naslov prozora"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Unesi naredbu za izbrišavanje unutar terminala"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -403,60 +431,68 @@ msgstr ""
 "Koristi ostatak naredbene linije kao naredbu za izbrišavanje unutar "
 "terminala, i njegove argumente."
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Podesi fasciklu za rad"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Podesi prilagođenu WM_WINDOW_ROLE svojinu na prozoru"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Koristi drugačiji profil kao podrazumevano"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Onemogući DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Omogući podatke za otklanjanje grešaka (dvaput za servere)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Zarezom odvojena lista nastave da se ograniči na otklanjanje grešaka"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Zarezom odvojena lista metoda da se ograniči na otklanjanje grešaka"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -483,7 +519,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Поставке"
 
@@ -508,12 +544,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -619,7 +655,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Све"
 
@@ -892,250 +928,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1143,80 +1147,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Профили"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1230,18 +1262,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1474,82 +1506,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Унеси број терминала"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Унеси уметнут број терминала"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Унеси број терминала"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Унеси уметнут број терминала"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Нови профил"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Нови изглед"
 
@@ -1594,141 +1638,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Раздвоји водо_равно"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Раздвоји у_справно"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Отвори _језичак"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Отвори _језичак за отклањање неисправности"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Приближи терминал"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Поврати све терминале"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Груписање"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Прикажи _препис"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Кодирања"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Подразумевано"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Кориснички дефинисано"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Друга кодирања"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Уклони %s групу"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Гру_пиши све у језичке"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Уклони све групе"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Затвори %s групу"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Љуска није пронађена"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Покретање љуске није успело:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1832,11 +1888,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "прозор"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "%d језичак"

--- a/po/su.po
+++ b/po/su.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Sundanese (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Loba terminal dina hiji jandela"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Swedish (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,24 +94,40 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -108,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Flera terminaler i ett fönster"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Robot-framtid för terminaler"
 
@@ -349,7 +377,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Utformning"
 
@@ -357,49 +385,49 @@ msgstr "Utformning"
 msgid "Launch"
 msgstr "Starta"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "flik"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Stäng flik"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Visa programversionen"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Maximera fönstret"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Gör så att fönstret fyller skärmen"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Inaktivera fönster-ramar"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Dölj fönster vid uppstart"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Ange en titel för fönstret"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Ange föredragen storlek och position för fönstret (läs mer på \"x man\"-"
 "sidan)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Ange ett kommando att köra inuti terminalen"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -407,60 +435,68 @@ msgstr ""
 "Använd resten av kommandoraden som ett kommando att köra inuti terminalen, "
 "och dess argument"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Ange en konfigurationsfil"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Ställ in arbetskatalogen"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Ange en anpassad ikon för fönstret (efter fil eller namn)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Ställ in en anpassad WM_WINDOW_ROLE-egenskap på fönstret"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Använd en annan profil som standard"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Inaktivera D-Bus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Aktivera felsökningsinformation (dubbelt för felsökningsserver)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Kommaseparerad lista över klasser för att begränsa felsökning till"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Kommaseparerad lista över metoder för att begränsa felsäkning till"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Om Terminator redan körs kan du helt enkelt öppna en ny flik"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -487,7 +523,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Inställningar"
 
@@ -512,12 +548,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Namn"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Kommando"
 
@@ -623,7 +659,7 @@ msgid "Escape sequence"
 msgstr "Undantagssekvens"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Alla"
 
@@ -896,250 +932,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Bakgrund:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Inaktiv"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Teckensnitt:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Använd systemets teckensnitt med fast breddsteg"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Teckensnitt:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Välj ett teckensnitt för terminalen"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Tillåt fet text"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Visa namnlisten"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Kopiera vid markering"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Tecken för _markering av ord:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Markör</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Färg:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Blinka"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Bakgrund:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Ringklocka för terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Ikon i namnlisten"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Synlig blinkning"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Hörbart pip"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Blinkning med fönsterramen"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Allmänt"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Kör kommando som ett inloggningsskal"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Kö_r ett eget kommando istället för mitt skal"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Eget ko_mmando:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "När kommandot a_vslutas:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Förgrund och bakgrund</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "Använd färger från _datorns tema"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Inbyggda s_cheman:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Textfärg:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Bakgrundsfärg:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Palett</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Inbyggda _scheman:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Färgp_alett:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Färger"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "_Enfärgad"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Transparent bakgrund"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ingen</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximal</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Bakgrund"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "_Rullningslisten är:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Ru_lla vid utdata"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "Rulla vid _tangentnedtryckning"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Obegränsad rullningshistorik"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "Rullnings_historik:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "rader"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Rullning"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1151,80 +1155,108 @@ msgstr ""
 "använda vissa program och operativsystem som förväntar sig ett annat "
 "terminalbeteende.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "_Backstegstangenten genererar:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "_Delete-tangenten genererar:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Återställ kompatibilitetsalternativ till standardvärden"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Inaktiv"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiler"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Typ"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Arbetskatalog:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Layouter"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Tangentbindningar"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Insticksmodul"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Denna insticksmodul har inga konfigureringsalternativ"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Insticksmoduler"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1238,18 +1270,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Om"
 
@@ -1482,82 +1514,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
-msgstr "Skapa ett nytt fönster"
+msgid "Group terminals in tab"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
-msgstr ""
+msgid "Create a new window"
+msgstr "Skapa ett nytt fönster"
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Infoga terminalnummer"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Infoga vadderat terminalnummer"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Infoga terminalnummer"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Infoga vadderat terminalnummer"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Öppna handboken"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Ny profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Ny layout"
 
@@ -1602,141 +1646,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Dela h_orisontellt"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Dela v_ertikalt"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Öppna _flik"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Öppna _felsökningsflik"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Zooma in terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Återställ alla terminaler"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Gruppering"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Visa _rullningslist"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Teckenkodningar"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Standard"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Användardefinierad"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Övriga teckenkodningar"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Ta bort grupp %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "G_ruppera alla i fliken"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Ta bort alla grupper"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Stäng grupp %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Kan inte hitta ett skal"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Kan inte starta skalet:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Byt namn på fönster"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Ange en ny rubrik för Terminator-fönstret …"
 
@@ -1840,11 +1896,25 @@ msgstr ""
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "fönster"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Flik %d"
+
+#~ msgid "Color:"
+#~ msgstr "Färg:"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Textfärg:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Bakgrundsfärg:"

--- a/po/sw.po
+++ b/po/sw.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Swahili (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -90,18 +102,34 @@ msgstr ""
 "* Ingizo hizi zinahitaji aidha mandhari ya var ya TERMINATOR_UUID,\n"
 "  au chaguzi la --uuid litumike"
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "UUID ya tungo amri wakati haipo kwenye env var TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -110,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Tungo amri kadhaa kwenye window moja"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Umbile ya kiroboti ya tungo amri"
 
@@ -351,7 +379,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -359,106 +387,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -485,7 +521,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -510,12 +546,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -621,7 +657,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -894,250 +930,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1145,80 +1149,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1232,18 +1264,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1476,82 +1508,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1596,141 +1640,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1834,11 +1890,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Tamil (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "முனையம்"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "ஒரு  சாளரத்தில் பல முனையங்கள்"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,107 +382,115 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "தத்தல்"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "தத்தலை மூடுக"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "நிரல் பதிப்பை காட்டு"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "சாளரத்தை படதிரையில் முழுதாக்கி காட்டு"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "சாளர எல்லைகளை முடக்கு"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "தொடங்கலின் போது சாளரத்தை மறை"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "சாளரத்திற்கு ஒரு தலைப்பை குறிபிடுக"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "முனைய உள்ளக இயக்கத்திற்கு கட்டளை ஒன்றை குறிப்பிடுக"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 "முனையத்தில் உள்ள இயக்க ஒரு கட்டளை கட்டளை வரி பாக்கி, மற்றும் அதன் வாதங்களை பயன்படுத்த"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "முனையத்தின் பணி அடைவை அமை"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "சாளரத்தில் ஒரு தனிபயன் WM_WINDOW_ROLE சொத்து அமைக்க"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "முன்னிருப்பாக வேறொரு சுயவிவரத்தை பயன்படுத்துக"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "DBus ஐ  முடக்கு"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "பிழைத்திருத்த தகவலை இயக்கு (இருமுறை பிழைத்திருத்த சேவையகத்தின்)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "என்று பிழைத்திருத்தங்களுக்கும் கட்டுப்படுத்த வகுப்புகள் கமாவால் பிரிக்கப்பட்ட பட்டியல்"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "என்று பிழைத்திருத்தங்களுக்கும் கட்டுப்படுத்த முறைகள் கமாவால் பிரிக்கப்பட்ட பட்டியல்"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "முனையம் ஏற்கனவே இயக்கத்தில் இருந்தால், ஒரு புதிய தாவலை மட்டும் திறக்கவும்"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -481,7 +517,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "முன்னுரிமைகள்"
 
@@ -506,12 +542,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -617,7 +653,7 @@ msgid "Escape sequence"
 msgstr "விடுபடு தொடர்"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "அனைத்து"
 
@@ -890,250 +926,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "உலக"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1141,80 +1145,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "_ நகர்வு முக்கிய உருவாக்குகிறது:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "விவரக்குறிப்புகள்"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1228,18 +1260,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1472,82 +1504,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "முனையத்தில் எண்ணை சேர்க்க"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Padded முனைய எண்ணை சேர்க்க"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "முனையத்தில் எண்ணை சேர்க்க"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Padded முனைய எண்ணை சேர்க்க"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "புதிய விவரம்"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "புதிய வடிவமைப்பு"
 
@@ -1592,141 +1636,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "சமதளத்தில் பிரி"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "நெடுதளமாக பிரி"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "திறந்த தாவல்"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "திறந்த பிழைத்திருத்த தாவல்"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "முனையத்தை பெரிதாக்க"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "அனைத்து முனயங்களையும்  திரும்பப்பெறு"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "குழுவாக்கம்"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "சுருள் பட்டியை காட்டு"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "குறியாக்கம்"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "முன்னிருப்பு"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "பயனர் வரையறுத்தது"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "ஏனைய குறியாக்கம்"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "குழுக்களை நீக்க %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "அனைத்து தாவலில் குழு"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "அனைத்து குழுக்களை நீக்க"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "குழுவை மூடு  %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "நிரப்பட்ட முனைய எண்ணை சேர்க்க"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "ஓட்டை  ஆரம்பிக்க முடியவில்லை:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1830,11 +1886,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "சாளரம்"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "தாவல் %d"

--- a/po/te.po
+++ b/po/te.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Telugu (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "టెర్మినేటర్"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "ఒకే విండోలో బహుళ టెర్మినల్స్"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "టాబ్"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "టాబ్‌ను మూసివెయ్యి"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "ప్రోగ్రాము రూపాంతరాన్ని ప్రదర్శించు"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "తెరకు సరిపోయేట్టు విండోను నింపు"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "విండో సరిహద్దులను అచేతనపరుచు"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "ప్రారంభములో విండోని దాయి"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "విండోకి ఒక శీర్షికను పేర్కొనండి"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "DBus అచేతనపరుచు"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "ప్రాధాన్యతలు (_P)"
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "అన్నీ"
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "ప్రొఫైల్స్"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "కొత్త ప్రొఫైల్"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "కొత్త నమూనా"
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "ట్యాబ్ తెరువు (_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "ఎన్‌కోడింగులు"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "అప్రమేయం"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "విండో"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/terminator.pot
+++ b/po/terminator.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,10 +63,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -74,24 +86,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -100,7 +128,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -341,7 +369,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -349,106 +377,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -475,7 +511,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -500,12 +536,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -611,7 +647,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -884,250 +920,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1135,80 +1139,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1222,18 +1254,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1466,82 +1498,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1586,141 +1630,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1824,11 +1880,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Thai (https://www.transifex.com/terminator/teams/109338/th/)\n"
@@ -67,10 +67,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -78,24 +90,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -104,7 +132,7 @@ msgid "Multiple terminals in one window"
 msgstr "หลายเทอร์มินัลในหน้าต่างเดียว"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -345,7 +373,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -353,106 +381,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "แท็บ"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "ปิดแท็ป"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "ปิดขอบหน้าต่าง"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "ไม่ใช้งาน DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -479,7 +515,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -504,12 +540,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -615,7 +651,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "ทั้งหมด"
 
@@ -888,250 +924,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1139,80 +1143,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1226,18 +1258,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1470,82 +1502,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "โปรไฟล์ใหม่"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1590,141 +1634,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "ลบกลุ่ม %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "ลบกลุ่มทั้งหมด"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "ปิดกลุ่ม %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1828,11 +1884,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "หน้าต่าง"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Turkish (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr "Ana sekmenin başlığını ayarla"
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr "Geçerli uçbirimin profilini değiştir"
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,25 +94,43 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
-msgstr "Şu girdiler ya TERMINATOR_UUID ortam vari,\n"
+msgstr ""
+"Şu girdiler ya TERMINATOR_UUID ortam vari,\n"
 "  ya --uuid seçeneğin kulanmasi gerekiyor."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "TERMINATOR_UUID ortam varında olmadığında uçbirim UUID'si"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
-msgstr "Ayarlayacak sekme adısı. Sadece \"set_tab_title\" komudu ile kulanılmak. "
+msgstr ""
+"Ayarlayacak sekme adısı. Sadece \"set_tab_title\" komudu ile kulanılmak. "
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
+msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminatör"
 
@@ -109,7 +139,7 @@ msgid "Multiple terminals in one window"
 msgstr "Tek pencerede birden çoklu uçbirim"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "Uçbirimlerinin robot gelegeğini"
 
@@ -350,7 +380,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Terminator dizilim başlatıcı"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Dizilim"
 
@@ -358,47 +388,47 @@ msgstr "Dizilim"
 msgid "Launch"
 msgstr "Çalıştır"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "sekme"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Sekmeyi Kapat"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Program sürümünü göster"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Pencere ekranı kaplar"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Pencerenin ekranı kaplamasını sağla"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Pencere sınırlarını devredışı bırak"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Pencereyi başlangıçta sakla"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Pencere için bir isim belirt"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Uçbirimin içinden başlatmak için bir komut belirleyin"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -406,61 +436,69 @@ msgstr ""
 "Komut satırının geri kalanını uçbirimin içinde argümanlarıyla başlatılacak "
 "bir komut olarak kullan."
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Ayar dosyası belirt"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Çalışma dizinini ayarla"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "Pencere için özel simge ayarla (dosya veya isimle)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Pencereye özel bir WM_WINDOW_ROLE özelliği ayarla"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "verilen düzende başlat"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Listeden bir düzeni seçin"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Varsayılan olarak farklı bir profil kullan"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "DBus'ı devredışı bırak"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 "Hata bulma bilgilendirmesine izin ver (hata bulma sunucusu için iki katı)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Hata bulmanın sınırlanacağı, virgüllerle ayrılmış olan sınıflar"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Hata bulmanın sınırlanacağı, virgüllerle ayrılmış olan metodlar"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Terminator zaten çalışıyorsa yeni bir sekme aç"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -487,7 +525,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Tercihler"
 
@@ -512,12 +550,12 @@ msgid "Enabled"
 msgstr "Etkin"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Adı"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Komut"
 
@@ -623,7 +661,7 @@ msgid "Escape sequence"
 msgstr "Kaçış dizisi"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Tümü"
 
@@ -896,250 +934,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Yazı tipi rengi:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Arkaplan"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "Odaklanmış"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Pasif"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "Alınıyor"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Yazı tipi:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Evrensel"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "Sistemin sabit genişlikteki yazı tipini kullan."
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Yazı tipi:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Bir Uçbirim Yazıtipi Seçin"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Kalın metne izin ver"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Başlıkçubuğunu göster"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Seçimi kopyala"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>İmleç</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "_Biçim"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "Yanıp sönme"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Arkaplan"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Genel"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "_Giriş kabuğu yerine komut çalıştır"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Komutu özelleştir"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Önplan ve Arkaplan</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Sistem temasının renklerini kullan"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "_Metin rengi:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "_Arkaplan rengi:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Renkler"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Hiçbiri</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Arkaplan"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "Kaydırma çubuğu:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Kaydırma"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1147,80 +1153,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Geri tuşuna basıldığında:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Sil tuşuna basıldığında:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Uyumluluk"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "Odaklanmış"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Pasif"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "Alınıyor"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Profiller"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Eklentiler"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1234,18 +1268,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1478,82 +1512,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
-msgstr "Uçbirim numarası ekle"
+msgid "Don't broadcast key presses"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
-msgstr "Takımlı uçbirim numarası ekle"
+msgid "Broadcast key presses to group"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
-msgstr ""
+msgid "Insert terminal number"
+msgstr "Uçbirim numarası ekle"
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
-msgstr ""
+msgid "Insert padded terminal number"
+msgstr "Takımlı uçbirim numarası ekle"
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Yeni Profil"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Yeni Düzen"
 
@@ -1598,141 +1644,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Y_atay olarak Böl"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "D_ikey olarak Böl"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "_Sekme Aç"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "hata ayıkla"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "Uçbirimi _yakınlaştır"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "Tüm uçbirimleri _geri al"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Gruplandırma"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "K_aydırma çubuğunu göster"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Kodlamalar"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "Öntanımlı"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Kullanıcı tanımlı"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Diğer Kodlamalar"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "%s grubunu kaldır"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "Hepsini sekmede t_opla"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Tüm grupları kaldır"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "%s grubunu kapat"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Kabuk bulunamadı"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Kabuk başlatılamadı:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1836,11 +1894,25 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "pencere"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Sekme %d"
+
+#~ msgid "Font color:"
+#~ msgstr "Yazı tipi rengi:"
+
+#~ msgid "_Text color:"
+#~ msgstr "_Metin rengi:"
+
+#~ msgid "_Background color:"
+#~ msgstr "_Arkaplan rengi:"

--- a/po/tyv.po
+++ b/po/tyv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminator\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2015-08-03 19:30+0000\n"
 "Last-Translator: boracasli <Unknown>\n"
 "Language-Team: Tuvinian <tyv@li.org>\n"
@@ -64,10 +64,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -75,24 +87,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -101,7 +129,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -342,7 +370,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -350,106 +378,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -476,7 +512,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -501,12 +537,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -612,7 +648,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -885,250 +921,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1136,80 +1140,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1223,18 +1255,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1467,82 +1499,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1587,141 +1631,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1825,11 +1881,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Uyghur (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2021-04-23 20:05+0300\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Ukrainian (https://www.transifex.com/terminator/teams/109338/"
@@ -71,10 +71,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -85,7 +97,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -93,18 +105,34 @@ msgstr ""
 "* Ці поля вимагають змінної оточення TERMINATOR_UUID,\n"
 "або використовувати кляч --ггшв."
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "UUID терміналу, коли немає змінної оточення TERMINATOR_UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -113,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Кілька терміналів в одному вікні"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -369,7 +397,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Запуск Макетів Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "Макети"
 
@@ -377,48 +405,48 @@ msgstr "Макети"
 msgid "Launch"
 msgstr "Запуск"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "вкладка"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Закрити вкладку"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Показати версію програми"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "Розгорнути вікно"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Розгорнути вікно"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Вимкнути обрамлення вікна"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Сховати вікно при запуску"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Вкажіть назву для вікна"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 "Встановіть потрібний розмір і положення вікна (див. довідкову статтю Іксів)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Вкажіть команду, щоб виконати в терміналі"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
@@ -426,62 +454,70 @@ msgstr ""
 "Використати залишок командного рядку як команду та її аргументи, що потрібно "
 "виконати в терміналі"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Вкажіть файл конфігурації"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "Вказати робочу папку"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 "Встановити користувальницький значок для цього вікна (по файлу або імені)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "Встановити довільне значення WM_WINDOW_ROLE для цього вікна"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "Запуск із заданим макетом"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "Виберіть макет зі списку"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "Використовувати інший профіль як типовий"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "Вимкнути DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "Увімкнути інформацію налагодження (два рази для сервера налагодження)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "Розділений комами список класів для обмеження налагодження"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "Розділений комами список методів обмеження для налагодження"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "Якщо Термінатор вже запущений, просто відкрийте нову вкладку"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
 msgstr "Якщо Terminator вже запущений, просто показати усі приховані вікна"
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
+msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
 #, fuzzy
@@ -508,7 +544,7 @@ msgstr "_ Користувацькі команди"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "_Налаштування"
 
@@ -533,12 +569,12 @@ msgid "Enabled"
 msgstr "Увімкнено"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "Назва"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "Команда"
 
@@ -645,7 +681,7 @@ msgid "Escape sequence"
 msgstr "Escape-послідовність"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "Усе"
 
@@ -921,252 +957,220 @@ msgid "Tabs scroll buttons"
 msgstr "Кнопки прокрутки вкладок"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>Рядок заголовка терміналу</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "Колір шрифта:"
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "Задній план:"
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "Неактивний"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr "Рядок заголовка внизу (вимагає перезапуску)"
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "Прибрати розмір із заголовку"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "_Використовувати системний шрифт"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "_Шрифт:"
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "Вибрати шрифт рядка заголовку"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "Загальний"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "Профіль"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "_Використовувати системний шрифт з фіксованою шириною"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "_Шрифт:"
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "Вибрати шрифт терміналу"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "_Дозволити жирний текст"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "Показати заголовок"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "Копіювання на вибір"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Вимкніть масштабування при Ctrl + коліщатко миші"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "Вибір _слів за символами:"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>Курсор </b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 #, fuzzy
 msgid "_Shape:"
 msgstr "_Форма:"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "Колір:"
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 #, fuzzy
 msgid "Blink"
 msgstr "Блимати"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "Передній план"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "Задній план:"
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Сигнал терміналу</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "Іконка заголовка"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "Помітний сигнал (блимання)"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "Звуковий сигнал"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "Блимання вікном"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "Загальний"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "За_пускати команду як  оболонку входу"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Запускати _іншу команду замість моєї оболонки"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "Користувацька к_оманда:"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "При _виході з команди:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Переднього і заднього плану</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "_Використати кольори з системної  теми"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "Вбудовані  схе_ми:"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "Колір  т_ексту:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "Колір _фону:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>Палітра </b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "Вбудовані  с_хеми:"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "Кольорова палітра:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr "Показувати ж_ирний текст у яскравих кольорах"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "Кольори"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "Су_цільний  колір"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "_Прозорий фон"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr "Фонове зображення"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr "Файл фонового зображення:"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr "Вибрати файл"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr "Т_інь фону:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ніякої</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Максимальне </i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "Фон"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "С_муга  прокрутки:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "Про_кручувати  при виводі"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "_Прокручувати  при натисканні клавіші"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "Нескінченна прокрутка"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "З_воротна  прокрутка:"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "рядки"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "Прокрутка"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1178,81 +1182,109 @@ msgstr ""
 "з деякими програмами та операційними ситемами, які очікували іншої поведінки "
 "терміналу.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Клавіша  _Backspace генерує:"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Клавіша  _Delete генерує:"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "Кодування:"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Восстановить параметры совместимости по умолчанию"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "Сумісність"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "Неактивний"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "Прибрати розмір із заголовку"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "_Використовувати системний шрифт"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "Вибрати шрифт рядка заголовку"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "Профілі"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "Тип"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "Профіль:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "Власна команда:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "Робочий каталог:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "Шаблони"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "Дія"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 #, fuzzy
 msgid "Keybinding"
 msgstr "Клавіатура"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "Комбінації  клавіш"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "Розширення"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "Цей плагін не має параметрів конфігурації"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "Плагіни"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1277,11 +1309,11 @@ msgstr ""
 "користувачів. Якщо у вас є якісь пропозиції, будь ласка, подайте помилки в "
 "списку бажань! (див. ліворуч посилання Розробка)"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "Посібник"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
@@ -1291,7 +1323,7 @@ msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Приблми / "
 "Пропозиції покращення</a>"
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "Про"
 
@@ -1524,82 +1556,94 @@ msgid "Ungroup all terminals"
 msgstr "Розгрупувати всі термінали"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "Згрупувати термінали у вкладці"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "Згрупувати/Розгрупувати всі термінали у вкладці"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "Розгрупувати термінали у вкладці"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "Створити нове вікно"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "Створити новий процес Terminator"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "Введіть номер терміналу"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "Вставити консольне число з цифрової клавіатури"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "Змінити заголовок віна"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "Змінити заголовок терміналу"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "Змінити заголовок вкладки"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "Відкрити вікно вибору макета"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "Перейти до наступного профіля"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "Перейти до попереднього профіля"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr "Відкрити вікно налаштувань"
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "Відкрити посібник користувача"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "Новий профіль"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "Поточна локаль"
 
@@ -1644,141 +1688,153 @@ msgstr "_Копіювати"
 msgid "_Paste"
 msgstr "_Вставити"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "Розділити горизонтально"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "Розділити вертикально"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "Відкрити в_кладку"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "Відкрити відла_годжувальну вкладку"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "_Закрити"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "_Збільшити термінал"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "Ро_згорнути термінал"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "_Відновити всі термінали"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "Групування"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr "Команда перезапуску"
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "Показувати повзунок прокрутки"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr "_Макети..."
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "Кодування"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "За замовчуванням"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "Визначене користувачем"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "Інше кодування"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "Н_ова група..."
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "_Немає"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "Видалити групу %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "З_групувати все на вкладці"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "Розгрупава_ти всу у вкладці"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "Видалити усі групи"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "Закрити групу %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "Автоматично_очистити групи"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "_Вставте номер терміналу"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "Не вдалося знайти командну оболонку"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "Неможливо запустити оболонку:"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "Перейменування вікна"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "Введіть нову назву для вікна Terminator..."
 
@@ -1883,14 +1939,37 @@ msgstr ""
 msgid "Omega"
 msgstr "Омега"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "вікно"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "Вкладка %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>Рядок заголовка терміналу</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "Колір шрифта:"
+
+#~ msgid "Color:"
+#~ msgstr "Колір:"
+
+#~ msgid "Foreground"
+#~ msgstr "Передній план"
+
+#~ msgid "_Text color:"
+#~ msgstr "Колір  т_ексту:"
+
+#~ msgid "_Background color:"
+#~ msgstr "Колір _фону:"
 
 #~ msgid "Version: 2.0.1"
 #~ msgstr "Версія: 2.0.1"

--- a/po/ur.po
+++ b/po/ur.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Urdu (https://www.transifex.com/terminator/teams/109338/ur/)\n"
@@ -67,10 +67,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -78,24 +90,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -104,7 +132,7 @@ msgid "Multiple terminals in one window"
 msgstr "ایک دریچے میں ایک سے زیادہ ٹرمنل"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -345,7 +373,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -353,106 +381,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "ٹیب"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "ٹیب بند کریں"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -479,7 +515,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -504,12 +540,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -615,7 +651,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -888,250 +924,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1139,80 +1143,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1226,18 +1258,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1470,82 +1502,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1590,141 +1634,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1828,11 +1884,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Vietnamese (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Mở nhiều terminal trong cùng cửa sổ"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "Đóng tab"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "Hiện phiên bản chương trình"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "Làm cho cửa sổ chiếm trọn màn hình"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "Tắt viền cửa sổ"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "Ẩn cửa sổ lúc mới chạy"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "Đặt tên cho cửa sổ"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "Đặt kích thước và vị trí tùy thích cho cửa sổ (xem man page của X)"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "Chọn một lệnh để chạy trong terminal này"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "Chọn tập tin thiết lập"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/wa.po
+++ b/po/wa.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Walloon (https://www.transifex.com/terminator/teams/109338/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Chinese (China) (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -90,18 +102,34 @@ msgstr ""
 "* 这些项需要 TERMINATOR_UUID环境变量，\n"
 "  或者使用 --uuid指定。"
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "终端UUID如果未设置TERMINATOR_UUID环境变量"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator 终端终结者"
 
@@ -110,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "一个窗口中的多个终端"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "高级终端的未来"
 
@@ -351,7 +379,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Terminator布局启动器"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "布局"
 
@@ -359,106 +387,114 @@ msgstr "布局"
 msgid "Launch"
 msgstr "启动"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "标签页"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "关闭标签"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "显示程序版本"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "最大化窗口"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "让窗口充满整个屏幕"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "隐藏窗口边缘"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "启动时隐藏窗口"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "给窗口命名"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "设置窗口的默认大小与位置（请参考 X 的文档）"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "指定要在终端中执行的命令"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr "将命令行剩下的部分当作命令(及其参数)在终端中执行"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "指定一个配置文件"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "设置工作目录"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "设置自定义的窗口的图标（提供一个文件或者图标名称）"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "设置窗口自定义的 WM_WINDOW_ROLE"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "启动制定的布局"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "从列表中选择一个布局"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "设置新的默认配置"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "禁用DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "启用调试信息(用调试服务器时输入两次)"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "限制调试以逗号分隔的列表中的类"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "限制调试以逗号分隔的列表中的方法"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "如果 Terminator 已经运行，打开一个新的标签页"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -485,7 +521,7 @@ msgstr "自定义命令(_C）"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "配置文件首选项(_P)"
 
@@ -510,12 +546,12 @@ msgid "Enabled"
 msgstr "已启用"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "名称"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "命令"
 
@@ -621,7 +657,7 @@ msgid "Escape sequence"
 msgstr "转义序列"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "全部"
 
@@ -894,250 +930,218 @@ msgid "Tabs scroll buttons"
 msgstr "标签滚动按钮"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>终端标题栏</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "字体颜色："
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "背景："
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "聚焦的"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "非活动"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "接收中"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "在标题中隐藏大小"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "使用系统字体(_U)"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "字体(_F)："
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "选择标题栏字体"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "全局"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "配置"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "使用系统的等宽字体(_U)"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "字体(_F)："
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "选择终端字体"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "允许粗体字(_A)"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "显示标题栏"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "选中则复制"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "视作单词组成部分的字符(_W)："
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>光标</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr "形状(_S)"
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "颜色："
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "闪烁"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "前景"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "背景："
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr "<b>终端响铃</b>"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "标题栏图标"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr "闪烁显示"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr "发出哔声"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr "闪烁窗口列表"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "一般设定"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr "以登录 Shell 方式运行命令(_R)"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "运行自定义命令而不是 Shell(_N)"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "自定义命令(_M)："
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "命令退出时(_E)："
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>前景与背景</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "使用系统主题中的颜色(_U)"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "内置方案(_M)："
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "文本颜色(_T)："
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "背景颜色(_B)："
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>调色板</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "内置方案(_S)："
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "调色板(_A)："
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "色彩"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "纯色(_S)"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "透明背景(_T)"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>无</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>最大</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "背景"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "滚动条(_S)："
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "输出时滚动(_O)"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "击键时滚动(_K)"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "无限回滚"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "回滚(_B)："
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "行"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "滚动"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1147,80 +1151,108 @@ msgstr ""
 "<small><i><b>注意：</b>这些选项可能造成一些应用程序产生不正确的行为。仅用于允"
 "许您在一些应用程序和操作系统中作调整以获得不同的终端行为。</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "按 _Backspace 键产生："
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "按 _Delete 键产生："
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "编码："
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "重置兼容性选项为默认值(_R)"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "兼容性"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "聚焦的"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "非活动"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "接收中"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "在标题中隐藏大小"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "使用系统字体(_U)"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "选择标题栏字体"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "配置"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "类型"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "配置："
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "自定义命令："
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "工作目录:"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "布局"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "动作"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "键绑定"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "快捷键"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "插件"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "此插件没有配置项"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "插件"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1240,18 +1272,18 @@ msgstr ""
 "时也希望向扩展更多不同方面的实用特性从而服务于系统管理员和其他用户。如果你有"
 "任何建议，请向wishlist中提交！（看左边的开发者链接）"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "手册"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "关于"
 
@@ -1484,82 +1516,94 @@ msgid "Ungroup all terminals"
 msgstr "解组所有终端"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "将标签页中的终端合为一组"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "分组/解组标签页中的终端"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "解组所有标签页中的终端"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "创建一个新窗口"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "启动一个新的Terminator进程"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "不要广播键入"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "广播键入到组"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "广播键入到所有终端"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "插入终端编号"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "插入适当宽度的终端号"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "编辑窗口标题"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "编辑终端标题"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "编辑标签标题"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "打开布局启动器窗口"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "切换到下一个配置文件"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "切换到上一个配置文件"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "打开手册"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "新配置"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "新布局"
 
@@ -1604,141 +1648,153 @@ msgstr "复制(_C)"
 msgid "_Paste"
 msgstr "粘贴(_P)"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "水平分割(_H)"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "垂直分割(_V)"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "打开标签(_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "打开Debug标签(_D)"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "关闭(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "缩放终端(_Z)"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "最大化终端(_X)"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "还原所有终端(_R)"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "分组"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "显示滚动条"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "编码"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "默认"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "用户定义"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "其他编码"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "新分组……(e)"
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "无(_N)"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "移除组 %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "将所有标签页中的终端合为一组(_R)"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "解散标签页中的分组(_U)"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "移除所有的组"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "关闭组 %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "广播到所有(_A)"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "广播到组(_G)"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "不广播(_O)"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "在组内分割(_S)"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr "自动清理分组(_C)"
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "插入终端编号(_I)"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr "插入对齐的终端编号(_I)"
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "无法找到shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "无法启动shell："
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "重命名窗口"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "输入新的Terminator窗口标题"
 
@@ -1842,11 +1898,34 @@ msgstr "Psi"
 msgid "Omega"
 msgstr "Omega"
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "窗口"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "标签 %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>终端标题栏</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "字体颜色："
+
+#~ msgid "Color:"
+#~ msgstr "颜色："
+
+#~ msgid "Foreground"
+#~ msgstr "前景"
+
+#~ msgid "_Text color:"
+#~ msgstr "文本颜色(_T)："
+
+#~ msgid "_Background color:"
+#~ msgstr "背景颜色(_B)："

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Chinese (Hong Kong) (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -79,24 +91,40 @@ msgid ""
 "%s"
 msgstr ""
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr ""
 
@@ -105,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -346,7 +374,7 @@ msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr ""
 
@@ -354,106 +382,114 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "關閉分頁"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -480,7 +516,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr ""
 
@@ -505,12 +541,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr ""
 
@@ -616,7 +652,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr ""
 
@@ -889,250 +925,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,80 +1144,108 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1227,18 +1259,18 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr ""
 
@@ -1471,82 +1503,94 @@ msgid "Ungroup all terminals"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:164
-msgid "Group terminals in tab"
+msgid "Group terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:165
-msgid "Group/Ungroup terminals in tab"
+msgid "Group/Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:166
-msgid "Ungroup terminals in tab"
+msgid "Ungroup terminals in window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:167
-msgid "Create a new window"
+msgid "Group terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:168
-msgid "Spawn a new Terminator process"
+msgid "Group/Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:169
-msgid "Don't broadcast key presses"
+msgid "Ungroup terminals in tab"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:170
-msgid "Broadcast key presses to group"
+msgid "Create a new window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:171
-msgid "Broadcast key events to all"
+msgid "Spawn a new Terminator process"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:172
-msgid "Insert terminal number"
+msgid "Don't broadcast key presses"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:173
-msgid "Insert padded terminal number"
+msgid "Broadcast key presses to group"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:174
-msgid "Edit window title"
+msgid "Broadcast key events to all"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:175
-msgid "Edit terminal title"
+msgid "Insert terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:176
-msgid "Edit tab title"
+msgid "Insert padded terminal number"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:177
-msgid "Open layout launcher window"
+msgid "Edit window title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:178
-msgid "Switch to next profile"
+msgid "Edit terminal title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:179
-msgid "Switch to previous profile"
+msgid "Edit tab title"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:180
-msgid "Open the Preferences window"
+msgid "Open layout launcher window"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:181
+msgid "Switch to next profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:182
+msgid "Switch to previous profile"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:183
+msgid "Open the Preferences window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr ""
 
@@ -1591,141 +1635,153 @@ msgstr ""
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "橫向分隔(_o)"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "垂直分隔(_e)"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "開啟分頁(_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "放大終端機(_Z)"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "顯示捲軸(_s)"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "編碼"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "其他編碼"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "無法找到 Shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1829,11 +1885,16 @@ msgstr ""
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-02 17:59+0200\n"
+"POT-Creation-Date: 2021-09-14 18:55+0200\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Chinese (Taiwan) (https://www.transifex.com/terminator/"
@@ -68,10 +68,22 @@ msgid "Set the title of a parent tab"
 msgstr ""
 
 #: ../remotinator.py:50
+msgid "Set the background image"
+msgstr ""
+
+#: ../remotinator.py:51
+msgid "Set the background image for all terminals"
+msgstr ""
+
+#: ../remotinator.py:52
 msgid "Switch current terminal profile"
 msgstr ""
 
-#: ../remotinator.py:67
+#: ../remotinator.py:53
+msgid "Switch profile of all currently running terminals"
+msgstr ""
+
+#: ../remotinator.py:70
 #, python-format
 msgid ""
 "Run one of the following Terminator DBus commands:\n"
@@ -82,7 +94,7 @@ msgstr ""
 "\n"
 "%s"
 
-#: ../remotinator.py:68
+#: ../remotinator.py:71
 msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
@@ -90,18 +102,34 @@ msgstr ""
 "* 這些項目需要用到TERMINATOR_UUID環境變數，\n"
 "  也可以使用--uuid選項來指定TERMINATOR_UUID。"
 
-#: ../remotinator.py:74 ../remotinator.py:77
+#: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr "當環境變數TERMINATOR_UUID不存在時，指定終端的UUID"
 
 #: ../remotinator.py:80
+msgid "Profile name to switch to"
+msgstr ""
+
+#: ../remotinator.py:83
+msgid "File to pass to command"
+msgstr ""
+
+#: ../remotinator.py:86
+msgid "Command to run in new terminal"
+msgstr ""
+
+#: ../remotinator.py:89
 msgid "Tab name to set. Only used with \"set_tab_title\" command."
+msgstr ""
+
+#: ../remotinator.py:92
+msgid "Tab name to set."
 msgstr ""
 
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -110,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "單一視窗，多重終端"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:156
 msgid "The robot future of terminals"
 msgstr "終結者(Terminator) - 終端機器人的未來"
 
@@ -351,7 +379,7 @@ msgid "Terminator Layout Launcher"
 msgstr "Terminator版面配置啟動器"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:142
 msgid "Layout"
 msgstr "版面配置"
 
@@ -359,106 +387,114 @@ msgstr "版面配置"
 msgid "Launch"
 msgstr "啟動"
 
-#: ../terminatorlib/notebook.py:359
+#: ../terminatorlib/notebook.py:384
 msgid "tab"
 msgstr "分頁"
 
-#: ../terminatorlib/notebook.py:629
+#: ../terminatorlib/notebook.py:656
 msgid "Close Tab"
 msgstr "關閉分頁"
 
-#: ../terminatorlib/optionparse.py:49
+#: ../terminatorlib/optionparse.py:43
 msgid "Display program version"
 msgstr "顯示程式版本"
 
-#: ../terminatorlib/optionparse.py:51 ../terminatorlib/optionparse.py:53
+#: ../terminatorlib/optionparse.py:45 ../terminatorlib/optionparse.py:47
 msgid "Maximize the window"
 msgstr "最大化視窗"
 
-#: ../terminatorlib/optionparse.py:55
+#: ../terminatorlib/optionparse.py:49
 msgid "Make the window fill the screen"
 msgstr "以全螢幕顯示視窗"
 
-#: ../terminatorlib/optionparse.py:57
+#: ../terminatorlib/optionparse.py:51
 msgid "Disable window borders"
 msgstr "取消視窗邊框"
 
-#: ../terminatorlib/optionparse.py:59
+#: ../terminatorlib/optionparse.py:53
 msgid "Hide the window at startup"
 msgstr "啟動時隱藏視窗"
 
-#: ../terminatorlib/optionparse.py:61
+#: ../terminatorlib/optionparse.py:55
 msgid "Specify a title for the window"
 msgstr "自訂視窗標題"
 
-#: ../terminatorlib/optionparse.py:63
+#: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr "設定喜好的尺寸及視窗的位置 ( 詳情請見 X man 的頁面 )"
 
-#: ../terminatorlib/optionparse.py:67 ../terminatorlib/optionparse.py:70
+#: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
 msgstr "自訂要在終端中執行的指令"
 
-#: ../terminatorlib/optionparse.py:73 ../terminatorlib/optionparse.py:81
+#: ../terminatorlib/optionparse.py:66 ../terminatorlib/optionparse.py:73
 msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr "將整個命令列內容（含參數）視為一個指令，於終端內執行"
 
-#: ../terminatorlib/optionparse.py:76
+#: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
 msgstr "指定一個設定檔"
 
-#: ../terminatorlib/optionparse.py:78
+#: ../terminatorlib/optionparse.py:71
 msgid "Specify a partial config json file"
 msgstr ""
 
-#: ../terminatorlib/optionparse.py:84
+#: ../terminatorlib/optionparse.py:76
 msgid "Set the working directory"
 msgstr "設定工作目錄"
 
-#: ../terminatorlib/optionparse.py:85
+#: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr "設定視窗圖示(透過檔案或是名稱)"
 
-#: ../terminatorlib/optionparse.py:88
+#: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
 msgstr "自訂視窗的 WM_WINDOW_ROLE 屬性"
 
-#: ../terminatorlib/optionparse.py:90
+#: ../terminatorlib/optionparse.py:82
 msgid "Launch with the given layout"
 msgstr "以給定的版面配置啟動"
 
-#: ../terminatorlib/optionparse.py:92
+#: ../terminatorlib/optionparse.py:84
 msgid "Select a layout from a list"
 msgstr "從清單中選取版面配置"
 
-#: ../terminatorlib/optionparse.py:94
+#: ../terminatorlib/optionparse.py:86
 msgid "Use a different profile as the default"
 msgstr "使用不同的設定檔為預設值"
 
-#: ../terminatorlib/optionparse.py:96
+#: ../terminatorlib/optionparse.py:88
 msgid "Disable DBus"
 msgstr "停用 DBus"
 
-#: ../terminatorlib/optionparse.py:98
+#: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
 msgstr "啟用除錯訊息（重複兩次以啟用 debug server）"
 
-#: ../terminatorlib/optionparse.py:100
+#: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
 msgstr "除錯訊息中只列出要顯示的DEBUG_CLASSES（多個選項時，請使用\",\"分隔）"
 
-#: ../terminatorlib/optionparse.py:102
+#: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr "除錯訊息中只列出要顯示的DEBUG_METHODS（多個選項時，請使用\",\"分隔）"
 
-#: ../terminatorlib/optionparse.py:104
+#: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
 msgstr "如果 Terminator 已經執行，在執行中的Terminator 開一個新的分頁"
 
-#: ../terminatorlib/optionparse.py:106
+#: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:100
+msgid "List all profiles"
+msgstr ""
+
+#: ../terminatorlib/optionparse.py:102
+msgid "List all layouts"
 msgstr ""
 
 #: ../terminatorlib/plugins/activitywatch.py:54
@@ -485,7 +521,7 @@ msgstr "自訂指令"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:194
+#: ../terminatorlib/terminal_popup_menu.py:198
 msgid "_Preferences"
 msgstr "偏好設定(_P)"
 
@@ -510,12 +546,12 @@ msgid "Enabled"
 msgstr "啟用"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Name"
 msgstr "名稱"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Command"
 msgstr "指令"
 
@@ -621,7 +657,7 @@ msgid "Escape sequence"
 msgstr "跳脫序列"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:718
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
 msgid "All"
 msgstr "全部"
 
@@ -894,250 +930,218 @@ msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "<b>Terminal Titlebar</b>"
-msgstr "<b>終端機標題</b>"
-
-#: ../terminatorlib/preferences.glade.h:75
-msgid "Font color:"
-msgstr "字型顏色："
-
-#: ../terminatorlib/preferences.glade.h:76
-msgid "Background:"
-msgstr "背景："
-
-#: ../terminatorlib/preferences.glade.h:77
-msgid "Focused"
-msgstr "當前視窗"
-
-#: ../terminatorlib/preferences.glade.h:78
-msgid "Inactive"
-msgstr "非使用中"
-
-#: ../terminatorlib/preferences.glade.h:79
-msgid "Receiving"
-msgstr "接收中"
-
-#: ../terminatorlib/preferences.glade.h:80
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
-msgid "Hide size from title"
-msgstr "不在標題列顯示終端機大小(列數X行數)"
-
-#: ../terminatorlib/preferences.glade.h:82
-msgid "_Use the system font"
-msgstr "使用系統字型"
-
-#: ../terminatorlib/preferences.glade.h:83
-msgid "_Font:"
-msgstr "字型 (_F)："
-
-#: ../terminatorlib/preferences.glade.h:84
-msgid "Choose A Titlebar Font"
-msgstr "選擇標題列字型"
-
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Global"
 msgstr "全域"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Profile"
 msgstr "設定檔"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:77
 msgid "_Use the system fixed width font"
 msgstr "使用系統的固定寬度字型 (_U)"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:78
+msgid "_Font:"
+msgstr "字型 (_F)："
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "Choose A Terminal Font"
 msgstr "請選取終端機字型"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Allow bold text"
 msgstr "可使用粗體文字 (_A)"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Show titlebar"
 msgstr "顯示標題列"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:82
 msgid "Copy on selection"
 msgstr "選擇即複製"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Select-by-_word characters:"
 msgstr "用滑鼠連按兩下選取字詞時會包括以下字元(_W):"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:85
 msgid "<b>Cursor</b>"
 msgstr "<b>游標</b>"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:86
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
-msgid "Color:"
-msgstr "顏色："
-
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:87
 msgid "Blink"
 msgstr "閃爍"
 
-#: ../terminatorlib/preferences.glade.h:98
-msgid "Foreground"
-msgstr "前景顏色"
+#: ../terminatorlib/preferences.glade.h:88
+msgid "Use default colors"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:89
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:90
+msgid "Background:"
+msgstr "背景："
+
+#: ../terminatorlib/preferences.glade.h:91
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Titlebar icon"
 msgstr "標題列圖示"
 
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:93
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:96
 msgid "General"
 msgstr "一般"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:97
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:98
 msgid "Ru_n a custom command instead of my shell"
 msgstr "啟動時執行自訂的指令而不是執行 shell(_N)"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:99
 msgid "Custom co_mmand:"
 msgstr "自訂指令 (_M)："
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:100
 msgid "When command _exits:"
 msgstr "當完成執行指令後(_E):"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:102
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>前景與背景</b>"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:103
 msgid "_Use colors from system theme"
 msgstr "使用系統佈景主題指定的色彩(_U)"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:104
 msgid "Built-in sche_mes:"
 msgstr "內建色彩組合(_M)"
 
-#: ../terminatorlib/preferences.glade.h:113
-msgid "_Text color:"
-msgstr "文字顏色(_T)："
+#: ../terminatorlib/preferences.glade.h:105
+msgid "_Foreground:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
-msgid "_Background color:"
-msgstr "背景顏色(_B)："
+#: ../terminatorlib/preferences.glade.h:106
+msgid "_Background:"
+msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:107
 msgid "<b>Palette</b>"
 msgstr "<b>調色盤</b>"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:108
 msgid "Built-in _schemes:"
 msgstr "內建色彩組合(_S)："
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:109
 msgid "Color p_alette:"
 msgstr "調色盤(_A)："
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Colors"
 msgstr "色彩"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:112
 msgid "_Solid color"
 msgstr "固定顏色(_S)"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:113
 msgid "_Transparent background"
 msgstr "透明背景(_T)"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:114
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:115
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:117
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:118
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>完全透明</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:119
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>不透明</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:120
 msgid "Background"
 msgstr "背景"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:121
 msgid "_Scrollbar is:"
 msgstr "捲動列(_S)："
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Scroll on _output"
 msgstr "輸出時捲動(_O)"
 
-#: ../terminatorlib/preferences.glade.h:131
+#: ../terminatorlib/preferences.glade.h:123
 msgid "Scroll on _keystroke"
 msgstr "按鍵時還原至原來位置(_K)"
 
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Infinite Scrollback"
 msgstr "無限制"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll_back:"
 msgstr "向後捲動(_B):"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:126
 msgid "lines"
 msgstr "行"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scrolling"
 msgstr "捲動列"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:128
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1148,80 +1152,108 @@ msgstr ""
 "在某些應用程式及作業系統需要不同的終端機運作方式時，提供暫時的解決方法。</"
 "i></small>"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:129
 msgid "_Backspace key generates:"
 msgstr "Backspace 鍵產生(_B)"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:130
 msgid "_Delete key generates:"
 msgstr "Detelet 鍵產生(_D):"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:131
 msgid "Encoding:"
 msgstr "編碼："
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "將有關兼容性的選項重設為預設值(_R)"
 
-#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/preferences.glade.h:133
 msgid "Compatibility"
 msgstr "相容性"
 
-#: ../terminatorlib/preferences.glade.h:142
-#: ../terminatorlib/terminal_popup_menu.py:201
+#: ../terminatorlib/preferences.glade.h:134
+msgid "Focused"
+msgstr "當前視窗"
+
+#: ../terminatorlib/preferences.glade.h:135
+msgid "Inactive"
+msgstr "非使用中"
+
+#: ../terminatorlib/preferences.glade.h:136
+msgid "Receiving"
+msgstr "接收中"
+
+#: ../terminatorlib/preferences.glade.h:137
+msgid "Hide size from title"
+msgstr "不在標題列顯示終端機大小(列數X行數)"
+
+#: ../terminatorlib/preferences.glade.h:138
+msgid "_Use the system font"
+msgstr "使用系統字型"
+
+#: ../terminatorlib/preferences.glade.h:139
+msgid "Choose A Titlebar Font"
+msgstr "選擇標題列字型"
+
+#: ../terminatorlib/preferences.glade.h:140
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:141
+#: ../terminatorlib/terminal_popup_menu.py:205
 msgid "Profiles"
 msgstr "設定組合"
 
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Type"
 msgstr "類型"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Profile:"
 msgstr "設定檔："
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Custom command:"
 msgstr "客製化命令"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Working directory:"
 msgstr "工作目錄："
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Layouts"
 msgstr "版面設置"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Action"
 msgstr "動作"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Keybinding"
 msgstr "快速鍵"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybindings"
 msgstr "快速鍵"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Plugin"
 msgstr "外掛程式"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:153
 msgid "This plugin has no configuration options"
 msgstr "當前外掛程式沒有可設定的選項"
 
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:154
 msgid "Plugins"
 msgstr "外掛程式"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:157
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:159
+#: ../terminatorlib/preferences.glade.h:158
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1242,18 +1274,18 @@ msgstr ""
 "添加更多的功能，也希望向系統管理員和其他用戶提供更多有用的功能。如果您有任何"
 "建議，請提交您期待的功能清單！（請參閱左側的鏈結）"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:161
 msgid "The Manual"
 msgstr "手冊"
 
-#: ../terminatorlib/preferences.glade.h:163
+#: ../terminatorlib/preferences.glade.h:162
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:165
+#: ../terminatorlib/preferences.glade.h:164
 msgid "About"
 msgstr "關於"
 
@@ -1486,82 +1518,94 @@ msgid "Ungroup all terminals"
 msgstr "取消群組(所有的終端機)"
 
 #: ../terminatorlib/prefseditor.py:164
+msgid "Group terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:165
+msgid "Group/Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:166
+msgid "Ungroup terminals in window"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:167
 msgid "Group terminals in tab"
 msgstr "群組分頁中的終端機"
 
-#: ../terminatorlib/prefseditor.py:165
+#: ../terminatorlib/prefseditor.py:168
 msgid "Group/Ungroup terminals in tab"
 msgstr "群組/取消群組 分頁中的終端機"
 
-#: ../terminatorlib/prefseditor.py:166
+#: ../terminatorlib/prefseditor.py:169
 msgid "Ungroup terminals in tab"
 msgstr "取消群組(分頁中的終端機)"
 
-#: ../terminatorlib/prefseditor.py:167
+#: ../terminatorlib/prefseditor.py:170
 msgid "Create a new window"
 msgstr "開啟新的視窗"
 
-#: ../terminatorlib/prefseditor.py:168
+#: ../terminatorlib/prefseditor.py:171
 msgid "Spawn a new Terminator process"
 msgstr "生成新的終端機程序"
 
-#: ../terminatorlib/prefseditor.py:169
+#: ../terminatorlib/prefseditor.py:172
 msgid "Don't broadcast key presses"
 msgstr "不要發送\"壓下按鍵\"通知"
 
-#: ../terminatorlib/prefseditor.py:170
+#: ../terminatorlib/prefseditor.py:173
 msgid "Broadcast key presses to group"
 msgstr "對群組發送\"壓下按鍵\"通知"
 
-#: ../terminatorlib/prefseditor.py:171
+#: ../terminatorlib/prefseditor.py:174
 msgid "Broadcast key events to all"
 msgstr "對所有視窗發送按鍵的事件"
 
-#: ../terminatorlib/prefseditor.py:172
+#: ../terminatorlib/prefseditor.py:175
 msgid "Insert terminal number"
 msgstr "插入終端機編號"
 
-#: ../terminatorlib/prefseditor.py:173
+#: ../terminatorlib/prefseditor.py:176
 msgid "Insert padded terminal number"
 msgstr "插入自動補 0 的終端機編號"
 
-#: ../terminatorlib/prefseditor.py:174
+#: ../terminatorlib/prefseditor.py:177
 msgid "Edit window title"
 msgstr "編輯視窗標題"
 
-#: ../terminatorlib/prefseditor.py:175
+#: ../terminatorlib/prefseditor.py:178
 msgid "Edit terminal title"
 msgstr "編輯終端機標題"
 
-#: ../terminatorlib/prefseditor.py:176
+#: ../terminatorlib/prefseditor.py:179
 msgid "Edit tab title"
 msgstr "編輯分頁標題"
 
-#: ../terminatorlib/prefseditor.py:177
+#: ../terminatorlib/prefseditor.py:180
 msgid "Open layout launcher window"
 msgstr "打開版面配置啟動器視窗"
 
-#: ../terminatorlib/prefseditor.py:178
+#: ../terminatorlib/prefseditor.py:181
 msgid "Switch to next profile"
 msgstr "切換到下一個配置檔"
 
-#: ../terminatorlib/prefseditor.py:179
+#: ../terminatorlib/prefseditor.py:182
 msgid "Switch to previous profile"
 msgstr "切換到上一個配置檔"
 
-#: ../terminatorlib/prefseditor.py:180
+#: ../terminatorlib/prefseditor.py:183
 msgid "Open the Preferences window"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:181
+#: ../terminatorlib/prefseditor.py:184
 msgid "Open the manual"
 msgstr "開啟使用手冊"
 
-#: ../terminatorlib/prefseditor.py:1334 ../terminatorlib/prefseditor.py:1339
+#: ../terminatorlib/prefseditor.py:1364
 msgid "New Profile"
 msgstr "新增設定組合"
 
-#: ../terminatorlib/prefseditor.py:1379 ../terminatorlib/prefseditor.py:1384
+#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
 msgid "New Layout"
 msgstr "新配置"
 
@@ -1606,141 +1650,153 @@ msgstr "複製(_C)"
 msgid "_Paste"
 msgstr "貼上(_P)"
 
-#: ../terminatorlib/terminal_popup_menu.py:114
+#: ../terminatorlib/terminal_popup_menu.py:113
+msgid "Set W_indow Title"
+msgstr ""
+
+#: ../terminatorlib/terminal_popup_menu.py:118
 msgid "Split H_orizontally"
 msgstr "水平分割"
 
-#: ../terminatorlib/terminal_popup_menu.py:124
+#: ../terminatorlib/terminal_popup_menu.py:128
 msgid "Split V_ertically"
 msgstr "垂直分割"
 
-#: ../terminatorlib/terminal_popup_menu.py:134
+#: ../terminatorlib/terminal_popup_menu.py:138
 msgid "Open _Tab"
 msgstr "開啟分頁(_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:140
+#: ../terminatorlib/terminal_popup_menu.py:144
 msgid "Open _Debug Tab"
 msgstr "開啟除錯分頁(_D)"
 
-#: ../terminatorlib/terminal_popup_menu.py:147
+#: ../terminatorlib/terminal_popup_menu.py:151
 msgid "_Close"
 msgstr "關閉(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:156
+#: ../terminatorlib/terminal_popup_menu.py:160
 msgid "_Zoom terminal"
 msgstr "縮放終端機(_Z)"
 
-#: ../terminatorlib/terminal_popup_menu.py:161
+#: ../terminatorlib/terminal_popup_menu.py:165
 msgid "Ma_ximize terminal"
 msgstr "最大化終端機"
 
-#: ../terminatorlib/terminal_popup_menu.py:168
+#: ../terminatorlib/terminal_popup_menu.py:172
 msgid "_Restore all terminals"
 msgstr "還原所有終端機(_R)"
 
-#: ../terminatorlib/terminal_popup_menu.py:175
+#: ../terminatorlib/terminal_popup_menu.py:179
 msgid "Grouping"
 msgstr "群組"
 
-#: ../terminatorlib/terminal_popup_menu.py:183
+#: ../terminatorlib/terminal_popup_menu.py:187
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:188
+#: ../terminatorlib/terminal_popup_menu.py:192
 msgid "Show _scrollbar"
 msgstr "顯示捲動列"
 
-#: ../terminatorlib/terminal_popup_menu.py:246
+#: ../terminatorlib/terminal_popup_menu.py:250
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:260
+#: ../terminatorlib/terminal_popup_menu.py:264
 msgid "Encodings"
 msgstr "編碼"
 
-#: ../terminatorlib/terminal_popup_menu.py:275
+#: ../terminatorlib/terminal_popup_menu.py:279
 msgid "Default"
 msgstr "預設"
 
-#: ../terminatorlib/terminal_popup_menu.py:278
+#: ../terminatorlib/terminal_popup_menu.py:282
 msgid "User defined"
 msgstr "使用者定義"
 
-#: ../terminatorlib/terminal_popup_menu.py:294
+#: ../terminatorlib/terminal_popup_menu.py:298
 msgid "Other Encodings"
 msgstr "其他編碼"
 
-#: ../terminatorlib/terminal.py:482
+#: ../terminatorlib/terminal.py:496
 msgid "N_ew group..."
 msgstr "新增群組"
 
-#: ../terminatorlib/terminal.py:488
+#: ../terminatorlib/terminal.py:502
 msgid "_None"
 msgstr "無(_N)"
 
-#: ../terminatorlib/terminal.py:508
+#: ../terminatorlib/terminal.py:522
 #, python-format
 msgid "Remove group %s"
 msgstr "移除群組 %s"
 
-#: ../terminatorlib/terminal.py:513
+#: ../terminatorlib/terminal.py:527
+msgid "G_roup all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:532
+msgid "Ungro_up all in window"
+msgstr ""
+
+#: ../terminatorlib/terminal.py:537
 msgid "G_roup all in tab"
 msgstr "將分頁內容合併為群組(_R)"
 
-#: ../terminatorlib/terminal.py:518
+#: ../terminatorlib/terminal.py:542
 msgid "Ungro_up all in tab"
 msgstr "取消分頁中的群組"
 
-#: ../terminatorlib/terminal.py:523
+#: ../terminatorlib/terminal.py:547
 msgid "Remove all groups"
 msgstr "移除所有群組"
 
-#: ../terminatorlib/terminal.py:530
+#: ../terminatorlib/terminal.py:554
 #, python-format
 msgid "Close group %s"
 msgstr "關閉群組 %s"
 
-#: ../terminatorlib/terminal.py:540
+#: ../terminatorlib/terminal.py:564
 msgid "Broadcast _all"
 msgstr "發送到所有終端機"
 
-#: ../terminatorlib/terminal.py:541
+#: ../terminatorlib/terminal.py:565
 msgid "Broadcast _group"
 msgstr "發送到群組"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:566
 msgid "Broadcast _off"
 msgstr "停用發送功能"
 
-#: ../terminatorlib/terminal.py:558
+#: ../terminatorlib/terminal.py:582
 msgid "_Split to this group"
 msgstr "分割群組"
 
-#: ../terminatorlib/terminal.py:563
+#: ../terminatorlib/terminal.py:587
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:570
+#: ../terminatorlib/terminal.py:594
 msgid "_Insert terminal number"
 msgstr "在命令列插入終端機編號"
 
-#: ../terminatorlib/terminal.py:574
+#: ../terminatorlib/terminal.py:598
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1487
+#: ../terminatorlib/terminal.py:1524
 msgid "Unable to find a shell"
 msgstr "找不到 shell"
 
-#: ../terminatorlib/terminal.py:1518
+#: ../terminatorlib/terminal.py:1555
 msgid "Unable to start shell:"
 msgstr "無法啟動 shell"
 
-#: ../terminatorlib/terminal.py:1958
+#: ../terminatorlib/terminal.py:2005
 msgid "Rename Window"
 msgstr "修改視窗名稱"
 
-#: ../terminatorlib/terminal.py:1966
+#: ../terminatorlib/terminal.py:2013
 msgid "Enter a new title for the Terminator window..."
 msgstr "輸入終端機視窗新標題"
 
@@ -1844,11 +1900,34 @@ msgstr "Psi"
 msgid "Omega"
 msgstr ""
 
-#: ../terminatorlib/window.py:283 ../terminatorlib/window.py:288
+#: ../terminatorlib/window.py:284 ../terminatorlib/window.py:289
 msgid "window"
 msgstr "視窗"
 
-#: ../terminatorlib/window.py:744
+#: ../terminatorlib/window.py:746
+#, python-format
+msgid "Window group %s"
+msgstr ""
+
+#: ../terminatorlib/window.py:772
 #, python-format
 msgid "Tab %d"
 msgstr "分頁 %d"
+
+#~ msgid "<b>Terminal Titlebar</b>"
+#~ msgstr "<b>終端機標題</b>"
+
+#~ msgid "Font color:"
+#~ msgstr "字型顏色："
+
+#~ msgid "Color:"
+#~ msgstr "顏色："
+
+#~ msgid "Foreground"
+#~ msgstr "前景顏色"
+
+#~ msgid "_Text color:"
+#~ msgstr "文字顏色(_T)："
+
+#~ msgid "_Background color:"
+#~ msgstr "背景顏色(_B)："

--- a/terminatorlib/optionparse.py
+++ b/terminatorlib/optionparse.py
@@ -18,7 +18,9 @@
 import sys
 import os
 
+# FIXME optparse is deprecated - argparse be used instead
 from optparse import OptionParser, SUPPRESS_HELP
+from terminatorlib.terminator import Terminator
 from .util import dbg, err
 from . import util
 from . import config
@@ -104,6 +106,10 @@ icon for the window (by file or name)'))
             help=_('If Terminator is already running, just open a new tab'))
     parser.add_option('--unhide', action='store_true', dest='unhide',
             help=_('If Terminator is already running, just unhide all hidden windows'))
+    parser.add_option('--list-profiles', action='store_true', dest='list_profiles',
+            help=_('List all profiles'))
+    parser.add_option('--list-layouts', action='store_true', dest='list_layouts',
+            help=_('List all layouts'))
 
     for item in ['--sm-client-id', '--sm-config-prefix', '--screen', '-n',
                  '--no-gconf' ]:
@@ -117,6 +123,13 @@ icon for the window (by file or name)'))
 
     if options.version:
         print('%s %s' % (version.APP_NAME, version.APP_VERSION))
+        sys.exit(0)
+
+    if options.list_profiles:
+        print(Terminator().config.list_profiles())
+        sys.exit(0)
+    if options.list_layouts:
+        print(Terminator().config.list_layouts())
         sys.exit(0)
 
     if options.debug_classes or options.debug_methods:

--- a/terminatorlib/optionparse.py
+++ b/terminatorlib/optionparse.py
@@ -114,10 +114,12 @@ icon for the window (by file or name)'))
         sys.exit(0)
 
     if options.list_profiles:
-        print(Terminator().config.list_profiles())
+        for p in Terminator().config.list_profiles():
+            print(p)
         sys.exit(0)
     if options.list_layouts:
-        print(Terminator().config.list_layouts())
+        for l in Terminator().config.list_layouts():
+            print(l)
         sys.exit(0)
 
     if options.debug_classes or options.debug_methods:

--- a/terminatorlib/optionparse.py
+++ b/terminatorlib/optionparse.py
@@ -15,11 +15,10 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 """Terminator.optionparse - Parse commandline options"""
 
+import argparse
 import sys
 import os
 
-# FIXME optparse is deprecated - argparse be used instead
-from optparse import OptionParser, SUPPRESS_HELP
 from terminatorlib.terminator import Terminator
 from .util import dbg, err
 from . import util
@@ -29,97 +28,86 @@ from .translation import _
 
 options = None
 
-def execute_cb(option, opt, value, lparser):
-    """Callback for use in parsing execute options"""
-    assert value is None
-    value = []
-    while lparser.rargs:
-        arg = lparser.rargs[0]
-        value.append(arg)
-        del(lparser.rargs[0])
-    setattr(lparser.values, option.dest, value)
+class ExecuteCallback(argparse.Action):
+    def __call__(self, lparser, namespace, values, option_string=None):
+        """Callback for use in parsing execute options"""
+        setattr(namespace, self.dest, values)
 
 def parse_options():
     """Parse the command line options"""
-    usage = "usage: %prog [options]"
-
     is_x_terminal_emulator = os.path.basename(sys.argv[0]) == 'x-terminal-emulator'
 
-    parser = OptionParser(usage)
+    parser = argparse.ArgumentParser()
 
-    parser.add_option('-v', '--version', action='store_true', dest='version',
+    parser.add_argument('-v', '--version', action='store_true', dest='version',
             help=_('Display program version'))
-    parser.add_option('-m', '--maximise', action='store_true', dest='maximise',
+    parser.add_argument('-m', '--maximise', action='store_true', dest='maximise',
             help=_('Maximize the window'))
-    parser.add_option('-M', '--maximize', action='store_true', dest='maximise',
+    parser.add_argument('-M', '--maximize', action='store_true', dest='maximise',
             help=_('Maximize the window'))
-    parser.add_option('-f', '--fullscreen', action='store_true',
+    parser.add_argument('-f', '--fullscreen', action='store_true',
             dest='fullscreen', help=_('Make the window fill the screen'))
-    parser.add_option('-b', '--borderless', action='store_true',
+    parser.add_argument('-b', '--borderless', action='store_true',
             dest='borderless', help=_('Disable window borders'))
-    parser.add_option('-H', '--hidden', action='store_true', dest='hidden',
+    parser.add_argument('-H', '--hidden', action='store_true', dest='hidden',
             help=_('Hide the window at startup'))
-    parser.add_option('-T', '--title', dest='forcedtitle', 
+    parser.add_argument('-T', '--title', dest='forcedtitle',
                       help=_('Specify a title for the window'))
-    parser.add_option('--geometry', dest='geometry', type='string', 
+    parser.add_argument('--geometry', dest='geometry', type=str,
                       help=_('Set the preferred size and position of the window'
                              '(see X man page)'))
     if not is_x_terminal_emulator:
-        parser.add_option('-e', '--command', dest='command', 
+        parser.add_argument('-e', '--command', dest='command',
                 help=_('Specify a command to execute inside the terminal'))
     else:
-        parser.add_option('--command', dest='command', 
+        parser.add_argument('--command', dest='command',
                 help=_('Specify a command to execute inside the terminal'))
-        parser.add_option('-e', '--execute2', dest='execute', action='callback',
-                callback=execute_cb, 
+        parser.add_argument('-e', '--execute2', dest='execute', action=ExecuteCallback,
                 help=_('Use the rest of the command line as a command to '
                        'execute inside the terminal, and its arguments'))
-    parser.add_option('-g', '--config', dest='config', 
+    parser.add_argument('-g', '--config', dest='config',
                       help=_('Specify a config file'))
-    parser.add_option('-j', '--config-json', dest='configjson', 
+    parser.add_argument('-j', '--config-json', dest='configjson',
                       help=_('Specify a partial config json file'))
-    parser.add_option('-x', '--execute', dest='execute', action='callback',
-            callback=execute_cb, 
+    parser.add_argument('-x', '--execute', dest='execute', action=ExecuteCallback,
             help=_('Use the rest of the command line as a command to execute '
                    'inside the terminal, and its arguments'))
-    parser.add_option('--working-directory', metavar='DIR',
+    parser.add_argument('--working-directory', metavar='DIR',
             dest='working_directory', help=_('Set the working directory'))
-    parser.add_option('-i', '--icon', dest='forcedicon', help=_('Set a custom \
+    parser.add_argument('-i', '--icon', dest='forcedicon', help=_('Set a custom \
 icon for the window (by file or name)'))
-    parser.add_option('-r', '--role', dest='role', 
+    parser.add_argument('-r', '--role', dest='role',
             help=_('Set a custom WM_WINDOW_ROLE property on the window'))
-    parser.add_option('-l', '--layout', dest='layout', 
+    parser.add_argument('-l', '--layout', dest='layout',
             help=_('Launch with the given layout'))
-    parser.add_option('-s', '--select-layout', action='store_true',
+    parser.add_argument('-s', '--select-layout', action='store_true',
             dest='select', help=_('Select a layout from a list'))
-    parser.add_option('-p', '--profile', dest='profile', 
+    parser.add_argument('-p', '--profile', dest='profile',
             help=_('Use a different profile as the default'))
-    parser.add_option('-u', '--no-dbus', action='store_true', dest='nodbus', 
+    parser.add_argument('-u', '--no-dbus', action='store_true', dest='nodbus',
             help=_('Disable DBus'))
-    parser.add_option('-d', '--debug', action='count', dest='debug',
+    parser.add_argument('-d', '--debug', action='count', dest='debug',
             help=_('Enable debugging information (twice for debug server)'))
-    parser.add_option('--debug-classes', action='store', dest='debug_classes', 
+    parser.add_argument('--debug-classes', action='store', dest='debug_classes',
             help=_('Comma separated list of classes to limit debugging to'))
-    parser.add_option('--debug-methods', action='store', dest='debug_methods',
+    parser.add_argument('--debug-methods', action='store', dest='debug_methods',
             help=_('Comma separated list of methods to limit debugging to'))
-    parser.add_option('--new-tab', action='store_true', dest='new_tab',
+    parser.add_argument('--new-tab', action='store_true', dest='new_tab',
             help=_('If Terminator is already running, just open a new tab'))
-    parser.add_option('--unhide', action='store_true', dest='unhide',
+    parser.add_argument('--unhide', action='store_true', dest='unhide',
             help=_('If Terminator is already running, just unhide all hidden windows'))
-    parser.add_option('--list-profiles', action='store_true', dest='list_profiles',
+    parser.add_argument('--list-profiles', action='store_true', dest='list_profiles',
             help=_('List all profiles'))
-    parser.add_option('--list-layouts', action='store_true', dest='list_layouts',
+    parser.add_argument('--list-layouts', action='store_true', dest='list_layouts',
             help=_('List all layouts'))
 
     for item in ['--sm-client-id', '--sm-config-prefix', '--screen', '-n',
                  '--no-gconf' ]:
-        parser.add_option(item, dest='dummy', action='store',
-                help=SUPPRESS_HELP)
+        parser.add_argument(item, dest='dummy', action='store',
+                help=argparse.SUPPRESS)
 
     global options
-    (options, args) = parser.parse_args()
-    if len(args) != 0:
-        parser.error('Additional unexpected arguments found: %s' % args)
+    options = parser.parse_args()
 
     if options.version:
         print('%s %s' % (version.APP_NAME, version.APP_VERSION))
@@ -178,5 +166,4 @@ icon for the window (by file or name)'))
     if util.DEBUG == True:
         dbg('OptionParse::parse_options: command line options: %s' % options)
 
-    
     return(options,optionslist)


### PR DESCRIPTION
Closes #495

First, I had to study how bash completion works. To do so, I simply studied the scripts used by other applications.
Then, I used `sed` and regex in order to scrape the options from `terminator --help`. (I might have nightmares about regex...)

In order to make the completion work, I put a symlink to the new file in
`/usr/share/bash-completion/completions` named `terminator`.
I think this is something the package maintainers have to care about.

Sadly, each shell uses a different type of completion script. This means that this one in particular will only work on bash.

In order to get the options, `terminator --help` has to be run, so there is a very little overhead because python has to start.

Edit: the folder where the scripts are put might be different depending on the distro. On Debian it's the one I wrote.