### PR TITLE
Add 'Disable mouse paste'

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -110,6 +110,7 @@ DEFAULTS = {
             'always_split_with_profile': False,
             'putty_paste_style'     : False,
             'putty_paste_style_source_clipboard': False,
+            'disable_mouse_paste'   : False,
             'smart_copy'            : True,
             'clear_select_on_copy'  : False,
             'line_height'           : 1.0,

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -562,7 +562,7 @@
                               </packing>
                             </child>
                             <child>
-                              <!-- n-columns=4 n-rows=8 -->
+                              <!-- n-columns=4 n-rows=9 -->
                               <object class="GtkGrid" id="grid2">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -679,8 +679,8 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
-                                    <property name="top-attach">4</property>
-                                    <property name="width">3</property>
+                                    <property name="top-attach">5</property>
+                                    <property name="width">4</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -693,53 +693,6 @@
                                     <property name="xalign">0.5</property>
                                     <property name="draw-indicator">True</property>
                                     <signal name="toggled" handler="on_use_custom_url_handler_checkbutton_toggled" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">6</property>
-                                    <property name="width">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkAlignment" id="alignment10">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
-                                    <child>
-                                      <object class="GtkBox" id="hbox11">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label33">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Custom URL handler:</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkEntry" id="custom_url_handler_entry">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="invisible-char">•</property>
-                                            <property name="primary-icon-activatable">False</property>
-                                            <property name="secondary-icon-activatable">False</property>
-                                            <signal name="changed" handler="on_custom_url_handler_entry_changed" swapped="no"/>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
@@ -808,15 +761,65 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
-                                    <property name="top-attach">5</property>
+                                    <property name="top-attach">6</property>
                                     <property name="width">4</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <placeholder/>
+                                  <object class="GtkCheckButton" id="disable_mouse_paste">
+                                    <property name="label" translatable="yes">Disable mouse paste</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="xalign">0.5</property>
+                                    <property name="draw-indicator">True</property>
+                                    <signal name="toggled" handler="on_disable_mouse_paste_toggled" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">4</property>
+                                    <property name="width">4</property>
+                                  </packing>
                                 </child>
                                 <child>
-                                  <placeholder/>
+                                  <object class="GtkBox" id="hbox11">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-left">12</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label33">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Custom URL handler:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="custom_url_handler_entry">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="invisible-char">•</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
+                                        <signal name="changed" handler="on_custom_url_handler_entry_changed" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">8</property>
+                                    <property name="width">4</property>
+                                  </packing>
                                 </child>
                                 <child>
                                   <placeholder/>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -356,6 +356,9 @@ class PrefsEditor:
         # Clear selection on copy
         widget = guiget('clear_select_on_copy')
         widget.set_active(self.config['clear_select_on_copy'])
+        # Disable mouse paste
+        widget = guiget('disable_mouse_paste')
+        widget.set_active(self.config['disable_mouse_paste'])
 
         ## Profile tab
         # Populate the profile list
@@ -840,6 +843,11 @@ class PrefsEditor:
     def on_clear_select_on_copy_toggled(self,widget):
         """Clear selection on smart copy"""
         self.config['clear_select_on_copy'] = widget.get_active()
+        self.config.save()
+
+    def on_disable_mouse_paste_toggled(self, widget):
+        """Disable mouse paste"""
+        self.config['disable_mouse_paste'] = widget.get_active()
         self.config.save()
 
     def on_cursor_blink_toggled(self, widget):

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -978,9 +978,9 @@ class Terminal(Gtk.VBox):
 
         if self.config['putty_paste_style']:
             middle_click = [self.popup_menu, (widget, event)]
-            right_click = [self.paste_clipboard, (not self.config['putty_paste_style_source_clipboard'], )]
+            right_click = [self.paste_clipboard, (not self.config['putty_paste_style_source_clipboard'], True)]
         else:
-            middle_click = [self.paste_clipboard, (True, )]
+            middle_click = [self.paste_clipboard, (True, True)]
             right_click = [self.popup_menu, (widget, event)]
 
         # Ctrl-click event here.
@@ -1621,14 +1621,15 @@ class Terminal(Gtk.VBox):
             webbrowser.open(url)
 
 
-    def paste_clipboard(self, primary=False):
+    def paste_clipboard(self, primary=False, mouse=False):
         """Paste one of the two clipboards"""
-        for term in self.terminator.get_target_terms(self):
-            if primary:
-                term.vte.paste_primary()
-            else:
-                term.vte.paste_clipboard()
-        self.vte.grab_focus()
+        if not (mouse and self.config['disable_mouse_paste']):
+            for term in self.terminator.get_target_terms(self):
+                if primary:
+                    term.vte.paste_primary()
+                else:
+                    term.vte.paste_clipboard()
+            self.vte.grab_focus()
 
     def feed(self, text):
         """Feed the supplied text to VTE"""


### PR DESCRIPTION
Fixes #415

These changes add the `disable_mouse_paste` setting. Default is `False`. When enabled, middle mouse click (or if putty, right click) will do nothing.

The setting is global, because it affects broadcast.