### PR TITLE
Unzoom terminal on interaction

### DIFF
--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -278,7 +278,6 @@ class Notebook(Container, Gtk.Notebook):
                    'split-horiz': self.split_horiz,
                    'split-vert': self.split_vert,
                    'title-change': self.propagate_title_change,
-                   'unzoom': self.unzoom,
                    'tab-change': top_window.tab_change,
                    'group-all': top_window.group_all,
                    'group-all-toggle': top_window.group_all_toggle,

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -915,20 +915,6 @@ class Terminal(Gtk.VBox):
         # FIXME: Does keybindings really want to live in Terminator()?
         mapping = self.terminator.keybindings.lookup(event)
 
-        # Just propagate tab-swictch events if there is only one tab
-        if (
-                mapping and (
-                    mapping.startswith('switch_to_tab') or
-                    mapping in ('next_tab', 'prev_tab')
-                )
-        ):
-            window = self.get_toplevel()
-            child = window.get_children()[0]
-            if isinstance(child, Terminal):
-                # not a Notebook instance => a single tab is used
-                # .get_n_pages() can not be used
-                return False
-
         if mapping == "hide_window":
             return False
 
@@ -1417,15 +1403,8 @@ class Terminal(Gtk.VBox):
 
     def is_zoomed(self):
         """Determine if we are a zoomed terminal"""
-        prop = None
         window = self.get_toplevel()
-
-        try:
-            prop = window.get_property('term-zoomed')
-        except TypeError:
-            prop = False
-
-        return prop
+        return window.is_zoomed()
 
     def zoom(self, widget=None):
         """Zoom ourself to fill the window"""

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -915,9 +915,8 @@ class Window(Container, Gtk.Window):
 
             if len(winners) > 1:
                 # Break an n-way tie using the cursor position
-                term_alloc = terminal.get_allocation()
-                cursor_x = term_alloc.x + term_alloc.width / 2
-                cursor_y = term_alloc.y + term_alloc.height / 2
+                cursor_x = allocation.x + allocation.width / 2
+                cursor_y = allocation.y + allocation.height / 2
 
                 for term in winners:
                     rect = layout[term]

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -572,11 +572,10 @@ class Window(Container, Gtk.Window):
 
     def rotate(self, widget, clockwise):
         """Rotate children in this window"""
-        # FIXME after an unzoom, child.get_allocation() returns
-        # strange values, making the rotation work improperly
-        # Same problem as in navigate_terminal
         if self.is_zoomed():
             self.unzoom()
+            while Gtk.events_pending():
+                Gtk.main_iteration_do(False)
 
         self.set_pos_by_ratio = True
         maker = Factory()
@@ -856,10 +855,10 @@ class Window(Container, Gtk.Window):
 
     def navigate_terminal(self, terminal, direction):
         """Navigate around terminals"""
-        # FIXME after an unzoom, terminal.get_allocation() returns
-        # strange values, making the navigation work improperly
         if self.is_zoomed():
             self.unzoom()
+            while Gtk.events_pending():
+                Gtk.main_iteration_do(False)
 
         _containers, terminals = util.enumerate_descendants(self)
         visibles = self.get_visible_terminals()


### PR DESCRIPTION
Fixes #550

These changes make a zoomed/maximized terminal unzoom on interactions such as: creating a new tab, resizing the terminal, splitting it etc...

There are still problems with two of these interactions: rotating the terminal and moving to another terminal.
The function `get_allocation()` returns `(width: 1, height: 1, ...)` right after an unzoom.

The bug can be replicated with a few terminals (I use one on the left, one top-right, one bottom-right). Zoom the bottom-right one and try to rotate or move to the top-right terminal.
What I get for the rotation is that one terminal is big, the other two are very small.