### PR TITLE
Bug Fix: hide_window keybinding ignores Shift key

### DIFF
--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -28,6 +28,7 @@ if display_manager() == 'X11':
         gi.require_version('Keybinder', '3.0')
         from gi.repository import Keybinder
         Keybinder.init()
+        Keybinder.set_use_cooked_accelerators(False)
     except (ImportError, ValueError):
         err('Unable to load Keybinder module. This means the \
 hide_window shortcut will be unavailable')
@@ -133,7 +134,7 @@ class Window(Container, Gtk.Window):
             if display_manager() == 'X11':
                 try:
                     self.hidebound = Keybinder.bind(
-                        self.config['keybindings']['hide_window'].replace('<Shift>',''),
+                        self.config['keybindings']['hide_window'],
                         self.on_hide_window)
                 except (KeyError, NameError):
                     pass


### PR DESCRIPTION
Fixes #509

The shift key gets ignored by the global Keybinder. That's not a bug in the library, it's a misconfiguration.
By default, keybinder uses "cooked accelerators".

I quote from the issue comments.

> The best documentation I found is the comments in the code. They are pretty good.
>From [this](https://github.com/kupferlauncher/keybinder/blob/master/libkeybinder/bind.c):
> > "Cooked" accelerators use symbols produced by using modifiers such as shift or altgr, for example if "!" is produced by "Shift+1".

There is this C function
```c
keybinder_set_use_cooked_accelerators
```

So yeah, we just had to disable them using this:
```py
Keybinder.set_use_cooked_accelerators(False)
```
---

There is another issue about hide_window not working (#427). I doubt it's related to this, I think that one is about Wayland.