### PR TITLE
Fix: 'None' value for keybindings breaks editor

### DIFF
--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1738,10 +1738,13 @@ class PrefsEditor:
 
         accel = Gtk.accelerator_name(key, mods)
         current_binding = liststore.get_value(liststore.get_iter(path), 0)
+        parsed_accel = Gtk.accelerator_parse(accel)
 
         duplicate_bindings = []
         for conf_binding, conf_accel in self.config["keybindings"].items():
-            parsed_accel = Gtk.accelerator_parse(accel)
+            if conf_accel is None:
+                continue
+
             parsed_conf_accel = Gtk.accelerator_parse(conf_accel)
 
             if (

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -130,7 +130,7 @@ class Window(Container, Gtk.Window):
 
         # Attempt to grab a global hotkey for hiding the window.
         # If we fail, we'll never hide the window, iconifying instead.
-        if self.config['keybindings']['hide_window'] != '':
+        if self.config['keybindings']['hide_window'] not in ('', None):
             if display_manager() == 'X11':
                 try:
                     self.hidebound = Keybinder.bind(


### PR DESCRIPTION
Fixes #548 

As explained in the issue, if a keybinding's value is set to None, it becomes impossible to remap it.
However, I've noticed this affects all the keybindings: if one of them is set to None, then the Preferences Editor won't be able to change any value.
This is because function `Gtk.accelerator_parse` (which is called to avoid keybinding duplication) does not allow None as a value.

Also, since we should consider `None` as a valid value for `hide_window`, we have to check for both `''` and `None` (last changed in #515)