### PR TITLE
Automatically focus the Keybindings menu

### DIFF
--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -3719,6 +3719,7 @@
                   <object class="GtkTreeView" id="keybindingtreeview">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
+                    <property name="has-focus">True</property>
                     <property name="model">KeybindingsListStore</property>
                     <property name="headers-clickable">False</property>
                     <property name="search-column">0</property>


### PR DESCRIPTION
Fixes a bug in Preferences, Keybindings.

Right now, to activate the search bar, we need to click the tree menu.
This change makes the search bar work without having to click the widget, giving the focus to it automatically.