### PR TITLE
Add paste_selection keybinding.

### DIFF
--- a/doc/terminator_config.5
+++ b/doc/terminator_config.5
@@ -228,6 +228,10 @@ Default value: \fB<Ctrl><Shift>C\fR
 Paste the current contents of the clipboard.
 Default value: \fB<Ctrl><Shift>V\fR
 .TP
+.B paste_selection
+Paste the current contents of the primary selection.
+Default value: \fBUnbound\fR
+.TP
 .B toggle_scrollbar
 Show/Hide the scrollbar.
 Default value: \fB<Ctrl><Shift>S\fR

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -142,6 +142,7 @@ DEFAULTS = {
             'close_term'       : '<Shift><Control>w',
             'copy'             : '<Shift><Control>c',
             'paste'            : '<Shift><Control>v',
+            'paste_selection'  : '',
             'toggle_scrollbar' : '<Shift><Control>s',
             'search'           : '<Shift><Control>f',
             'page_up'          : '',

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -124,6 +124,7 @@ class PrefsEditor:
                         'close_term'       : _('Close terminal'),
                         'copy'             : _('Copy selected text'),
                         'paste'            : _('Paste clipboard'),
+                        'paste_selection'  : _('Paste primary selection'),
                         'toggle_scrollbar' : _('Show/Hide the scrollbar'),
                         'search'           : _('Search terminal scrollback'),
                         'page_up'          : _('Scroll upwards one page'),

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1810,6 +1810,9 @@ class Terminal(Gtk.VBox):
     def key_paste(self):
         self.paste_clipboard()
 
+    def key_paste_selection(self):
+        self.paste_clipboard(True)
+
     def key_toggle_scrollbar(self):
         self.do_scrollbar_toggle()
 


### PR DESCRIPTION
Unbound by default, pastes primary selection.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>