### PR TITLE
Add initial flatpak-spawn support

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1505,14 +1505,37 @@ class Terminal(Gtk.VBox):
 
         dbg('Forking shell: "%s" with args: %s' % (shell, args))
         args.insert(0, shell)
-        result,  self.pid = self.vte.spawn_sync(Vte.PtyFlags.DEFAULT,
-                                                self.cwd,
-                                                args,
-                                                envv,
-                                                GLib.SpawnFlags.FILE_AND_ARGV_ZERO,
-                                                None,
-                                                None,
-                                                None)
+
+        if util.is_flatpak():
+            dbg('Flatpak detected')
+            args = util.get_flatpak_args(args, envv, self.cwd)
+            dbg('Forking shell: "%s" with args: %s via flatpak-spawn' % (shell, args))
+        
+            self.pid = self.vte.spawn_async(
+                Vte.PtyFlags.NO_CTTY,
+                self.cwd,
+                args,
+                envv,
+                0,
+                None,
+                None,
+                -1,
+                None,
+                None,
+                None,
+            )
+        else:
+            result, self.pid = self.vte.spawn_sync(
+                    Vte.PtyFlags.DEFAULT,
+                    self.cwd,
+                    args,
+                    envv,
+                    GLib.SpawnFlags.FILE_AND_ARGV_ZERO,
+                    None,
+                    None,
+                    None
+                    )
+
         self.command = shell
 
         self.titlebar.update()

--- a/terminatorlib/util.py
+++ b/terminatorlib/util.py
@@ -407,20 +407,13 @@ def update_config_to_cell_height(filename):
 
 def get_flatpak_args(args, envv, cwd):
     """Contruct args to be executed via flatpak-spawn"""
-    import json
     flatpak_args = None
-    shell = [args[0]]
     env_args = ['--env={}'.format(env) for env in envv]
     flatpak_spawn = [
         "flatpak-spawn", "--host", "--watch-bus", "--forward-fd=1",
         "--forward-fd=2", "--directory={}".format(cwd)
     ]
-    if len(args) == 2:
-        flatpak_args = flatpak_spawn + env_args + shell
-
-    # Support -x, -e, custom commands etc.
-    if len(args) > 2:
-        flatpak_args = flatpak_spawn + env_args + args[1:]
+    flatpak_args = flatpak_spawn + env_args + args
 
     dbg('returned flatpak args:  %s' % flatpak_args)
 

--- a/terminatorlib/util.py
+++ b/terminatorlib/util.py
@@ -413,6 +413,11 @@ def get_flatpak_args(args, envv, cwd):
         "flatpak-spawn", "--host", "--watch-bus", "--forward-fd=1",
         "--forward-fd=2", "--directory={}".format(cwd)
     ]
+    # Detect and remove duplicate shell in args
+    # to work around vte.spawn_sync() requirement.
+    if len(set([args[0], args[1]])) == 1:
+        del args[0]
+
     flatpak_args = flatpak_spawn + env_args + args
 
     dbg('returned flatpak args:  %s' % flatpak_args)

--- a/terminatorlib/util.py
+++ b/terminatorlib/util.py
@@ -43,6 +43,9 @@ DEBUGCLASSES = []
 # list of methods to show debugging for. empty list means show all methods
 DEBUGMETHODS = []
 
+def is_flatpak():
+    return os.path.exists("/.flatpak-info")
+
 def dbg(log = ""):
     """Print a message if debugging is enabled"""
     if DEBUG:
@@ -144,6 +147,13 @@ def path_lookup(command):
 
 def shell_lookup():
     """Find an appropriate shell for the user"""
+    if is_flatpak():
+        getent = subprocess.check_output([
+            'flatpak-spawn', '--host', 'getent', 'passwd',
+            pwd.getpwuid(os.getuid())[0]
+        ]).decode(encoding='UTF-8').rstrip('\n')
+        shell = getent.split(':')[6]
+        return shell
     try:
         usershell = pwd.getpwuid(os.getuid())[6]
     except KeyError:
@@ -394,3 +404,24 @@ def update_config_to_cell_height(filename):
     except Exception as ex:
         err('Unable to open ‘%s’ for reading and/or writting.\n(%s)'
                 % (filename, ex))
+
+def get_flatpak_args(args, envv, cwd):
+    """Contruct args to be executed via flatpak-spawn"""
+    import json
+    flatpak_args = None
+    shell = [args[0]]
+    env_args = ['--env={}'.format(env) for env in envv]
+    flatpak_spawn = [
+        "flatpak-spawn", "--host", "--watch-bus", "--forward-fd=1",
+        "--forward-fd=2", "--directory={}".format(cwd)
+    ]
+    if len(args) == 2:
+        flatpak_args = flatpak_spawn + env_args + shell
+
+    # Support -x, -e, custom commands etc.
+    if len(args) > 2:
+        flatpak_args = flatpak_spawn + env_args + args[1:]
+
+    dbg('returned flatpak args:  %s' % flatpak_args)
+
+    return flatpak_args


### PR DESCRIPTION
This is adding experimental flatpak support as well as definition.

It builds and works ok however flatpak-spawn doesn't seem to be handling tty properly (see https://github.com/flatpak/flatpak/issues/3697)

It's usable and perhaps could be submitted to flathub beta and wait until flatpak-spawn resolves issues with tty or someone rewrites it. 

Fixes: https://github.com/gnome-terminator/terminator/issues/206