### PR TITLE
Fix terminal separator size setting

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -84,7 +84,7 @@ DEFAULTS = {
         'global_config':   {
             'dbus'                  : True,
             'focus'                 : 'click',
-            'handle_size'           : -1,
+            'handle_size'           : 1,
             'geometry_hinting'      : False,
             'window_state'          : 'normal',
             'borderless'            : False,

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -307,9 +307,9 @@
     </data>
   </object>
   <object class="GtkAdjustment" id="adjustment1">
-    <property name="lower">-1</property>
+    <property name="lower">1</property>
     <property name="upper">20</property>
-    <property name="value">-1</property>
+    <property name="value">1</property>
     <property name="step-increment">1</property>
     <property name="page-increment">2</property>
   </object>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1270,6 +1270,8 @@ class PrefsEditor:
         value = int(value)          # Cast to int.
         if value > 20:
             value = 20
+        if value < 1:
+            value = 1
         self.config['handle_size'] = value
         self.config.save()
         guiget = self.builder.get_object


### PR DESCRIPTION
Partially addresses #518 , not sure where I can insert a config to modify color of terminal seperator so I'll put that one on hold for now.

1. Make it such that if handle_size is out of range, handle_size will be defaulted to smallest.
2. Terminator seperator size in gui settings will have range from 1 to 20, instead of -1 to 20 which is extremely misleading as -1 and 0 is out of range and previously defaults to a larger value.
