### PR TITLE
Fix POTFILES.in + update translation files

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -12,7 +12,6 @@ terminatorlib/container.py
 terminatorlib/cwd.py
 terminatorlib/debugserver.py
 terminatorlib/editablelabel.py
-terminatorlib/encoding.py
 terminatorlib/factory.py
 terminatorlib/__init__.py
 terminatorlib/keybindings.py

--- a/po/af.po
+++ b/po/af.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Afrikaans (https://www.transifex.com/terminator/teams/109338/af/)\n"
+"Language-Team: Afrikaans (https://www.transifex.com/terminator/teams/109338/"
+"af/)\n"
+"Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: af\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Veelvuldige terminale in een venster"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Huldige Lokaliteit"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Westers"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Sentraal-Europees"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Suid-Europees"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Balties"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrillies"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabies"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grieks"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebreeus Visueel"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebreeus"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turks"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Noors"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Kelties"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romeens"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unikode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armeens"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Sjinees Tradisioneel"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyrillies/Russies"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japannees"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koriaans"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Sjinees Vereenvoudig"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgies"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cyrillies/Oekraïens"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroaties"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persies"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Goedjarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Yslands"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Viëtnamees"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thais"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "oortjie"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Sluit oortjie"
 
@@ -517,7 +374,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Voorkeure"
 
@@ -542,12 +399,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -653,7 +510,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Alle"
 
@@ -870,43 +727,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -914,437 +771,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiele"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1579,11 +1452,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nuwe profiel"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nuwe uitleg"
 
@@ -1596,185 +1469,169 @@ msgstr "Soek:"
 msgid "Close Search bar"
 msgstr "Sluit die soekbalk"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Stuur e-pos aan…"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopieer e-pos adres"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Be_l VoIP-adres"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopiëren VoIP-adres"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Open skakel"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopiëer adres"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Split H_orisontaal"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Split Vertikaal"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Nuwe _oortjie"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Open _ontfoutingsoortjie"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zoem in op terminaal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "He_rstel alle terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Groepering"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Vertoon rol_staaf"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Enkoderings"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Verstek"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Gebruikersgedefinieerd"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Ander enkoderings"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Verwyder groep %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_roepeer alle in dié oortjie"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Verwyder alle groepe"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Sluit groep %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Geen shell gevind nie"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Kan shell nie start nie"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1882,12 +1739,117 @@ msgstr ""
 msgid "window"
 msgstr "venster"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Oortjie %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Huldige Lokaliteit"
+
+#~ msgid "Western"
+#~ msgstr "Westers"
+
+#~ msgid "Central European"
+#~ msgstr "Sentraal-Europees"
+
+#~ msgid "South European"
+#~ msgstr "Suid-Europees"
+
+#~ msgid "Baltic"
+#~ msgstr "Balties"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrillies"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabies"
+
+#~ msgid "Greek"
+#~ msgstr "Grieks"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebreeus Visueel"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebreeus"
+
+#~ msgid "Turkish"
+#~ msgstr "Turks"
+
+#~ msgid "Nordic"
+#~ msgstr "Noors"
+
+#~ msgid "Celtic"
+#~ msgstr "Kelties"
+
+#~ msgid "Romanian"
+#~ msgstr "Romeens"
+
+#~ msgid "Unicode"
+#~ msgstr "Unikode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armeens"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Sjinees Tradisioneel"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyrillies/Russies"
+
+#~ msgid "Japanese"
+#~ msgstr "Japannees"
+
+#~ msgid "Korean"
+#~ msgstr "Koriaans"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Sjinees Vereenvoudig"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgies"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cyrillies/Oekraïens"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroaties"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persies"
+
+#~ msgid "Gujarati"
+#~ msgstr "Goedjarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Yslands"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Viëtnamees"
+
+#~ msgid "Thai"
+#~ msgstr "Thais"
+
+#~ msgid "Encodings"
+#~ msgstr "Enkoderings"
+
+#~ msgid "Default"
+#~ msgstr "Verstek"
+
+#~ msgid "User defined"
+#~ msgstr "Gebruikersgedefinieerd"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Ander enkoderings"

--- a/po/ar.po
+++ b/po/ar.po
@@ -2,24 +2,26 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Arabic (https://www.transifex.com/terminator/teams/109338/ar/)\n"
+"Language-Team: Arabic (https://www.transifex.com/terminator/teams/109338/"
+"ar/)\n"
+"Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ar\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -123,7 +125,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "المتطرف"
 
@@ -132,7 +134,7 @@ msgid "Multiple terminals in one window"
 msgstr "العديد من الطرفيات في نافذة واحدة"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +142,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +226,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "لا تعرض هذه الرسالة مرة أخرى"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "اللغه الحاليه"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "الغربيه"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "الاوروبيه الوسطيه"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "الاوروبيه الجنوبيه"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "البلطيقيه"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "السيريليه"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "العربيه"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "اليونانيه"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "العبرية البصرية"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "العبريه"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "التركيه"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "الشماليه"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "السلتيه"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "الرومانيه"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "الترميز"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "الأرميني"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "الصينيّة التقليديّة"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "السيرياليه/الروسيه"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "اليابانيه"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "الكوريه"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "الصينيه المُبَسَطه"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "الجورجيه"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "السيرياليه/الاكرانيه"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "كرواتي"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "هندي"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "الفارسية"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "الغوجاراتية"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "غرموخي"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "الآيسلندية"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "الفيتنامية"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "التايلندية"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +239,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "تبويب"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "إغلاق تبويب"
 
@@ -515,7 +373,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_تفضيلات"
 
@@ -540,12 +398,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "أمر"
 
@@ -651,7 +509,7 @@ msgid "Escape sequence"
 msgstr "انهاء التسلسل"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "الجميع"
 
@@ -868,43 +726,43 @@ msgid "Use custom URL handler"
 msgstr "استخدم معالج عناوين مخصص"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
+msgid "<b>Appearance</b>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "حدود النافذة"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,439 +770,457 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
+msgid "Tabs scroll buttons"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "شامل"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "الملف الشخصي"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_استخدم خط النظام ذو العرض الثابت"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_الخط:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "اختر خط الطرفية"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_اسمح بالنص العريض"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "أظهر شريط العنوان"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "أنسخ عند التحديد"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "اختيار باعتبار رموز ال_كلمات:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>المؤشر</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>جرس الطرفيّة</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "أيقونة شريط العنوان"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "وميض مرئي"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "رنّة مسموعة"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "نافذة القائمة الومضية"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "عامّ"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_شغل الأمر كمفتاح لتسجيل الدخول"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "_شغل أمراً مخصّصاُ عوضاً عن الأمر الهيكلي"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "ال_أمر المخصّص:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "عند _وجود الأمر:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>المقدمة و الخلفية</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "استخدم ألوان سمة النظام"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "المخططات م_ضمنة:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>لوح الألوان</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "ال_مخططات المضمنة:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "_لوح الألوان:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "اﻷلوان"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "لون _جامد"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "خلفية _شفافة"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>لا شيء</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>الأقصى</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "الخلفية"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_شريط التمرير:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "لف عند ال_خرْج"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "لف عند _نقر مفتاح"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "رجوع العجلة للوراء بدون جد معين"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "ا_لف إلى الوراء:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "سطور"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "التمرير"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
-"<small><i><b>ملاحظة:</b> قد تتسبّب هذه الخيارات في عدم عمل بعض التطبيقات بسلامة.\n"
-"الخيارات موجودة فقط لتجعلك تتخطّى عددا من التطبيقات و أنظمة التشغيل التي تتوقّع سلوكا مختلفا من الطرفيّة.</i></small>"
+"<small><i><b>ملاحظة:</b> قد تتسبّب هذه الخيارات في عدم عمل بعض التطبيقات "
+"بسلامة.\n"
+"الخيارات موجودة فقط لتجعلك تتخطّى عددا من التطبيقات و أنظمة التشغيل التي "
+"تتوقّع سلوكا مختلفا من الطرفيّة.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "_زر Backspace يولد:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "_زر DELETE يولد:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_أعد ضبط خيارات التوافق لقيمها الافتراضية"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "التوافق"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "ملفات المستخدمين"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "المخططات"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "ارتباطات المفاتيح"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "هذه الإضافة ليس لها خيارات ضبط"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "الإضافات"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1579,11 +1455,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "ملف شخصي جديد"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "مظهر جديد"
 
@@ -1596,185 +1472,169 @@ msgstr "إبحث:"
 msgid "Close Search bar"
 msgstr "إغلاق شريط البحث"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_إرسال بريد إلكتروني إلى..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_نسخ بريد إلكتروني إلى..."
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Ca_ll  عنوان اتصال VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_نسخ عنوان اتصال VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_فتح رابط"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_نسخ عنوان"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "اقسم أف_قيا"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "اقسم ع_موديا"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "افتح _لسان"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "فتح_لسان تصحيحي"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "ت_كبير الطرفية"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_استعادة جميع الطرفيّات"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "تجميع"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "إظهار_شريط تمرير"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "الترميزات"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "افتراضي"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "المستخدم معرّف"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "ترميزات اخرى"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "حذف المجموعة %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "تجمي_ع كل التبويبات"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "حذف كل المجموعات"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "إغلاق المجموعة %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "تعثر العثور على قشرة"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "لا يمكن تمكين الهيكل"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "أعد تسمية النافذة"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "ضع عنواناً جديداً لنافذة المنهي...."
 
@@ -1882,12 +1742,117 @@ msgstr ""
 msgid "window"
 msgstr "نافذة"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "تبويب %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "اللغه الحاليه"
+
+#~ msgid "Western"
+#~ msgstr "الغربيه"
+
+#~ msgid "Central European"
+#~ msgstr "الاوروبيه الوسطيه"
+
+#~ msgid "South European"
+#~ msgstr "الاوروبيه الجنوبيه"
+
+#~ msgid "Baltic"
+#~ msgstr "البلطيقيه"
+
+#~ msgid "Cyrillic"
+#~ msgstr "السيريليه"
+
+#~ msgid "Arabic"
+#~ msgstr "العربيه"
+
+#~ msgid "Greek"
+#~ msgstr "اليونانيه"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "العبرية البصرية"
+
+#~ msgid "Hebrew"
+#~ msgstr "العبريه"
+
+#~ msgid "Turkish"
+#~ msgstr "التركيه"
+
+#~ msgid "Nordic"
+#~ msgstr "الشماليه"
+
+#~ msgid "Celtic"
+#~ msgstr "السلتيه"
+
+#~ msgid "Romanian"
+#~ msgstr "الرومانيه"
+
+#~ msgid "Unicode"
+#~ msgstr "الترميز"
+
+#~ msgid "Armenian"
+#~ msgstr "الأرميني"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "الصينيّة التقليديّة"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "السيرياليه/الروسيه"
+
+#~ msgid "Japanese"
+#~ msgstr "اليابانيه"
+
+#~ msgid "Korean"
+#~ msgstr "الكوريه"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "الصينيه المُبَسَطه"
+
+#~ msgid "Georgian"
+#~ msgstr "الجورجيه"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "السيرياليه/الاكرانيه"
+
+#~ msgid "Croatian"
+#~ msgstr "كرواتي"
+
+#~ msgid "Hindi"
+#~ msgstr "هندي"
+
+#~ msgid "Persian"
+#~ msgstr "الفارسية"
+
+#~ msgid "Gujarati"
+#~ msgstr "الغوجاراتية"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "غرموخي"
+
+#~ msgid "Icelandic"
+#~ msgstr "الآيسلندية"
+
+#~ msgid "Vietnamese"
+#~ msgstr "الفيتنامية"
+
+#~ msgid "Thai"
+#~ msgstr "التايلندية"
+
+#~ msgid "Encodings"
+#~ msgstr "الترميزات"
+
+#~ msgid "Default"
+#~ msgstr "افتراضي"
+
+#~ msgid "User defined"
+#~ msgstr "المستخدم معرّف"
+
+#~ msgid "Other Encodings"
+#~ msgstr "ترميزات اخرى"

--- a/po/ast.po
+++ b/po/ast.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Asturian (https://www.transifex.com/terminator/teams/109338/ast/)\n"
+"Language-Team: Asturian (https://www.transifex.com/terminator/teams/109338/"
+"ast/)\n"
+"Language: ast\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ast\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Delles terminales nuna ventana"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Configuración llocal actual"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Occidental"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Centroeuropéu"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Europa del sur"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Bálticu"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirílicu"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Árabe"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Griegu"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebréu visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebréu"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turcu"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nórdicu"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Célticu"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumanu"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armeniu"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chinu tradicional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cirílicu/Rusu"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Xaponés"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coreanu"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chinu simplificáu"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Xorxanu"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirílicu/Ucranianu"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croata"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindí"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persa"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandés"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamita"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "llingüeta"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Zarrar llingüeta"
 
@@ -518,7 +375,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferencies"
 
@@ -543,12 +400,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -654,7 +511,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Too"
 
@@ -871,43 +728,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -915,437 +772,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Perfiles"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1580,11 +1453,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Perfil nuevu"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Aspeutu nuevu"
 
@@ -1597,185 +1470,169 @@ msgstr "Guetar:"
 msgid "Close Search bar"
 msgstr "Zarrar la barra de gueta"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Unviar corréu a..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copiar señes de corréu"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_Llamar a señes de VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copiar señes de VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Abrir enllaz"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copiar señes"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Dividir n'h_orizontal"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Dividir en v_ertical"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Abrir llingüe_ta"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Abrir llingüeta de _depuración"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zoom del terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restaurar tolos terminales"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Agrupamientu"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Amosar barra de de_splazamientu"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Codificaciones"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Predetermináu"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definío pol usuariu"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Otres codificaciones"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Desaniciar el grupu %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Ag_rupar too en llingüeta"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Desaniciar tolos grupos"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Zarrar el grupu %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Nun se pue alcontrar una shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Nun se pue aniciar la shell:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1883,12 +1740,117 @@ msgstr ""
 msgid "window"
 msgstr "ventana"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "llingüeta %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Configuración llocal actual"
+
+#~ msgid "Western"
+#~ msgstr "Occidental"
+
+#~ msgid "Central European"
+#~ msgstr "Centroeuropéu"
+
+#~ msgid "South European"
+#~ msgstr "Europa del sur"
+
+#~ msgid "Baltic"
+#~ msgstr "Bálticu"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirílicu"
+
+#~ msgid "Arabic"
+#~ msgstr "Árabe"
+
+#~ msgid "Greek"
+#~ msgstr "Griegu"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebréu visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebréu"
+
+#~ msgid "Turkish"
+#~ msgstr "Turcu"
+
+#~ msgid "Nordic"
+#~ msgstr "Nórdicu"
+
+#~ msgid "Celtic"
+#~ msgstr "Célticu"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumanu"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armeniu"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chinu tradicional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cirílicu/Rusu"
+
+#~ msgid "Japanese"
+#~ msgstr "Xaponés"
+
+#~ msgid "Korean"
+#~ msgstr "Coreanu"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chinu simplificáu"
+
+#~ msgid "Georgian"
+#~ msgstr "Xorxanu"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirílicu/Ucranianu"
+
+#~ msgid "Croatian"
+#~ msgstr "Croata"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindí"
+
+#~ msgid "Persian"
+#~ msgstr "Persa"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandés"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamita"
+
+#~ msgid "Thai"
+#~ msgstr "Thai"
+
+#~ msgid "Encodings"
+#~ msgstr "Codificaciones"
+
+#~ msgid "Default"
+#~ msgstr "Predetermináu"
+
+#~ msgid "User defined"
+#~ msgstr "Definío pol usuariu"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Otres codificaciones"

--- a/po/az.po
+++ b/po/az.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Azerbaijani (https://www.transifex.com/terminator/teams/109338/az/)\n"
+"Language-Team: Azerbaijani (https://www.transifex.com/terminator/"
+"teams/109338/az/)\n"
+"Language: az\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: az\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Çoxsaylı terminallar bir pəncərədə"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Bu mesajı gələn səfərdə göstərmə"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Hazırki Dil"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Qərb dilləri"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Mərkəzi Avropa"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Cənubi Avropa dilləri"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltik"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kirillə"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Ərəb dili"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Yunan dili"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Əyani Yəhudi dili"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Yəhudi Dili"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Türkcə"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Skandinavca"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltcə"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumınca"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unikod"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Ermənicə"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Ənənəvi Çincə"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kiril/Rusca"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Yaponca"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreya"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Sadələşdirilmiş Cincə"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gürcücə"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kiril/Ukraynaca"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Horvatca"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindcə"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Farsca"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Qucarati dili"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Qurmuxicə"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "İsland dili"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vyetnamca"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tay dili"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "səkmə"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Səkməni Bağla"
 
@@ -517,7 +374,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -542,12 +399,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -653,7 +510,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -870,43 +727,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -914,437 +771,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1579,11 +1452,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1596,185 +1469,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1882,12 +1739,105 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "Hazırki Dil"
+
+#~ msgid "Western"
+#~ msgstr "Qərb dilləri"
+
+#~ msgid "Central European"
+#~ msgstr "Mərkəzi Avropa"
+
+#~ msgid "South European"
+#~ msgstr "Cənubi Avropa dilləri"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltik"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kirillə"
+
+#~ msgid "Arabic"
+#~ msgstr "Ərəb dili"
+
+#~ msgid "Greek"
+#~ msgstr "Yunan dili"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Əyani Yəhudi dili"
+
+#~ msgid "Hebrew"
+#~ msgstr "Yəhudi Dili"
+
+#~ msgid "Turkish"
+#~ msgstr "Türkcə"
+
+#~ msgid "Nordic"
+#~ msgstr "Skandinavca"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltcə"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumınca"
+
+#~ msgid "Unicode"
+#~ msgstr "Unikod"
+
+#~ msgid "Armenian"
+#~ msgstr "Ermənicə"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Ənənəvi Çincə"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kiril/Rusca"
+
+#~ msgid "Japanese"
+#~ msgstr "Yaponca"
+
+#~ msgid "Korean"
+#~ msgstr "Koreya"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Sadələşdirilmiş Cincə"
+
+#~ msgid "Georgian"
+#~ msgstr "Gürcücə"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kiril/Ukraynaca"
+
+#~ msgid "Croatian"
+#~ msgstr "Horvatca"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindcə"
+
+#~ msgid "Persian"
+#~ msgstr "Farsca"
+
+#~ msgid "Gujarati"
+#~ msgstr "Qucarati dili"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Qurmuxicə"
+
+#~ msgid "Icelandic"
+#~ msgstr "İsland dili"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vyetnamca"
+
+#~ msgid "Thai"
+#~ msgstr "Tay dili"

--- a/po/be.po
+++ b/po/be.po
@@ -2,24 +2,27 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Belarusian (https://www.transifex.com/terminator/teams/109338/be/)\n"
+"Language-Team: Belarusian (https://www.transifex.com/terminator/teams/109338/"
+"be/)\n"
+"Language: be\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: be\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -123,7 +126,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Тэрмінатар"
 
@@ -132,7 +135,7 @@ msgid "Multiple terminals in one window"
 msgstr "Некалькі тэрміналаў у акне"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +143,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +227,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Не паказваць  гэта паведамленне у наступны час?"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Бягучая мясцовасьць"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Заходні"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Цэнтральнаеўрапейскі"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Румынская"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Армянскае"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Кітайская традыцыйная"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Кірыліца/Руская"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Японская"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Карэйская"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Кітайская спрошчаная"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Грузінскае"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Кірыліца/Украінская"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "харвацкая"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Хіндзі"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Персідская (Фарсі)"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Гуджараці"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +240,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "табуляцыя"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Зачыніць укладку"
 
@@ -515,7 +374,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +399,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +510,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +727,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +771,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1452,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1469,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1739,63 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "Бягучая мясцовасьць"
+
+#~ msgid "Western"
+#~ msgstr "Заходні"
+
+#~ msgid "Central European"
+#~ msgstr "Цэнтральнаеўрапейскі"
+
+#~ msgid "Romanian"
+#~ msgstr "Румынская"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Армянскае"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Кітайская традыцыйная"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Кірыліца/Руская"
+
+#~ msgid "Japanese"
+#~ msgstr "Японская"
+
+#~ msgid "Korean"
+#~ msgstr "Карэйская"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Кітайская спрошчаная"
+
+#~ msgid "Georgian"
+#~ msgstr "Грузінскае"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Кірыліца/Украінская"
+
+#~ msgid "Croatian"
+#~ msgstr "харвацкая"
+
+#~ msgid "Hindi"
+#~ msgstr "Хіндзі"
+
+#~ msgid "Persian"
+#~ msgstr "Персідская (Фарсі)"
+
+#~ msgid "Gujarati"
+#~ msgstr "Гуджараці"

--- a/po/bg.po
+++ b/po/bg.po
@@ -2,24 +2,25 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Dimitar Dikov <dim.dikoff@gmail.com>, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Dimitar Dikov <dim.dikoff@gmail.com>, 2021\n"
-"Language-Team: Bulgarian (https://www.transifex.com/terminator/teams/109338/bg/)\n"
+"Language-Team: Bulgarian (https://www.transifex.com/terminator/teams/109338/"
+"bg/)\n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bg\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -124,7 +125,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Терминатор"
 
@@ -133,7 +134,7 @@ msgid "Multiple terminals in one window"
 msgstr "Множество терминали в един прозорец"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -141,8 +142,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -225,156 +226,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Не показвай това съобщение отново"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Текуща локализация"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Западен"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Централно-европейски"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Южноевропейски"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Балтийски"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Кирилица"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Арабски"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Гръцки"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Иврит (визуален)"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Иврит"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Турски"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Скандинавски"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Келтски"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Румънски"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Уникод"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Арменски"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Традниционен китайски"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Кирилица/Руски"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Японски"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Корейски"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Китайски опростен"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Грузински"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Кирилица/Украински"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Хърватски"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Хинди"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Персийски"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Гуджарати"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Гурмуки"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Исландски"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Виетнамски"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Тайландски"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -382,11 +239,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "табулация"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Затваряне на подпрозореца"
 
@@ -522,7 +379,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Настройки"
 
@@ -547,12 +404,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Команда"
 
@@ -658,7 +515,7 @@ msgid "Escape sequence"
 msgstr "Екранираща последователност"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Всичко"
 
@@ -875,43 +732,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
+msgid "<b>Appearance</b>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Рамка на прозореца"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -919,439 +776,457 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
+msgid "Tabs scroll buttons"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Общи"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Профил"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "Използване на _системния шрифт с фиксирана ширина на буквите"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Шрифт:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Избор на шрифт за терминала"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "Позволяване на полу_чер текст"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Показване на заглавната лента"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Копиране при избиране"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Показалец</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Икона на заглавната лента"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Общи"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Изпълнение на команда като обвивка при влизане"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Изпълнение на команда _вместо стандартната обвивка"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Потребителска _команда:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "_При приключване на командата:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Преден план и фон</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Използване на цветовете от системната тема"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "_Вградени схеми:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Палитра</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Вградени _схеми:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "_Цветова палитра:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Цветове"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Плътен цвят"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Про_зрачен фон"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Минимална</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Максимална</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Фон"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Лентата за придвижване е:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Придвижване при _извеждане на текст"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Придвижване при _натискане на клавиш"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Безкрайно придвижване назад"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Придвижване _назад:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "редове"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Придвижване"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
-"<small><i><b>Бележка:</b> Тези настройки могат да доведат до некоректна работа на някои програми.\n"
-"Те са тук, само за да ви позволят да работите с някои програми и операционни системи, които очакват различно поведение на терминала.</i></small>"
+"<small><i><b>Бележка:</b> Тези настройки могат да доведат до некоректна "
+"работа на някои програми.\n"
+"Те са тук, само за да ви позволят да работите с някои програми и операционни "
+"системи, които очакват различно поведение на терминала.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "_Клавишът „Backspace“ генерира:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Клавишът „Delete“ _генерира:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Връщане настройките за съвместимост към стандартните"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Съвместимост"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Профили"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Подредби"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Клавишни комбинации"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Тази приставка няма опции за конфигуриране"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Приставки"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1586,11 +1461,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Нов потребителски профил"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Нова подредба"
 
@@ -1603,185 +1478,169 @@ msgstr "Търсене:"
 msgid "Close Search bar"
 msgstr "Затваряне на лентата за търсене"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Изпрати електронна поща до..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Копиране на адрес на електронна поща"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Отваряне на връзка"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Разделяне х_оризонално"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Раздели в_ертикално"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Отвори _подпрозорец"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Отвори подпрозорец за диагностика"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Възстановяване на всички командни редове"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Групиране"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Показване на лентата за придвижване"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Кодова таблица"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "По подразбиране"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Потребителски"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Други кодирания"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Премахване на група %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Премахване на всички групи"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Затваряне на група %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Не е намерен Шел"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Неуспешно стартиране на обвивката на командния ред"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Преименуване на прозорец"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Въведете ново заглавие за прозореца на Terminator..."
 
@@ -1889,12 +1748,117 @@ msgstr "Омега"
 msgid "window"
 msgstr "прозорец"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Подпрозорец %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Текуща локализация"
+
+#~ msgid "Western"
+#~ msgstr "Западен"
+
+#~ msgid "Central European"
+#~ msgstr "Централно-европейски"
+
+#~ msgid "South European"
+#~ msgstr "Южноевропейски"
+
+#~ msgid "Baltic"
+#~ msgstr "Балтийски"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Кирилица"
+
+#~ msgid "Arabic"
+#~ msgstr "Арабски"
+
+#~ msgid "Greek"
+#~ msgstr "Гръцки"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Иврит (визуален)"
+
+#~ msgid "Hebrew"
+#~ msgstr "Иврит"
+
+#~ msgid "Turkish"
+#~ msgstr "Турски"
+
+#~ msgid "Nordic"
+#~ msgstr "Скандинавски"
+
+#~ msgid "Celtic"
+#~ msgstr "Келтски"
+
+#~ msgid "Romanian"
+#~ msgstr "Румънски"
+
+#~ msgid "Unicode"
+#~ msgstr "Уникод"
+
+#~ msgid "Armenian"
+#~ msgstr "Арменски"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Традниционен китайски"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Кирилица/Руски"
+
+#~ msgid "Japanese"
+#~ msgstr "Японски"
+
+#~ msgid "Korean"
+#~ msgstr "Корейски"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Китайски опростен"
+
+#~ msgid "Georgian"
+#~ msgstr "Грузински"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Кирилица/Украински"
+
+#~ msgid "Croatian"
+#~ msgstr "Хърватски"
+
+#~ msgid "Hindi"
+#~ msgstr "Хинди"
+
+#~ msgid "Persian"
+#~ msgstr "Персийски"
+
+#~ msgid "Gujarati"
+#~ msgstr "Гуджарати"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Гурмуки"
+
+#~ msgid "Icelandic"
+#~ msgstr "Исландски"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Виетнамски"
+
+#~ msgid "Thai"
+#~ msgstr "Тайландски"
+
+#~ msgid "Encodings"
+#~ msgstr "Кодова таблица"
+
+#~ msgid "Default"
+#~ msgstr "По подразбиране"
+
+#~ msgid "User defined"
+#~ msgstr "Потребителски"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Други кодирания"

--- a/po/bn.po
+++ b/po/bn.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Bengali (https://www.transifex.com/terminator/teams/109338/bn/)\n"
+"Language-Team: Bengali (https://www.transifex.com/terminator/teams/109338/"
+"bn/)\n"
+"Language: bn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bn\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "টার্মিনেটর"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "এক উইন্ডোতে একাধিক টার্মিনাল"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "বর্তমান অবস্থান"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "পশ্চিমা"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "মধ্য ইউরোপীয়"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "দক্ষিণ ইউরোপীয়"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "বাল্টিক"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "ক্রিলিক"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "আরবী"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "গ্রীক"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "হিব্রু ভিজ্যুয়াল"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "হিব্রু"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "তুর্কী"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "নর্ডিক"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "কেল্টিক"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "রোমানীয়"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "ইউনিকোড"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "আর্মেনীয়"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "ঐতিহ্যবাহী চীনা"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "ক্রিলিক/রাশিয়ান"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "জাপানী"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "কোরীয়"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "সরলীকৃত চীনা"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "জর্জীয়"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "ক্রিলিক/ইউক্রেনীয়"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "ক্রোশীয়"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "হিন্দী"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "ফারসী"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "গুজরাটি"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "গুর্মুখী"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "আইসল্যান্ডীয়"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "ভিয়েতনামীয়"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "থাই"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "ট্যাব"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "ট্যাব বন্ধ কর"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "প_ছন্দসমূহ"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "সব"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "প্রোফাইলমসূহ"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "নতুন প্রোফাইল"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "নতুন লে-আউট"
 
@@ -1594,185 +1467,169 @@ msgstr "অনুসন্ধানঃ"
 msgid "Close Search bar"
 msgstr "অনুসন্ধান বার বন্ধ কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "ইমেইল _পাঠাও..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "ইমেইল এড্রেস _কপি কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "ভিওআইপি এড্রেস ক_ল কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "কপি ভিওআইপি _এড্রেস"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_লিঙ্ক খোল"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "এড্রে_স কপি করা"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "সমান্তরালভাবে ভাগ কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "লম্বভাবে ভাগ কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "_ট্যাব খোল"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "ডিব্যাগ ট্যাব _ওপেন কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "টার্মিনাল _জুম কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "স_কল টার্মিনাল রিস্টোর কর"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "দলীয়করণ"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "স্ক্রলবার দেখাও"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "এনকোডিংসমূহ"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "ডিফল্ট"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "ব্যবহারকারী কর্তৃক নির্দিষ্ট"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "অন্যান্য এনকোডিং সমূহ"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "%s গ্রুপটি অপসারণ কর"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "ট্যাবে সবগুলো _গ্রুপ কর"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "সকল গ্রুপ অপসারণ কর"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "%s গ্রুপটি বন্ধ কর"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,117 @@ msgstr ""
 msgid "window"
 msgstr "উইন্ডো"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "%d ট্যাব"
+
+#~ msgid "Current Locale"
+#~ msgstr "বর্তমান অবস্থান"
+
+#~ msgid "Western"
+#~ msgstr "পশ্চিমা"
+
+#~ msgid "Central European"
+#~ msgstr "মধ্য ইউরোপীয়"
+
+#~ msgid "South European"
+#~ msgstr "দক্ষিণ ইউরোপীয়"
+
+#~ msgid "Baltic"
+#~ msgstr "বাল্টিক"
+
+#~ msgid "Cyrillic"
+#~ msgstr "ক্রিলিক"
+
+#~ msgid "Arabic"
+#~ msgstr "আরবী"
+
+#~ msgid "Greek"
+#~ msgstr "গ্রীক"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "হিব্রু ভিজ্যুয়াল"
+
+#~ msgid "Hebrew"
+#~ msgstr "হিব্রু"
+
+#~ msgid "Turkish"
+#~ msgstr "তুর্কী"
+
+#~ msgid "Nordic"
+#~ msgstr "নর্ডিক"
+
+#~ msgid "Celtic"
+#~ msgstr "কেল্টিক"
+
+#~ msgid "Romanian"
+#~ msgstr "রোমানীয়"
+
+#~ msgid "Unicode"
+#~ msgstr "ইউনিকোড"
+
+#~ msgid "Armenian"
+#~ msgstr "আর্মেনীয়"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "ঐতিহ্যবাহী চীনা"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "ক্রিলিক/রাশিয়ান"
+
+#~ msgid "Japanese"
+#~ msgstr "জাপানী"
+
+#~ msgid "Korean"
+#~ msgstr "কোরীয়"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "সরলীকৃত চীনা"
+
+#~ msgid "Georgian"
+#~ msgstr "জর্জীয়"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "ক্রিলিক/ইউক্রেনীয়"
+
+#~ msgid "Croatian"
+#~ msgstr "ক্রোশীয়"
+
+#~ msgid "Hindi"
+#~ msgstr "হিন্দী"
+
+#~ msgid "Persian"
+#~ msgstr "ফারসী"
+
+#~ msgid "Gujarati"
+#~ msgstr "গুজরাটি"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "গুর্মুখী"
+
+#~ msgid "Icelandic"
+#~ msgstr "আইসল্যান্ডীয়"
+
+#~ msgid "Vietnamese"
+#~ msgstr "ভিয়েতনামীয়"
+
+#~ msgid "Thai"
+#~ msgstr "থাই"
+
+#~ msgid "Encodings"
+#~ msgstr "এনকোডিংসমূহ"
+
+#~ msgid "Default"
+#~ msgstr "ডিফল্ট"
+
+#~ msgid "User defined"
+#~ msgstr "ব্যবহারকারী কর্তৃক নির্দিষ্ট"
+
+#~ msgid "Other Encodings"
+#~ msgstr "অন্যান্য এনকোডিং সমূহ"

--- a/po/bs.po
+++ b/po/bs.po
@@ -2,25 +2,27 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Marko Dzidic <mdzidic@gmail.com>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Marko Dzidic <mdzidic@gmail.com>, 2020\n"
-"Language-Team: Bosnian (https://www.transifex.com/terminator/teams/109338/bs/)\n"
+"Language-Team: Bosnian (https://www.transifex.com/terminator/teams/109338/"
+"bs/)\n"
+"Language: bs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bs\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -130,7 +132,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -139,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Više terminala u jednom prozoru"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Robotizirana budućnost terminala"
 
@@ -147,8 +149,8 @@ msgstr "Robotizirana budućnost terminala"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -235,156 +237,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Ne prikazuj ovu poruku sljedeći put"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Trenutne regionalne postavke"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Zapadni"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Srednjeevropski"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Južnoevropski"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltički"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Ćirilica"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arapski"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grčki"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebrejski vizuelni"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebrejski"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turski"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordijski"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltski"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumunski"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenski"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Kineski (tradicionalni)"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Ćirilični/Ruski"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japanski"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korejski"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Kineski (pojednostavljeni)"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gruzijski"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Ćirilični/Ukrajinski"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Hrvatski"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindu"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Perzijski"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Guđarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmuki"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandski"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vijetnamski"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tajlandski"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Terminatorov \"Aktivator rasporeda\""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Raspored"
 
@@ -392,11 +250,11 @@ msgstr "Raspored"
 msgid "Launch"
 msgstr "Pokreni"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Zatvori karticu"
 
@@ -527,7 +385,7 @@ msgstr "Korisničke komande"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "Postavke"
 
@@ -552,12 +410,12 @@ msgid "Enabled"
 msgstr "Omogućeno"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Naziv"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Komanda"
 
@@ -663,7 +521,7 @@ msgid "Escape sequence"
 msgstr "Sekvenca izlaza"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Za sve"
 
@@ -880,488 +738,511 @@ msgid "Use custom URL handler"
 msgstr "Koristi korisnički URL rukovatelj"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Korisnički rukovatelj:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Korisnički rukovatelj:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Izgled</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Rubovi prozora"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Svjetlina fonta (bez fokusa):"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Veličina razdjelnika terminala"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Dodatni stilovi (uslovljeno temom)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Pozicija kartice:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Homogeno uređenje kartica"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Dugmad za pomjeranje kartica"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Globalno"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "Koristi sistemski font fiksne širine"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "Font:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Odabir fonta terminala"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "Dozvoli podebljani tekst"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Prikaži naslovnu traku"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Kopiraj pri selekciji"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Karakteri za izbor-po-riječima:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Kursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "Oblik:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Treptanje"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Pozadina:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal signalizacija</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Ikona naslovne trake"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Treptanje"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Zvučni signal"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Treptanje liste prozora"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Općenito"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "Pokreni komandu kao shell za prijavu"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Pokreni korisničku komandu umjesto shell-a"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Korisnička komanda:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Kada komanda završi:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Prednji plan i pozadina</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "Koristi boje iz teme sistema"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Ugrađene sheme:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Ugrađene sheme:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Paleta boja:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr "Prikaži p_odebljani tekst na svijetlim bojama"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Boje"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "Neprozirno"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Prozirna pozadina"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ništa</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimalno</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Pozadina"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "Pomična traka je:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Pomiči pri ispisu"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Pomiči na pritisak tipke"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Beskonačno pomicanje"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Zadržavanje:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "linija"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Pomicanje"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Napomena:</b> Ove opcije mogu uzrokovati neispravnosti u nekim "
 "programima. Ovdje su samo kao prelazno rješenje za određene aplikacije i "
 "operativne sisteme u kojima se očekuje drugačiji rad terminala.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "<Backspace> tipka generiše:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "<Delete> tipka generiše:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Kodiranje:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "Vrati na zadane postavke kompatibilnosti"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Kompatibilnost"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Fokusirano"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Neaktivno"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Primanje"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Sakrij veličinu u naslovu"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "Koristi sistemski font"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Odabir fonta naslovne trake"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Tip"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Korisnička komanda:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Radni direktorij:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Rasporedi"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Akcija"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Kombinacija tastera"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Prečice na tastaturi"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Dodatak"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Ovaj dodatak nema konfiguracijske opcije"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Dodaci"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Cilj ovog projekta je razvoj korisnog alata za organizaciju terminala. Inspirisan programima poput gnome-multi-term, quadkonsole, itd. pri čemu je fokus na organizaciju terminala u mreži/poljima (kartice su najkorišteniji metod prikaza, koji Terminator takođe podržava).\n"
+"Cilj ovog projekta je razvoj korisnog alata za organizaciju terminala. "
+"Inspirisan programima poput gnome-multi-term, quadkonsole, itd. pri čemu je "
+"fokus na organizaciju terminala u mreži/poljima (kartice su najkorišteniji "
+"metod prikaza, koji Terminator takođe podržava).\n"
 "\n"
-"Najveći dio karakteristika Terminatora se temelje na GNOME Terminal aplikaciji i mi vremenom dodajemo nove funkcionalnosti, ali takođe želimo ići i u drugim smjerovima sa proširenjima za sistem administratore i ostale korisnike. Ukoliko imate neki prijedlog, molimo Vas da popunite listu želja! (provjerite Razvoj na lijevoj strani)"
+"Najveći dio karakteristika Terminatora se temelje na GNOME Terminal "
+"aplikaciji i mi vremenom dodajemo nove funkcionalnosti, ali takođe želimo "
+"ići i u drugim smjerovima sa proširenjima za sistem administratore i ostale "
+"korisnike. Ukoliko imate neki prijedlog, molimo Vas da popunite listu želja! "
+"(provjerite Razvoj na lijevoj strani)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "Uputstvo"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "O programu"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Povećaj veličinu fonta"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Smanji veličinu fonta"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Vrati originalnu veličinu fonta"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Kreiraj novu karticu"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Fokusiraj sljedeći terminal"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Fokusiraj prethodni terminal"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Fokusiraj terminal na gore"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Fokusiraj terminal na dole"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Fokusiraj terminal na lijevo"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Fokusiraj terminal na desno"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Zarotiraj terminale u smjeru kazaljki"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Zarotiraj terminale suprotno smjeru kazaljki"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Podijeli horizontalno"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Podijeli vertikalno"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Zatvori terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Kopiraj označeni tekst"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Zalijepi sadržaj iz međuspremnika"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1595,11 +1476,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Otvori uputstvo"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Novi profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Novi raspored"
 
@@ -1612,185 +1493,169 @@ msgstr "Traži:"
 msgid "Close Search bar"
 msgstr "Zatvori traku pretrage"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "Pošalji e-poštu..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "Kopiraj adresu e-pošte"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Pozovi VoIP adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "Kopiraj VoIP adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "Otvori vezu"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "Kopiraj adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "Kopiraj"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "Zalijepi"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Podijeli horizontalno"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Podijeli vertikalno"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Otvori karticu"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Otvori karticu \"Ispravljanje grešaka\""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "Zatvori"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "Zumiraj terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Maksimiziraj terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "Vrati sve terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Grupisanje"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Prikaži pomičnu traku"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kodiranja"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Zadano"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Korisnički definisano"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Ostala kodiranja"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "Nova grupa..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "Bez grupe"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Ukloni grupu %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Grupiši sve u kartici"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Razgrupiši sve u kartici"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Ukloni sve grupe"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Zatvori grupu %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Emitovanje svima"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Emitovanje grupi"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Emitovanje ugašeno"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "Podijeli na ovu grupu"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Automatsko čišćenje grupa"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "Dodaj broj terminala"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Dodaj formatiran broj terminala"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Lociranje Shell-a neuspješno"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Pokretanje Shell-a neuspješno:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Promijeni naslov prozora"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Unesite novi naslov za Terminator prozor..."
 
@@ -1898,12 +1763,120 @@ msgstr "Omega"
 msgid "window"
 msgstr "prozor"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Trenutne regionalne postavke"
+
+#~ msgid "Western"
+#~ msgstr "Zapadni"
+
+#~ msgid "Central European"
+#~ msgstr "Srednjeevropski"
+
+#~ msgid "South European"
+#~ msgstr "Južnoevropski"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltički"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Ćirilica"
+
+#~ msgid "Arabic"
+#~ msgstr "Arapski"
+
+#~ msgid "Greek"
+#~ msgstr "Grčki"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebrejski vizuelni"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebrejski"
+
+#~ msgid "Turkish"
+#~ msgstr "Turski"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordijski"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltski"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumunski"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenski"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Kineski (tradicionalni)"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Ćirilični/Ruski"
+
+#~ msgid "Japanese"
+#~ msgstr "Japanski"
+
+#~ msgid "Korean"
+#~ msgstr "Korejski"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Kineski (pojednostavljeni)"
+
+#~ msgid "Georgian"
+#~ msgstr "Gruzijski"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Ćirilični/Ukrajinski"
+
+#~ msgid "Croatian"
+#~ msgstr "Hrvatski"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindu"
+
+#~ msgid "Persian"
+#~ msgstr "Perzijski"
+
+#~ msgid "Gujarati"
+#~ msgstr "Guđarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmuki"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandski"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vijetnamski"
+
+#~ msgid "Thai"
+#~ msgstr "Tajlandski"
+
+#~ msgid "Encoding:"
+#~ msgstr "Kodiranje:"
+
+#~ msgid "Encodings"
+#~ msgstr "Kodiranja"
+
+#~ msgid "Default"
+#~ msgstr "Zadano"
+
+#~ msgid "User defined"
+#~ msgstr "Korisnički definisano"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Ostala kodiranja"

--- a/po/ca.po
+++ b/po/ca.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Catalan (https://www.transifex.com/terminator/teams/109338/ca/)\n"
+"Language-Team: Catalan (https://www.transifex.com/terminator/teams/109338/"
+"ca/)\n"
+"Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ca\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -98,7 +99,8 @@ msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
-"* Aquestes opcions requereixen que la variable d'entorn TERMINARTOR_UUID existeixi\n"
+"* Aquestes opcions requereixen que la variable d'entorn TERMINARTOR_UUID "
+"existeixi\n"
 "  o emprar l'opció --uuid"
 
 #: ../remotinator.py:77
@@ -130,7 +132,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -139,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Diversos terminals en una finestra"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "El futur robot de terminals"
 
@@ -147,8 +149,8 @@ msgstr "El futur robot de terminals"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -231,156 +233,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "No mostris aquest missatge la propera vegada"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Localització actual"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Occidental"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europeu central"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Europeu meridional"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Bàltic"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Ciríl·lic"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Àrab"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grec"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebreu visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebreu"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turc"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nòrdic"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Cèltic"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romanès"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armeni"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Xinès tradicional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Ciríl·lic/Rus"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonès"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coreà"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Xinès simplificat"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgià"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Ciríl·lic/Ucraïnès"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croat"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persa"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandès"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamita"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -388,11 +246,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "pestanya"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Tancar pestanya"
 
@@ -453,8 +311,7 @@ msgstr "Estableix el directori de treball"
 #: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
 msgstr ""
-"Establir una icona personalitzada per la finestra(mitjançant un fitxer o "
-"nom)"
+"Establir una icona personalitzada per la finestra(mitjançant un fitxer o nom)"
 
 #: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
@@ -531,7 +388,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferències"
 
@@ -556,12 +413,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Ordre"
 
@@ -667,7 +524,7 @@ msgid "Escape sequence"
 msgstr "Seqüència d'escapament"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Tot"
 
@@ -884,43 +741,43 @@ msgid "Use custom URL handler"
 msgstr "Utilitza un gestor d'URLs personalitzat"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
+msgid "<b>Appearance</b>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Vores de la finestra"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -928,442 +785,458 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
-msgstr "Global"
+msgid "Tabs scroll buttons"
+msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
+msgid "Global"
+msgstr "Global"
+
+#: ../terminatorlib/preferences.glade.h:78
+msgid "Profile"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Utilitza el tipus de lletra d'amplada fixa del sistema"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Tipus de lletra:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Trieu un tipus de lletra de terminal"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Permet text en negreta"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Mostra la barra de títol"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Copiar en seleccionar"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Caràcters de _selecció per paraula:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Campana del Terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Icona de la barra de títol"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Ràfega visual"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Xiulet audible"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "General"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 "E_xecuta una ordre personalitzada en comptes del meu intèrpret d'ordres"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Or_dre personalitzada:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Quan l'ordre _surt:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Primer pla i fons</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Utilitza els colors del tema del sistema"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Esq_uemes integrats:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "_Esquemes integrats:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "_Paleta de colors:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Colors"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "Color _sòlid"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Fons _transparent"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Cap</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Màxim</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Fons"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "La _barra de desplaçament és:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Desplaçament en _mostrar"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Desplaçament en _prémer una tecla"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Desplaçament cap enrere infinit"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Desplaçament cap _enrere:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "línies"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Desplaçament"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Nota:</b>Aquestes opcions poden fer que algunes aplicacions no "
 "funcionin correctament. Només hi són per permetre-us solucionar aspectes de "
-"certes aplicacions i sistemes operatius que esperen un comportament diferent"
-" del terminal.</i></small>"
+"certes aplicacions i sistemes operatius que esperen un comportament diferent "
+"del terminal.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "La tecla de _retrocés genera:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "La tecla de _suprimir genera:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Reinicia les opcions de compatibilitat a les Opcions per Defecte"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Compatibilitat"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Perfils"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Plantilles"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Assignacions de tecles"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Aquest plugin no te opcions de configuració"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Connectors"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1598,11 +1471,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nou perfil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Disposició nova"
 
@@ -1615,185 +1488,169 @@ msgstr "Cerca:"
 msgid "Close Search bar"
 msgstr "Tanca la barra de cerca"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "En_via un correu a..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copia l'adreça electrònica"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_Truca a una adreça de VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copia l'adreça de VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Obre l'enllaç"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copia l'adreça"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Divideix h_oritzontalment"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Divideix v_erticalment"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Obre una pes_tanya"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Obre una pestanya de _depuració"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "A_mplia el terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Recupera tots els terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Agrupament"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Mostra la barra de de_splaçament"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Codificacions"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Predeterminat"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definit per l'usuari"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Altres codificacions"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Suprimeix el grup %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "A_grupa-ho tot en la pestanya"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Suprimeix tots els grups"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Tanca el grup %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "No s'ha pogut trobar cap intèrpret d'ordres"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "No s'ha pogut iniciar l'intèrpret d'ordres:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Reanomenar finestra"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Introdueix un títol nou per a la finestra del Terminator"
 
@@ -1901,12 +1758,117 @@ msgstr ""
 msgid "window"
 msgstr "finestra"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Pestanya %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Localització actual"
+
+#~ msgid "Western"
+#~ msgstr "Occidental"
+
+#~ msgid "Central European"
+#~ msgstr "Europeu central"
+
+#~ msgid "South European"
+#~ msgstr "Europeu meridional"
+
+#~ msgid "Baltic"
+#~ msgstr "Bàltic"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Ciríl·lic"
+
+#~ msgid "Arabic"
+#~ msgstr "Àrab"
+
+#~ msgid "Greek"
+#~ msgstr "Grec"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebreu visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebreu"
+
+#~ msgid "Turkish"
+#~ msgstr "Turc"
+
+#~ msgid "Nordic"
+#~ msgstr "Nòrdic"
+
+#~ msgid "Celtic"
+#~ msgstr "Cèltic"
+
+#~ msgid "Romanian"
+#~ msgstr "Romanès"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armeni"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Xinès tradicional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Ciríl·lic/Rus"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonès"
+
+#~ msgid "Korean"
+#~ msgstr "Coreà"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Xinès simplificat"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgià"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Ciríl·lic/Ucraïnès"
+
+#~ msgid "Croatian"
+#~ msgstr "Croat"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persa"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandès"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamita"
+
+#~ msgid "Thai"
+#~ msgstr "Tai"
+
+#~ msgid "Encodings"
+#~ msgstr "Codificacions"
+
+#~ msgid "Default"
+#~ msgstr "Predeterminat"
+
+#~ msgid "User defined"
+#~ msgstr "Definit per l'usuari"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Altres codificacions"

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Catalan (Valencian) (https://www.transifex.com/terminator/teams/109338/ca@valencia/)\n"
+"Language-Team: Catalan (Valencian) (https://www.transifex.com/terminator/"
+"teams/109338/ca@valencia/)\n"
+"Language: ca@valencia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ca@valencia\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Diversos terminals en una finestra"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Localització actual"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Occidental"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europeu central"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Europeu meridional"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Bàltic"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Ciríl·lic"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Àrab"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grec"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebreu visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebreu"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turc"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nòrdic"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Cèltic"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romanés"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armeni"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Xinés tradicional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Ciríl·lic/Rus"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonés"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coreà"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Xinés simplificat"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgià"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Ciríl·lic/Ucraïnés"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croat"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persa"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandés"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamita"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "pestanya"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Tanca la pestanya"
 
@@ -519,7 +376,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferències"
 
@@ -544,12 +401,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -655,7 +512,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Tot"
 
@@ -872,43 +729,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -916,437 +773,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Perfils"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1581,11 +1454,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nou perfil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Disposició nova"
 
@@ -1598,185 +1471,169 @@ msgstr "Cerca:"
 msgid "Close Search bar"
 msgstr "Tanca la barra de cerca"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "En_via un correu a..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copia l'adreça electrònica"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_Truca a una adreça de VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copia l'adreça de VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Obri l'enllaç"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copia l'adreça"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Divideix h_oritzontalment"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Divideix v_erticalment"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Obri una pes_tanya"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Obri una pestanya de _depuració"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "A_mplia el terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Recupera tots els terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Agrupament"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Mostra la barra de de_splaçament"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Codificacions"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Predeterminat"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definit per l'usuari"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Altres codificacions"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Suprimeix el grup %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "A_grupa-ho tot en la pestanya"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Suprimeix tots els grups"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Tanca el grup %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "No s'ha pogut trobar cap intèrpret d'ordes"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "No s'ha pogut iniciar l'intèrpret d'ordes:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1884,12 +1741,117 @@ msgstr ""
 msgid "window"
 msgstr "finestra"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Pestanya %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Localització actual"
+
+#~ msgid "Western"
+#~ msgstr "Occidental"
+
+#~ msgid "Central European"
+#~ msgstr "Europeu central"
+
+#~ msgid "South European"
+#~ msgstr "Europeu meridional"
+
+#~ msgid "Baltic"
+#~ msgstr "Bàltic"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Ciríl·lic"
+
+#~ msgid "Arabic"
+#~ msgstr "Àrab"
+
+#~ msgid "Greek"
+#~ msgstr "Grec"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebreu visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebreu"
+
+#~ msgid "Turkish"
+#~ msgstr "Turc"
+
+#~ msgid "Nordic"
+#~ msgstr "Nòrdic"
+
+#~ msgid "Celtic"
+#~ msgstr "Cèltic"
+
+#~ msgid "Romanian"
+#~ msgstr "Romanés"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armeni"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Xinés tradicional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Ciríl·lic/Rus"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonés"
+
+#~ msgid "Korean"
+#~ msgstr "Coreà"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Xinés simplificat"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgià"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Ciríl·lic/Ucraïnés"
+
+#~ msgid "Croatian"
+#~ msgstr "Croat"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persa"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandés"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamita"
+
+#~ msgid "Thai"
+#~ msgstr "Tai"
+
+#~ msgid "Encodings"
+#~ msgstr "Codificacions"
+
+#~ msgid "Default"
+#~ msgstr "Predeterminat"
+
+#~ msgid "User defined"
+#~ msgstr "Definit per l'usuari"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Altres codificacions"

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Central Kurdish (https://www.transifex.com/terminator/teams/109338/ckb/)\n"
+"Language-Team: Central Kurdish (https://www.transifex.com/terminator/"
+"teams/109338/ckb/)\n"
+"Language: ckb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ckb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "عه‌ره‌بی"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "فارسی"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,18 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Arabic"
+#~ msgstr "عه‌ره‌بی"
+
+#~ msgid "Persian"
+#~ msgstr "فارسی"

--- a/po/cs.po
+++ b/po/cs.po
@@ -2,24 +2,26 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Czech (https://www.transifex.com/terminator/teams/109338/cs/)\n"
+"Language-Team: Czech (https://www.transifex.com/terminator/teams/109338/"
+"cs/)\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs\n"
-"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
+"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -130,7 +132,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminátor"
 
@@ -139,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Vícero terminálů v jednom okně"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Robotická budoucnost terminálů"
 
@@ -147,8 +149,8 @@ msgstr "Robotická budoucnost terminálů"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -237,156 +239,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Příště tuto zprávu nezobrazovat"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Stávající místní a jazyková nastavení"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Západoevropské jazyky"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Středoevropské jazyky"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Jihoevropské jazyky"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltské jazyky"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrilice"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabština"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Řečtina"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebrejské vizuální"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebrejština"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turečtina"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Skandinávské jazyky"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltské jazyky"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumunština"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Arménština"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Tradiční čínština"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Azbuka/Rusko"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonština"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korejština"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Zjednodušená čínština"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gruzínština"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Azbuka/Ukrajinské"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Chorvatština"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindština"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Perština"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujaratština"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandština"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamština"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thajština"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Spouštěč uspořádání v Terminátor"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Uspořádání"
 
@@ -394,11 +252,11 @@ msgstr "Uspořádání"
 msgid "Launch"
 msgstr "Spustit"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "panel"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Zavřít panel"
 
@@ -532,7 +390,7 @@ msgstr "_Uživatelské příkazy"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Vlastnosti"
 
@@ -557,12 +415,12 @@ msgid "Enabled"
 msgstr "Zapnuto"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Název"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Příkaz"
 
@@ -668,7 +526,7 @@ msgid "Escape sequence"
 msgstr "Escape sekvence"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Vše"
 
@@ -885,489 +743,511 @@ msgid "Use custom URL handler"
 msgstr "Použít uživatelem určené nakládání s URL adresami"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Uživatelem určené nakládání s URL adresou:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Uživatelem určené nakládání s URL adresou:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Vzhled</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Ohraničení okna"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Jas písma nezaměřeného terminálu:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Velikost oddělovače terminálu:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Další stylování (závislé na motivu vzhledu)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Pozice panelu:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Homogení panely"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Tlačítka posuvníku panelů"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Společné"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "Po_užívat systémové písmo s pevnou šířkou"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Písmo:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Zvolte písmo terminálu"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "Povolit _tučný text"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Zobrazit pruh s titulkem"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Kopírovat při výběru"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Znaky pro výběr _slov:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Ukazatel</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Podoba:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Blikat"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Pozadí:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Pípání terminálu</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Ikona pruhu s titulkem"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Problikávání"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Slyšitelné zvukové znamení"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Blikání seznamu oken"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Obecné"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Spustit příkaz jako přihlašovací shell"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "S_pustit vlastní příkaz místo mého shellu"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "_Uživatelský příkaz:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Po skonč_ení příkazu:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Popředí a pozadí</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "Po_užívat barvy systémového motivu"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Zabudovaná sché_mata:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Zabudovaná _schémata:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "P_aleta barev:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Barvy"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Jednolitá barva"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Průhledné pozadí"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Žádný</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Největší</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Pozadí"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "Zobrazení po_suvníku:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "P_osouvat při výstupu"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Posouvat při stisku _klávesy"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Pamatovat si vše zpět"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "_Pamatovat si:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "řádků"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Posouvání"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Poznámka:</b> Tyto volby mohou způsobit, že některé aplikace "
-"nebudou fungovat správně. Jsou zde pouze proto, aby bylo možné obejít to, že"
-" některé aplikace a operační systémy očekávají jiné chování "
-"terminálu.</i></small>"
+"nebudou fungovat správně. Jsou zde pouze proto, aby bylo možné obejít to, že "
+"některé aplikace a operační systémy očekávají jiné chování terminálu.</i></"
+"small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Klávesa _Backspace vytváří:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Klávesa _Delete vytváří:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Kódování znaků:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "V_rátit nastavení kompatibility na výchozí"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Kompatibilita"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Zaměřeno"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Nečinné"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Přijímající"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Nezobrazovat v titulku velikost"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "Po_užít systémové písmo"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Zvolte písmo pro titulní lištu"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profily"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Typ"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Uživatelský příkaz:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Pracovní adresář:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Rozvržení"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Akce"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Klávesová zkratka"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Klávesové zkratky"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Zásuvný modul"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Tento zásuvný modul nemá žádné volby pro nastavení"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Zásuvné moduly"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Cílem tohoto projektu je vytvořit užitečný nástroj pro uspořádávání terminálů. Inspirováno aplikacemi jako gnome-multi-term, quadkonsole, atp. hlavním zaměřením je uspořádávání terminálů v mřížkách (karty jsou nejběžnější výchozí metodou, kterou Terminátor také podporuje).\n"
+"Cílem tohoto projektu je vytvořit užitečný nástroj pro uspořádávání "
+"terminálů. Inspirováno aplikacemi jako gnome-multi-term, quadkonsole, atp. "
+"hlavním zaměřením je uspořádávání terminálů v mřížkách (karty jsou "
+"nejběžnější výchozí metodou, kterou Terminátor také podporuje).\n"
 "\n"
-"Mnohé z chování Terminátor je založeno na GNOME Terminal a postupně jsou přidávány další funkce z něj. Úmyslem je ale také rozšíření v různých směrech o funkce užitečné pro správce systémů a další uživatele. Pokud máte nějaké návrhy, nahlaste nám je! (viz vlevo odkaz Vývoj)"
+"Mnohé z chování Terminátor je založeno na GNOME Terminal a postupně jsou "
+"přidávány další funkce z něj. Úmyslem je ale také rozšíření v různých "
+"směrech o funkce užitečné pro správce systémů a další uživatele. Pokud máte "
+"nějaké návrhy, nahlaste nám je! (viz vlevo odkaz Vývoj)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "Příručka"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "O aplikaci"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Zvětšit velikost písma"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Zmenšit velikost písma"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Vrátit původní velikost písma"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Vytvořit nový panel"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Zaměřit následující terminál"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Zaměřit předchozí terminál"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Zaměřit terminál výše"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Zaměřit terminál níže"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Zaměřit terminál vlevo"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Zaměřit terminál vpravo"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Otočit terminály doprava"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Otočit terminály doleva"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Rozdělit vodorovně"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Rozdělit svisle"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Zavřít terminál"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Zkopírovat označený text"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Vložit ze schránky"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1601,11 +1481,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Otevřít příručku"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nový profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nové rozvržení"
 
@@ -1618,185 +1498,169 @@ msgstr "Hledat:"
 msgid "Close Search bar"
 msgstr "Zavřít vyhledávač"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "Po_slat e-mail…"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "Zkopírovat e-mailovou _adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Zavo_lat VoIP adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Zkopírovat VoIP adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Otevřít odkaz"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "Zkopírovat a_dresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Kopírovat"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "_Vložit"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Rozdělit v_odorovně"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Rozdělit svisl_e"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Otevří_t panel"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Otevřít panel la_dění"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Zavřít"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Změnit přiblížení terminálu"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximalizovat terminál"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "Obnovit všechny te_rminály"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Seskupování"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Zobrazit po_suvník"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kódování znaků"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Výchozí"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Uživatelem určené"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Ostatní kódování"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "_Nová skupina…"
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Nic"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Odstranit skupinu %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Seskupit všechny v panelech"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Zr_ušit seskupení v panelu"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Odstranit všechny skupiny"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Zavřít skupinu %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Vysíl_at vše"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "_Skupina pro vysílání"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Vysílání vypnut_o"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "Rozdělit do této _skupiny"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Automati_cky čistit skupiny"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "Zadejte číslo term_inálu"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Zadejte celé číslo terminálu"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Nedaří se najít shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Nedaří se spustit příkazový řádek:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Přejmenovat okno"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Zadejte nový název pro okno s Terminátor…"
 
@@ -1904,12 +1768,120 @@ msgstr "Omega"
 msgid "window"
 msgstr "okno"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Panel %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Stávající místní a jazyková nastavení"
+
+#~ msgid "Western"
+#~ msgstr "Západoevropské jazyky"
+
+#~ msgid "Central European"
+#~ msgstr "Středoevropské jazyky"
+
+#~ msgid "South European"
+#~ msgstr "Jihoevropské jazyky"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltské jazyky"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrilice"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabština"
+
+#~ msgid "Greek"
+#~ msgstr "Řečtina"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebrejské vizuální"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebrejština"
+
+#~ msgid "Turkish"
+#~ msgstr "Turečtina"
+
+#~ msgid "Nordic"
+#~ msgstr "Skandinávské jazyky"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltské jazyky"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumunština"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Arménština"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Tradiční čínština"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Azbuka/Rusko"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonština"
+
+#~ msgid "Korean"
+#~ msgstr "Korejština"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Zjednodušená čínština"
+
+#~ msgid "Georgian"
+#~ msgstr "Gruzínština"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Azbuka/Ukrajinské"
+
+#~ msgid "Croatian"
+#~ msgstr "Chorvatština"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindština"
+
+#~ msgid "Persian"
+#~ msgstr "Perština"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujaratština"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandština"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamština"
+
+#~ msgid "Thai"
+#~ msgstr "Thajština"
+
+#~ msgid "Encoding:"
+#~ msgstr "Kódování znaků:"
+
+#~ msgid "Encodings"
+#~ msgstr "Kódování znaků"
+
+#~ msgid "Default"
+#~ msgstr "Výchozí"
+
+#~ msgid "User defined"
+#~ msgstr "Uživatelem určené"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Ostatní kódování"

--- a/po/da.po
+++ b/po/da.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Danish (https://www.transifex.com/terminator/teams/109338/da/)\n"
+"Language-Team: Danish (https://www.transifex.com/terminator/teams/109338/"
+"da/)\n"
+"Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: da\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -128,7 +129,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -137,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Flere terminaler i et vindue"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Fremtiden for robotterminaler"
 
@@ -145,8 +146,8 @@ msgstr "Fremtiden for robotterminaler"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -229,156 +230,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Vis ikke denne besked næste gang"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Nuværende regionaldata"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Vestligt"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Centraleuropæisk"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Sydeuropæisk"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltisk"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kyrillisk"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabisk"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Græsk"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebraisk, Visuel"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebraisk"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Tyrkisk"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordisk"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltisk"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumænsk"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armensk"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Kinesisk, traditionel"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kyrillisk/russisk"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japansk"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreansk"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Kinesisk, forenklet"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgisk"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kyrillisk/Ukrainsk"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroatisk"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persisk"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandsk"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamesisk"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Terminator Layout Launcher"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Udseende"
 
@@ -386,11 +243,11 @@ msgstr "Udseende"
 msgid "Launch"
 msgstr "Kør"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "faneblad"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Luk faneblad"
 
@@ -522,7 +379,7 @@ msgstr "_Brugertilpassede kommandoer"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Indstillinger"
 
@@ -547,12 +404,12 @@ msgid "Enabled"
 msgstr "Aktiveret"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Navn"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Kommando"
 
@@ -658,7 +515,7 @@ msgid "Escape sequence"
 msgstr "Undslip sekvens"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Alle"
 
@@ -875,488 +732,515 @@ msgid "Use custom URL handler"
 msgstr "Brug tilpasset URL håndtering"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Tilpasset URL håndtering:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Tilpasset URL håndtering:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Udseende</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Vindueskanter"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Ufokuseret terminal skrift lysstyrke"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Terminal adskillelses størrelse:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Fanebladsposition:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Homogene faneblade"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Faneblads rulleknapper"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "Benyt _systemets fastbredde-skrifttype"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Skrifttype:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Vælg en terminalskrifttype"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Tillad fed tekst"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Vis titellinje"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Kopiér ved selektion"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "_Ordmarkeringstegn:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Markør</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Form"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Blink"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Baggrund:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal klokke</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Titellinje ikon"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Visuelt blink"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Hørbart bip"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Vinduesliste blink"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Generelt"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Kør kommando som en logindskal"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Kør en brugerdefineret kommando i stedet for min kommandoskal"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Brugerdefineret kommando:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Når kommando _slutter:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Forgrund og baggrund</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Benyt farver fra systemtemaet"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Indbyggede skemaer:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Indbyggede _skemaer:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Farvep_alet:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Farver"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Ensfarvet"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Gennemsigtig baggrund"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ingen</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimal</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Baggrund"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Rullebjælken er:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Rul ned ved _uddata"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Rul ned ved _tastetryk"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Uendelig tilbagerulning"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Til_bagerulning:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "linjer"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Rulning"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
-"<small><i><b>Bemærk:</b> Disse indstillinger kan få nogle programmer til at opføre sig forkert.\r\n"
-"De er her kun for at gøre det muligt for dig, at arbejde dig rundt om visse programmer og styresystemer, som forventer anderledes terminalopførsel.</i></small>"
+"<small><i><b>Bemærk:</b> Disse indstillinger kan få nogle programmer til at "
+"opføre sig forkert.\r\n"
+"De er her kun for at gøre det muligt for dig, at arbejde dig rundt om visse "
+"programmer og styresystemer, som forventer anderledes terminalopførsel.</i></"
+"small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "_Backspace-tast genererer:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "_Delete-tast genererer:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Nulstil kompatibilitetsindstillinger til standardværdier"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Fokuseret"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Modtagene"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Skjul størrelse fra titel"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Brug systemskrittypen"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Vælg en titellinje skrifttype"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiler"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Type"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Tilpasset kommando:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Arbejdsmappe:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Layouts"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Handling"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Genvejstast"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Genvejstaster"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Udvidelsesmodul"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Dette udvidelsesmodul har ingen konfigurationsmuligheder"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Udvidelsesmoduler"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Målet for dette projekt er at producere et brugbart værktøj til at arrangere terminaler. Det er inspireret af programmer som gnome-multi-term, quadkonsole, etc. på den måde at det primære fokus er at arrangere terminaler i net (faneblade er den mest normale standardmetode, som Terminator også understøtter).\n"
+"Målet for dette projekt er at producere et brugbart værktøj til at arrangere "
+"terminaler. Det er inspireret af programmer som gnome-multi-term, "
+"quadkonsole, etc. på den måde at det primære fokus er at arrangere "
+"terminaler i net (faneblade er den mest normale standardmetode, som "
+"Terminator også understøtter).\n"
 "\n"
-"Meget af Terminators opførsel, er besaeret på GNOME Terminal, og vi tilføjer flere funktioner fra den som tiden går, men vi vil også gerne udvide i andre retninger med brugbare funktioner til systemadministratorer og andre brugere.\n"
-"Hvis du har nogen forslag, så indgiv gerne ønskeliste fejl! (se til venstre for Udvikler link)"
+"Meget af Terminators opførsel, er besaeret på GNOME Terminal, og vi tilføjer "
+"flere funktioner fra den som tiden går, men vi vil også gerne udvide i andre "
+"retninger med brugbare funktioner til systemadministratorer og andre "
+"brugere.\n"
+"Hvis du har nogen forslag, så indgiv gerne ønskeliste fejl! (se til venstre "
+"for Udvikler link)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "Manualen"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Om"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Forøg skriftstørrelse"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Formindsk skriftstørrelse"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Genskab original skriftstørrelse"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Opret et nyt faneblad"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Fokusér den næste terminal"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Fokusér den foregående terminal"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Fokuser terminalen ovenfor"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Fokusér terminalen nedenfor"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Fokusér terminalen til venstre"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Fokusér terminalen til højre"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Rotér terminalerne med uret"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Rotér terminalerne mod uret"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Del horisontalt"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Del vertikalt"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Luk terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Kopiér markeret tekst"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Indsæt fra klippebordet"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1590,11 +1474,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Åbn manualen"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Ny profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nyt layout"
 
@@ -1607,185 +1491,169 @@ msgstr "Søg:"
 msgid "Close Search bar"
 msgstr "Luk søgebjælken"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Send email til..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopiér email adresse"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Opka_ld VoIP-adresse"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopiér VoIP-adresse"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Åbn link"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopiér adresse"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Del _Vandret"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Del _Lodret"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Åbn _Fane"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Åbn _Fejlsøgning Fane"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zoom terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Ma_ksimér terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Genskab alle terminaler"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Gruppering"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Vis _rullebjælke"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Tegnsæt"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Standard"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Brugerdefineret"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Andre Tegnsæt"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "N_y gruppe"
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Ingen"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Fjern gruppen %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_ruppér alle i fane"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Opde_l alle i faneblad"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Fjern alle grupper"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Luk gruppen %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Udsend _alle"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Udsend _gruppe"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Udsend _off"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "O_pdel til denne gruppe"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Autoop_ryd grupper"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_Indsæt terminalnummer"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Indsæt forøget terminalnummer"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Kan ikke finde en kommandofortolker"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Kan ikke starte skal:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Omdøb vindue"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Indtast en ny titel for Terminator vinduet..."
 
@@ -1893,12 +1761,117 @@ msgstr "Omega"
 msgid "window"
 msgstr "vindue"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Faneblad %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Nuværende regionaldata"
+
+#~ msgid "Western"
+#~ msgstr "Vestligt"
+
+#~ msgid "Central European"
+#~ msgstr "Centraleuropæisk"
+
+#~ msgid "South European"
+#~ msgstr "Sydeuropæisk"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltisk"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kyrillisk"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabisk"
+
+#~ msgid "Greek"
+#~ msgstr "Græsk"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebraisk, Visuel"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebraisk"
+
+#~ msgid "Turkish"
+#~ msgstr "Tyrkisk"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordisk"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltisk"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumænsk"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armensk"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Kinesisk, traditionel"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kyrillisk/russisk"
+
+#~ msgid "Japanese"
+#~ msgstr "Japansk"
+
+#~ msgid "Korean"
+#~ msgstr "Koreansk"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Kinesisk, forenklet"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgisk"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kyrillisk/Ukrainsk"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroatisk"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persisk"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandsk"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamesisk"
+
+#~ msgid "Thai"
+#~ msgstr "Thai"
+
+#~ msgid "Encodings"
+#~ msgstr "Tegnsæt"
+
+#~ msgid "Default"
+#~ msgstr "Standard"
+
+#~ msgid "User defined"
+#~ msgstr "Brugerdefineret"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Andre Tegnsæt"

--- a/po/de.po
+++ b/po/de.po
@@ -2,25 +2,26 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Markus Frosch <markus@lazyfrosch.de>, 2021
 # Constantin Kraft <ckraft@smail.uni-koeln.de>, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Constantin Kraft <ckraft@smail.uni-koeln.de>, 2021\n"
-"Language-Team: German (https://www.transifex.com/terminator/teams/109338/de/)\n"
+"Language-Team: German (https://www.transifex.com/terminator/teams/109338/"
+"de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -130,7 +131,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -139,7 +140,7 @@ msgid "Multiple terminals in one window"
 msgstr "Mehrere Terminals in einem Fenster"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Die Roboterzukunft der Terminals"
 
@@ -147,13 +148,13 @@ msgstr "Die Roboterzukunft der Terminals"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 "Ein Werkzeug für erfahrene Nutzer, um Terminals anzuordnen. Es ist von "
 "Anwendungen wie gnome-multi-term, quadkonsole, usw. inspiriert, deren "
-"Hauptfokus darin besteht, Terminals in Raster anzuordnen (die Verwendung von"
-" Reitern ist die meist verbreitete Methode, welche auch ebenfalls von "
+"Hauptfokus darin besteht, Terminals in Raster anzuordnen (die Verwendung von "
+"Reitern ist die meist verbreitete Methode, welche auch ebenfalls von "
 "Terminator unterstützt wird)."
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -247,156 +248,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Diese Nachricht in Zukunft nicht mehr anzeigen"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Derzeitiger Einstellungssatz"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Westlich"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Mitteleuropäisch"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Südeuropäisch"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltisch"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kyrillisch"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabisch"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Griechisch"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebräisch (visuell)"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebräisch"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Türkisch"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordisch"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltisch"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumänisch"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenisch"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chinesisch (traditionell)"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kyrillisch/Russisch"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japanisch"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreanisch"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chinesisch (vereinfacht)"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgisch"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kyrillisch/Ukrainisch"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroatisch"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persisch"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Isländisch"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamesisch"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thailändisch"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Terminator-Anordnungsstarter"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Anordnung"
 
@@ -404,11 +261,11 @@ msgstr "Anordnung"
 msgid "Launch"
 msgstr "Starten"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "Reiter"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Reiter schließen"
 
@@ -505,8 +362,7 @@ msgstr ""
 #: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
 msgstr ""
-"Komma getrennte Liste von Funktionen, auf die die Fehlersuche beschränkt "
-"wird"
+"Komma getrennte Liste von Funktionen, auf die die Fehlersuche beschränkt wird"
 
 #: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
@@ -548,7 +404,7 @@ msgstr "_Benutzerdefinierte Befehle"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Einstellungen"
 
@@ -573,12 +429,12 @@ msgid "Enabled"
 msgstr "Aktiviert"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Name"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Befehl"
 
@@ -684,7 +540,7 @@ msgid "Escape sequence"
 msgstr "Escape-Sequenz"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Alle"
 
@@ -901,493 +757,510 @@ msgid "Use custom URL handler"
 msgstr "Benutzerdefinierten URL-Handler benutzen"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Benutzerdefinierter URL-Handler:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr "PRIMÄR"
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr "Zwischenablage"
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr "Auswahl nach dem Kopieren aufheben"
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Benutzerdefinierter URL-Handler:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Aussehen</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Fensterrahmen"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Schrifthelligkeit von nicht fokussiertem Terminal:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Terminal-Trennergröße:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr "Zeilenabstand:"
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Zusätzliches Styling (Themenabhängig)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Reiterposition:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Einheitliche Reiter"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Reiterscrolltasten"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr "Titelleiste unten (Neustart erfordelich)"
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Systemschriftart mit fester Breite verwenden"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Schriftart:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Terminal-Schriftart auswählen"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Fettschrift erlauben"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Titelleiste anzeigen"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Bei Auswahl kopieren"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Strg+Mausrad-Zoom deaktivieren"
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "_Zeichenfolgen auswählen:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Zeiger</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Form:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Blinken"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Hintergrund:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal-Glocke</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Titelleistensymbol"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Visuelles aufblitzen"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Akustisches Signal"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Fensterliste aufblitzen"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Allgemein"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Befehl in Login-Shell ausführen"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "_Benutzerdefinierten Befehl ausführen, anstatt meiner Shell"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "_Benutzerdefinierter Befehl:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "_Wenn der Befehl beendet wird:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Vorder- und Hintergrund</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Farben vom Systemthema verwenden"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "_Integrierte Schemata:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Farbpalette</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Integrierte _Schemata:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "_Farbpalette:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr "_Zeige Fettschrift in hellen Farben"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Farben"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Einfarbig"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Transparenter Hintergrund"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr "Hintergrund Bild"
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr "Hintergrund Bild Datei:"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr "Datei wählen"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Keine</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximal</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Hintergrund"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Bildlaufleiste ist:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "_Bildlauf bei Ausgabe"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "_Bildlauf bei Tastendruck"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Unbegrenzter Verlauf"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "_Verlauf:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "Zeilen"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Bildlauf"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Hinweis:</b> Diese Einstellungen können dazu führen, dass sich "
 "einige Anwendungen nicht mehr korrekt verhalten. Sie stehen nur zur "
 "Verfügung, um problematische Anwendungen oder Betriebssysteme zu umgehen, "
 "die ein anderes Terminal-Verhalten erwarten.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "_Rücktaste erzeugt:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "_Entfernen-Taste erzeugt:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Zeichensatz:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Kompatibilitätseinstellungen auf Standardwerte zurücksetzen"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Kompatibilität"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Fokussiert"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Empfangen"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Größe im Titel verstecken"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Systemschriftart verwenden"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Schriftart für die Titelleiste auswählen"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profile"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Art"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Benutzerdefinierter Befehl:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Arbeitsverzeichnis:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Anordnungen"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Aktion"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Tastenbelegung"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Tastenbelegungen"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Zusatzmodul"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Dieses Zusatzmodul hat keine Konfigurationsoptionen"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Zusatzmodule"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Das Ziel dieses Projekts ist es, ein nützliches Werkzeug zur Einrichtung von"
-" Terminals zu schaffen. Es ist von Programmen wie gnome-multi-term, "
+"Das Ziel dieses Projekts ist es, ein nützliches Werkzeug zur Einrichtung von "
+"Terminals zu schaffen. Es ist von Programmen wie gnome-multi-term, "
 "quadkonsole, usw. inspiriert, bei dem der Hauptfokus auf das Anordnen von "
 "Terminals in Gittern (Tabs sind die meist verbreitete Methode, die "
 "Terminator ebenfalls unterstützt."
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "Das Handbuch"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Entwicklung</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs/Verbesserungen</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs/"
+"Verbesserungen</a>"
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Über"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Schrift vergrößern"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Schrift verkleinern"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Orginale Schriftgröße wiederherstellen"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Neuen Reiter erstellen"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Nächstes Terminal fokussieren"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Vorheriges Terminal fokussieren"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Obiges Terminal fokussieren"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Unteres Terminal fokussieren"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Linkes Terminal fokussieren"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Rechtes Terminal fokussieren"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Terminals im Uhrzeigersinn drehen"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Terminals gegen den Uhrzeigersinn drehen"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Horizontal teilen"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Senkrecht teilen"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Terminal schließen"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Ausgewählten Text kopieren"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Zwischenablage einfügen"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1621,11 +1494,11 @@ msgstr "Einstellungs-Fenster öffnen"
 msgid "Open the manual"
 msgstr "Handbuch öffnen"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Neues Profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Neue Anordnung"
 
@@ -1638,185 +1511,169 @@ msgstr "Suche:"
 msgid "Close Search bar"
 msgstr "Suchleiste schließen"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_E-Mail senden an…"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_E-Mail-Adresse kopieren"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_VoIP-Adresse anrufen"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_VoIP-Adresse kopieren"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Link öffnen"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Adresse kopieren"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Kopieren"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "_Einfügen"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "_Horizontal teilen"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "_Vertikal teilen"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "_Reiter öffnen"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "_Debuggingreiter öffnen"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Schließen"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Terminal vergrößern"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "_Terminal maximieren"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Alle Terminals wiederherstellen"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Gruppierung"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "_Bildlaufleiste anzeigen"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr "_Anordnungen …"
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Zeichenkodierungen"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Standard"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Benutzerdefiniert"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Weitere Zeichenkodierungen"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "Neue Gruppe …"
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Keine"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Gruppe %s entfernen"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Alle im Reiter gruppieren"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Gruppe im Reiter auflösen"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Alle Gruppen entfernen"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Gruppe %s schließen"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "_Alles senden"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "_Gruppe senden"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "_Senden aus"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "_In diese Gruppe teilen"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Gruppen automatisch aufräumen"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_Terminal-Nummer einfügen"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "_Terminal-Nummer einfügen (auffüllen)"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Es konnte keine Shell gefunden werden"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Shell kann nicht gestartet werden:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Fenster umbenennen"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Neuen Titel für das Terminator-Fenster eingeben …"
 
@@ -1924,12 +1781,123 @@ msgstr "Omega"
 msgid "window"
 msgstr "Fenster"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Reiter %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Derzeitiger Einstellungssatz"
+
+#~ msgid "Western"
+#~ msgstr "Westlich"
+
+#~ msgid "Central European"
+#~ msgstr "Mitteleuropäisch"
+
+#~ msgid "South European"
+#~ msgstr "Südeuropäisch"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltisch"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kyrillisch"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabisch"
+
+#~ msgid "Greek"
+#~ msgstr "Griechisch"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebräisch (visuell)"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebräisch"
+
+#~ msgid "Turkish"
+#~ msgstr "Türkisch"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordisch"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltisch"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumänisch"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenisch"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chinesisch (traditionell)"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kyrillisch/Russisch"
+
+#~ msgid "Japanese"
+#~ msgstr "Japanisch"
+
+#~ msgid "Korean"
+#~ msgstr "Koreanisch"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chinesisch (vereinfacht)"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgisch"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kyrillisch/Ukrainisch"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroatisch"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persisch"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Isländisch"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamesisch"
+
+#~ msgid "Thai"
+#~ msgstr "Thailändisch"
+
+#~ msgid "Line Height:"
+#~ msgstr "Zeilenabstand:"
+
+#~ msgid "Encoding:"
+#~ msgstr "Zeichensatz:"
+
+#~ msgid "Encodings"
+#~ msgstr "Zeichenkodierungen"
+
+#~ msgid "Default"
+#~ msgstr "Standard"
+
+#~ msgid "User defined"
+#~ msgstr "Benutzerdefiniert"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Weitere Zeichenkodierungen"

--- a/po/el.po
+++ b/po/el.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Greek (https://www.transifex.com/terminator/teams/109338/el/)\n"
+"Language-Team: Greek (https://www.transifex.com/terminator/teams/109338/"
+"el/)\n"
+"Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: el\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -126,7 +127,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -135,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Πολλαπλά τερματικά σε ένα παράθυρο"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -143,8 +144,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -227,156 +228,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Μην δείξεις αυτό το μήνυμα την επόμενη φορά"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Τρέχουσα εντοπιότητα (locale)"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Δυτικός"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Κεντρικής Ευρώπης"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Νότιας Ευρώπης"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Βαλτικής"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Κυριλλικά"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Αραβικά"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Ελληνικά"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Εβραϊκά Οπτικά"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Εβραϊκά"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Τουρκικά"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Σκανδιναβικά"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Κελτικά"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Ρουμανικά"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Αρμενικά"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Κινέζικα Παραδοσιακά"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Κυριλλικά/Ρώσικα"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Ιαπωνικά"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Κορεάτικα"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Κινέζικα Απλοποιημένα"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Γεωργιανά"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Κυριλλικά/Ουκρανικά"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Κροατικά"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Ινδικά"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Περσικά"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Γκουτζαράτι"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Ισλανδικά"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Βιετναμέζικα"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Ταϋλανδέζικα"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Διάταξη"
 
@@ -384,11 +241,11 @@ msgstr "Διάταξη"
 msgid "Launch"
 msgstr "Εκτέλεση"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "στηλοθέτης"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Κλείσιμο καρτέλας"
 
@@ -526,7 +383,7 @@ msgstr "Προσαρμοσμένες εντολές"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Προτιμήσεις"
 
@@ -551,12 +408,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Όνομα"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Εντολή"
 
@@ -662,7 +519,7 @@ msgid "Escape sequence"
 msgstr "Ακολουθία διαφυγής"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Όλα"
 
@@ -879,481 +736,497 @@ msgid "Use custom URL handler"
 msgstr "Χρήση προσαρμοσμένου χειριστή URL"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Εμφάνιση</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Περιγράμματα παραθύρου"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Μέγεθος διαχωριστικού τερματικών:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
-msgstr "Θέση καρτέλας:"
+msgid "Cell Height:"
+msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
-msgstr ""
+msgid "Tab position:"
+msgstr "Θέση καρτέλας:"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
+msgid "Global"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Προφίλ"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Χρήση της γραμματοσειράς σταθερού πλάτους του συστήματος"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Γραμματοσειρά:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Επιλογή γραμματοσειράς τερματικού"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Να επιτρέπεται η χρήση έντονου κειμένου"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Εμφάνιση μπάρας τίτλων"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Αντιγραφή στην επιλογή"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Δρομέας</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Σχήμα"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Φόντο:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Γενικά"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Προσκήνιο και παρασκήνιο</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Παλέτα</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Πα_λέτα χρωμάτων:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Χρώματα"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Συμπαγές χρώμα"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Διαφανές παρασκήνιο"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Φόντο"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
+msgid "_Reset Compatibility Options to Defaults"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Συμβατότητα"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Γίνεται λήψη"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Προφίλ"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Συνδυασμοί πλήκτρων"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Το πρόσθετο δεν έχει επιλογές παραμετροποίησης"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Πρόσθετα"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1588,11 +1461,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Νέο Προφίλ"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Νέα Διάταξη"
 
@@ -1605,185 +1478,169 @@ msgstr "Αναζήτηση:"
 msgid "Close Search bar"
 msgstr "Κλείσιμο της μπάρας Αναζήτησης"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_ Αποστολή ηλεκτρονικού μηνύματος σε..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Αντιγραφή της διεύθυνσης ηλεκτρονικού ταχυδρομείου"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Κλήσεων VoIP διεύθυνση"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Αντιγραφή της διεύθυνσης VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Άνοιγμα συνδέσμου"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Αντιγραφή διεύθυνσης"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Ο_ριζόντιος  διαχωρισμός"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Κά_θετος διαχωρισμός"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Άνοιγμα _Καρτέλας"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Άνοιγμα καρτέλας αποσφαλμάτωσης"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Προσέγγιση τερματικού"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "Απο_κατάσταση όλων των τερματικών"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Ομαδοποίηση"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Εμφάνισε _την  μπάρα κύλισης"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Κωδικοποιήσεις"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Προκαθορισμένο"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Ορισμένο από τον χρήστη"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Άλλες Κωδικοποιήσεις"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Διαγραφή της ομάδας %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Ομάδα όλα στην καρτέλα"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Διαγραφή όλων των ομάδων"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Κλείσιμο της ομάδας %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Αδυναμία εξεύρεσης περιβάλλοντος"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Αδύνατη η εκκίνηση κελύφους:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Μετονομασία παραθύρου"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Πληκτρολόγηση νέου τίτλου για το παράθυρο του Terminator..."
 
@@ -1891,12 +1748,117 @@ msgstr ""
 msgid "window"
 msgstr "παράθυρο"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Καρτέλα %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Τρέχουσα εντοπιότητα (locale)"
+
+#~ msgid "Western"
+#~ msgstr "Δυτικός"
+
+#~ msgid "Central European"
+#~ msgstr "Κεντρικής Ευρώπης"
+
+#~ msgid "South European"
+#~ msgstr "Νότιας Ευρώπης"
+
+#~ msgid "Baltic"
+#~ msgstr "Βαλτικής"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Κυριλλικά"
+
+#~ msgid "Arabic"
+#~ msgstr "Αραβικά"
+
+#~ msgid "Greek"
+#~ msgstr "Ελληνικά"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Εβραϊκά Οπτικά"
+
+#~ msgid "Hebrew"
+#~ msgstr "Εβραϊκά"
+
+#~ msgid "Turkish"
+#~ msgstr "Τουρκικά"
+
+#~ msgid "Nordic"
+#~ msgstr "Σκανδιναβικά"
+
+#~ msgid "Celtic"
+#~ msgstr "Κελτικά"
+
+#~ msgid "Romanian"
+#~ msgstr "Ρουμανικά"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Αρμενικά"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Κινέζικα Παραδοσιακά"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Κυριλλικά/Ρώσικα"
+
+#~ msgid "Japanese"
+#~ msgstr "Ιαπωνικά"
+
+#~ msgid "Korean"
+#~ msgstr "Κορεάτικα"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Κινέζικα Απλοποιημένα"
+
+#~ msgid "Georgian"
+#~ msgstr "Γεωργιανά"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Κυριλλικά/Ουκρανικά"
+
+#~ msgid "Croatian"
+#~ msgstr "Κροατικά"
+
+#~ msgid "Hindi"
+#~ msgstr "Ινδικά"
+
+#~ msgid "Persian"
+#~ msgstr "Περσικά"
+
+#~ msgid "Gujarati"
+#~ msgstr "Γκουτζαράτι"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Ισλανδικά"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Βιετναμέζικα"
+
+#~ msgid "Thai"
+#~ msgstr "Ταϋλανδέζικα"
+
+#~ msgid "Encodings"
+#~ msgstr "Κωδικοποιήσεις"
+
+#~ msgid "Default"
+#~ msgstr "Προκαθορισμένο"
+
+#~ msgid "User defined"
+#~ msgstr "Ορισμένο από τον χρήστη"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Άλλες Κωδικοποιήσεις"

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: English (Australia) (https://www.transifex.com/terminator/teams/109338/en_AU/)\n"
+"Language-Team: English (Australia) (https://www.transifex.com/terminator/"
+"teams/109338/en_AU/)\n"
+"Language: en_AU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_AU\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -128,7 +129,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -137,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Multiple terminals in one window"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "The robot future of terminals"
 
@@ -145,8 +146,8 @@ msgstr "The robot future of terminals"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -229,156 +230,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Do not show this message next time"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Current Locale"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Western"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Central European"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "South European"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltic"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrillic"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabic"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Greek"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebrew Visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebrew"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turkish"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordic"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtic"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romanian"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenian"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chinese Traditional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyrillic/Russian"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japanese"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korean"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chinese Simplified"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgian"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cyrillic/Ukrainian"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croatian"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persian"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Icelandic"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamese"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Terminator Layout Launcher"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Layout"
 
@@ -386,11 +243,11 @@ msgstr "Layout"
 msgid "Launch"
 msgstr "Launch"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Close Tab"
 
@@ -522,7 +379,7 @@ msgstr "_Custom Commands"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferences"
 
@@ -547,12 +404,12 @@ msgid "Enabled"
 msgstr "Enabled"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Name"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Command"
 
@@ -658,7 +515,7 @@ msgid "Escape sequence"
 msgstr "Escape sequence"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "All"
 
@@ -875,481 +732,497 @@ msgid "Use custom URL handler"
 msgstr "Use custom URL handler"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Custom URL handler:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Custom URL handler:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Appearance</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Window borders"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Unfocused terminal font brightness:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Terminal separator size:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Tab position:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Tabs homogeneous"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Tabs scroll buttons"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
+msgid "Compatibility"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Focused"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Receiving"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiles"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1584,11 +1457,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "New Profile"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "New Layout"
 
@@ -1601,185 +1474,169 @@ msgstr "Search:"
 msgid "Close Search bar"
 msgstr "Close Search bar"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Send email to..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copy email address"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Ca_ll VoIP address"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copy VoIP address"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Open link"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copy address"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Split H_orizontally"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Split V_ertically"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Open _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Open _Debug Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zoom terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restore all terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Grouping"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Show _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Encodings"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Default"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "User defined"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Other Encodings"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Remove group %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_roup all in tab"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Remove all groups"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Close group %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Unable to find a shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Unable to start shell:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1887,12 +1744,117 @@ msgstr ""
 msgid "window"
 msgstr "window"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Current Locale"
+
+#~ msgid "Western"
+#~ msgstr "Western"
+
+#~ msgid "Central European"
+#~ msgstr "Central European"
+
+#~ msgid "South European"
+#~ msgstr "South European"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltic"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrillic"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabic"
+
+#~ msgid "Greek"
+#~ msgstr "Greek"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebrew Visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebrew"
+
+#~ msgid "Turkish"
+#~ msgstr "Turkish"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordic"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtic"
+
+#~ msgid "Romanian"
+#~ msgstr "Romanian"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenian"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chinese Traditional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyrillic/Russian"
+
+#~ msgid "Japanese"
+#~ msgstr "Japanese"
+
+#~ msgid "Korean"
+#~ msgstr "Korean"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chinese Simplified"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgian"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cyrillic/Ukrainian"
+
+#~ msgid "Croatian"
+#~ msgstr "Croatian"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persian"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Icelandic"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamese"
+
+#~ msgid "Thai"
+#~ msgstr "Thai"
+
+#~ msgid "Encodings"
+#~ msgstr "Encodings"
+
+#~ msgid "Default"
+#~ msgstr "Default"
+
+#~ msgid "User defined"
+#~ msgstr "User defined"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Other Encodings"

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: English (Canada) (https://www.transifex.com/terminator/teams/109338/en_CA/)\n"
+"Language-Team: English (Canada) (https://www.transifex.com/terminator/"
+"teams/109338/en_CA/)\n"
+"Language: en_CA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_CA\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Multiple terminals in one window"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Current Locale"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Western"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Central European"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "South European"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltic"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrillic"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabic"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Greek"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebrew Visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebrew"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turkish"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordic"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtic"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romanian"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenian"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chinese Traditional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyrillic/Russian"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japanese"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korean"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chinese Simplified"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgian"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cyrillic/Ukrainian"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croatian"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persian"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Icelandic"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamese"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Close Tab"
 
@@ -517,7 +374,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferences"
 
@@ -542,12 +399,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -653,7 +510,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "All"
 
@@ -870,43 +727,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -914,437 +771,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiles"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1579,11 +1452,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "New Profile"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "New Layout"
 
@@ -1596,185 +1469,169 @@ msgstr "Search:"
 msgid "Close Search bar"
 msgstr "Close Search bar"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Send email to..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copy email address"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Ca_ll VoIP address"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copy VoIP address"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Open link"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copy address"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Split H_orizontally"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Split V_ertically"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Open _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Open _Debug Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zoom terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restore all terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Grouping"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Show _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Encodings"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Default"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "User defined"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Other Encodings"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Remove group %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_roup all in tab"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Remove all groups"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Close group %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Unable to find a shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Unable to start shell:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1882,12 +1739,117 @@ msgstr ""
 msgid "window"
 msgstr "window"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Current Locale"
+
+#~ msgid "Western"
+#~ msgstr "Western"
+
+#~ msgid "Central European"
+#~ msgstr "Central European"
+
+#~ msgid "South European"
+#~ msgstr "South European"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltic"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrillic"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabic"
+
+#~ msgid "Greek"
+#~ msgstr "Greek"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebrew Visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebrew"
+
+#~ msgid "Turkish"
+#~ msgstr "Turkish"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordic"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtic"
+
+#~ msgid "Romanian"
+#~ msgstr "Romanian"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenian"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chinese Traditional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyrillic/Russian"
+
+#~ msgid "Japanese"
+#~ msgstr "Japanese"
+
+#~ msgid "Korean"
+#~ msgstr "Korean"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chinese Simplified"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgian"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cyrillic/Ukrainian"
+
+#~ msgid "Croatian"
+#~ msgstr "Croatian"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persian"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Icelandic"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamese"
+
+#~ msgid "Thai"
+#~ msgstr "Thai"
+
+#~ msgid "Encodings"
+#~ msgstr "Encodings"
+
+#~ msgid "Default"
+#~ msgstr "Default"
+
+#~ msgid "User defined"
+#~ msgstr "User defined"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Other Encodings"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: English (United Kingdom) (https://www.transifex.com/terminator/teams/109338/en_GB/)\n"
+"Language-Team: English (United Kingdom) (https://www.transifex.com/"
+"terminator/teams/109338/en_GB/)\n"
+"Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -128,7 +129,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -137,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Multiple terminals in one window"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "The robot future of terminals"
 
@@ -145,8 +146,8 @@ msgstr "The robot future of terminals"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -233,156 +234,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Do not show this message next time"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Current Locale"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Western"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Central European"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "South European"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltic"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrillic"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabic"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Greek"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebrew Visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebrew"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turkish"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordic"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtic"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romanian"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenian"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chinese Traditional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyrillic/Russian"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japanese"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korean"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chinese Simplified"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgian"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cyrillic/Ukrainian"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croatian"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persian"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Icelandic"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamese"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Terminator Layout Launcher"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Layout"
 
@@ -390,11 +247,11 @@ msgstr "Layout"
 msgid "Launch"
 msgstr "Launch"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Close Tab"
 
@@ -526,7 +383,7 @@ msgstr "_Custom Commands"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferences"
 
@@ -551,12 +408,12 @@ msgid "Enabled"
 msgstr "Enabled"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Name"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Command"
 
@@ -662,7 +519,7 @@ msgid "Escape sequence"
 msgstr "Escape sequence"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "All"
 
@@ -879,489 +736,512 @@ msgid "Use custom URL handler"
 msgstr "Use custom URL handler"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Custom URL handler:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Custom URL handler:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Appearance</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Window borders"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Unfocused terminal font brightness:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Terminal separator size:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Extra Styling (Theme dependent)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Tab position:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Tabs homogeneous"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Tabs scroll buttons"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profile"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Use the system fixed width font"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Font:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Choose A Terminal Font"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Allow bold text"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Show titlebar"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Copy on selection"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Select-by-_word characters:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Shape:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Blink"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Background:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal bell</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Titlebar icon"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Visual flash"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Audible beep"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Window list flash"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "General"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Run command as a login shell"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Ru_n a custom command instead of my shell"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Custom co_mmand:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "When command _exits:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Foreground and Background</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Use colours from system theme"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Built-in sche_mes:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Palette</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Built-in _schemes:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Colour p_alette:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Colours"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Solid colour"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Transparent background"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>None</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Background"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Scrollbar is:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Scroll on _output"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Scroll on _keystroke"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Infinite Scrollback"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Scroll_back:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "lines"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Scrolling"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behaviour.</i></small>"
+"applications and operating systems that expect different terminal behaviour."
+"</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "_Backspace key generates:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "_Delete key generates:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Encoding:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Reset Compatibility Options to Defaults"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Compatibility"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Focused"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Inactive"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Receiving"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Hide size from title"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Use the system font"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Choose A Titlebar Font"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiles"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Type"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profile:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Custom command:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Working directory:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Layouts"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Action"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Keybinding"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Keybindings"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "This plug-in has no configuration options"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behaviour of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behaviour of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "The Manual"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "About"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Increase font size"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Decrease font size"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Restore original font size"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Create a new tab"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Focus the next terminal"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Focus the previous terminal"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Focus the terminal above"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Focus the terminal below"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Focus the terminal left"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Focus the terminal right"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Rotate terminals clockwise"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Rotate terminals counter-clockwise"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Split horizontally"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Split vertically"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Close terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Copy selected text"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Paste clipboard"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1595,11 +1475,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Open the manual"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "New Profile"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "New Layout"
 
@@ -1612,185 +1492,169 @@ msgstr "Search:"
 msgid "Close Search bar"
 msgstr "Close Search bar"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Send email to..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copy email address"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Ca_ll VoIP address"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copy VoIP address"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Open link"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copy address"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Copy"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "_Paste"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Split H_orizontally"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Split V_ertically"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Open _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Open _Debug Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Close"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zoom terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximise terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restore all terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Grouping"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Show _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Encodings"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Default"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "User defined"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Other Encodings"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "N_ew group..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_None"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Remove group %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_roup all in tab"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Ungro_up all in tab"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Remove all groups"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Close group %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Broadcast _all"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Broadcast _group"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Broadcast _off"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "_Split to this group"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Auto_clean groups"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_Insert terminal number"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Insert _padded terminal number"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Unable to find a shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Unable to start shell:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Rename Window"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Enter a new title for the Terminator window..."
 
@@ -1898,12 +1762,120 @@ msgstr "Omega"
 msgid "window"
 msgstr "window"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Current Locale"
+
+#~ msgid "Western"
+#~ msgstr "Western"
+
+#~ msgid "Central European"
+#~ msgstr "Central European"
+
+#~ msgid "South European"
+#~ msgstr "South European"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltic"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrillic"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabic"
+
+#~ msgid "Greek"
+#~ msgstr "Greek"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebrew Visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebrew"
+
+#~ msgid "Turkish"
+#~ msgstr "Turkish"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordic"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtic"
+
+#~ msgid "Romanian"
+#~ msgstr "Romanian"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenian"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chinese Traditional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyrillic/Russian"
+
+#~ msgid "Japanese"
+#~ msgstr "Japanese"
+
+#~ msgid "Korean"
+#~ msgstr "Korean"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chinese Simplified"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgian"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cyrillic/Ukrainian"
+
+#~ msgid "Croatian"
+#~ msgstr "Croatian"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persian"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Icelandic"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamese"
+
+#~ msgid "Thai"
+#~ msgstr "Thai"
+
+#~ msgid "Encoding:"
+#~ msgstr "Encoding:"
+
+#~ msgid "Encodings"
+#~ msgstr "Encodings"
+
+#~ msgid "Default"
+#~ msgstr "Default"
+
+#~ msgid "User defined"
+#~ msgstr "User defined"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Other Encodings"

--- a/po/eo.po
+++ b/po/eo.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Esperanto (https://www.transifex.com/terminator/teams/109338/eo/)\n"
+"Language-Team: Esperanto (https://www.transifex.com/terminator/teams/109338/"
+"eo/)\n"
+"Language: eo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: eo\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminatoro"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Pluraj terminaloj en unu fenestro"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Ne montru ĉi tiun mesaĝon venontfoje"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Aktuala lokaĵaro"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Okcidenta"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Mezeŭropa"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Sudeŭropa"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Balta"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirila"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Araba"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Greka"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Vidhebrea"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebrea"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turka"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Norda"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Kelta"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumana"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unikoda"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armena"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Tradicia ĉina"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cirila/Rusa"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japana"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korea"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Simpligita ĉina"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Kartvela"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirila/Ukraina"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroata"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hinda"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persa"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Guĝarata"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukia"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islanda"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vjetnama"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Taja"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "langeto"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Fermi langeton"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Agordoj"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Komando"
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Ĉiuj"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
+msgid "Profile"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:79
+msgid "_Use the system fixed width font"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Tiparo:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Elektu tiparon de la terminalo"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Permesi dikan tekston"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Kursoro</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Ĝenerala"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Propra ko_mando:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Kiam komando _ekzistas:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Malfono kaj Fono</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Uzi kolorojn de la sistema etoso"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Koloraro</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Kolorp_aletro:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Koloroj"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Travidebla fono"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Neniu</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimuma</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Fono"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "linioj"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "_Retropaŝoklavo generas:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "_Forigklavo generas:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Kongrueco"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiloj"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Ĉi tiu kromprogramo ne havas agordajn opciojn"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Kromprogramoj"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nova profilo"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr "Serĉi:"
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Sendi retpoŝton al..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopii retadreson"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Malfermi ligilon"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopii adreson"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Dividi _Horizontale"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Dividi _Vertikale"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Malfermu _Langeton"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Pligrandigi terminalon"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Grupado"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kodoprezentoj"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Agordita de la uzanto"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Alia kodoprezentoj"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Forigi grupon %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_rupigi ĉiujn en langeto"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Forigi ĉiujn grupojn"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Fermi grupon %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Ne troveblas terminalon"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Ne startigeblas la terminalon"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Renomi fenestron"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Enigu novan titolon por la Terminatora fenestro"
 
@@ -1880,12 +1737,114 @@ msgstr ""
 msgid "window"
 msgstr "fenestro"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Langeto %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Aktuala lokaĵaro"
+
+#~ msgid "Western"
+#~ msgstr "Okcidenta"
+
+#~ msgid "Central European"
+#~ msgstr "Mezeŭropa"
+
+#~ msgid "South European"
+#~ msgstr "Sudeŭropa"
+
+#~ msgid "Baltic"
+#~ msgstr "Balta"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirila"
+
+#~ msgid "Arabic"
+#~ msgstr "Araba"
+
+#~ msgid "Greek"
+#~ msgstr "Greka"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Vidhebrea"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebrea"
+
+#~ msgid "Turkish"
+#~ msgstr "Turka"
+
+#~ msgid "Nordic"
+#~ msgstr "Norda"
+
+#~ msgid "Celtic"
+#~ msgstr "Kelta"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumana"
+
+#~ msgid "Unicode"
+#~ msgstr "Unikoda"
+
+#~ msgid "Armenian"
+#~ msgstr "Armena"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Tradicia ĉina"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cirila/Rusa"
+
+#~ msgid "Japanese"
+#~ msgstr "Japana"
+
+#~ msgid "Korean"
+#~ msgstr "Korea"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Simpligita ĉina"
+
+#~ msgid "Georgian"
+#~ msgstr "Kartvela"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirila/Ukraina"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroata"
+
+#~ msgid "Hindi"
+#~ msgstr "Hinda"
+
+#~ msgid "Persian"
+#~ msgstr "Persa"
+
+#~ msgid "Gujarati"
+#~ msgstr "Guĝarata"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukia"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islanda"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vjetnama"
+
+#~ msgid "Thai"
+#~ msgstr "Taja"
+
+#~ msgid "Encodings"
+#~ msgstr "Kodoprezentoj"
+
+#~ msgid "User defined"
+#~ msgstr "Agordita de la uzanto"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Alia kodoprezentoj"

--- a/po/es.po
+++ b/po/es.po
@@ -2,24 +2,25 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Pedro Flor <pedro.flor@gmail.com>, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Pedro Flor <pedro.flor@gmail.com>, 2021\n"
-"Language-Team: Spanish (https://www.transifex.com/terminator/teams/109338/es/)\n"
+"Language-Team: Spanish (https://www.transifex.com/terminator/teams/109338/"
+"es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -99,7 +100,8 @@ msgid ""
 "* These entries require either TERMINATOR_UUID environment var,\n"
 "  or the --uuid option must be used."
 msgstr ""
-"* Estas opciones requieren que la variable de entorno TERMINATOR_UUID exista\n"
+"* Estas opciones requieren que la variable de entorno TERMINATOR_UUID "
+"exista\n"
 "  o que la opción --uuid sea empleada"
 
 #: ../remotinator.py:77
@@ -131,7 +133,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -140,7 +142,7 @@ msgid "Multiple terminals in one window"
 msgstr "Múltiples terminales en una ventana"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "El futuro robot de terminales"
 
@@ -148,8 +150,8 @@ msgstr "El futuro robot de terminales"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 " Una herramienta de usuario avanzado para organizar terminales. Está "
 "inspirado en programas como gnome-multi-term, quadkonsole, etc. en que el "
@@ -163,8 +165,8 @@ msgid ""
 "out in different directions with useful features for sysadmins and other "
 "users."
 msgstr ""
-"Gran parte del comportamiento de Terminator está basado en GNOME Terminal, y"
-" estamos añadiendo más de esas características a medida que pasa el tiempo, "
+"Gran parte del comportamiento de Terminator está basado en GNOME Terminal, y "
+"estamos añadiendo más de esas características a medida que pasa el tiempo, "
 "pero también queremos extendernos en diferentes direcciones con "
 "características útiles para administradores de sistemas y otros usuarios."
 
@@ -248,156 +250,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "No mostrar este mensaje nuevamente"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Configuración regional actual"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Occidental"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europa central"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Europa del sur"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Báltico"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirílico"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Árabe"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Griego"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebreo visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebreo"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turco"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nórdico"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Céltico"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumano"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenio"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chino tradicional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cirílico/Ruso"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonés"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coreano"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chino simplificado"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgiano"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirílico/Ucraniano"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croata"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindú"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persa"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandés"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamita"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tailandés"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Lanzador de Disposición de Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Diseño"
 
@@ -405,11 +263,11 @@ msgstr "Diseño"
 msgid "Launch"
 msgstr "Lanzar"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "pestaña"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
@@ -546,7 +404,7 @@ msgstr "_Comandos Personalizados"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferencias"
 
@@ -571,12 +429,12 @@ msgid "Enabled"
 msgstr "Activado"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Nombre"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Comando"
 
@@ -682,7 +540,7 @@ msgid "Escape sequence"
 msgstr "Secuencia de escape"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Todo"
 
@@ -899,492 +757,518 @@ msgid "Use custom URL handler"
 msgstr "Usar  operario de URL predefinido"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "URL personalizada:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr "PRINCIPAL"
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr "Portapapeles"
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr "Limpiar selección en la copia"
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "URL personalizada:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Apariencia</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Bordes de la ventana"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Brillo de fuente para terminal fuera de foco:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Tamaño del Separador del Terminal:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr "Altura de la línea:"
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Estilizado extra (depende del tema)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Posición de pestaña:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Pestañas homogéneas"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Botones para cambiar de pestañas"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr "Barra de título en la parte inferior (Requiere reinicio)"
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Perfil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Usar la tipografía de ancho fijo del sistema"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Tipografía:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Elija una tipografía de terminal"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Permitir texto resaltado"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Mostrar barra de título"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Copia de la selección"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Deshabilitar Ctrl + zoom de la rueda del ratón"
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Selección de caracteres por _palabra:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "Forma (_Shape):"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Parpadeo"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Fondo:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Campana del terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Icono de la barra de título"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Destello visual"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Pitido audible"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Destello lista de ventana"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "General"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Ejecutar el comando como un intérprete de conexión"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Ejec_utar un comando personalizado en vez de mi intérprete"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Co_mando personalizado:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Cuando la orden  _termina:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Frente y Fondo</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Usar colores del tema del sistema"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Esque_mas incluidos:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Esquemas_incluidos:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "P_aleta de colores:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr "Mostrar texto b_old en colores brillantes"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Colores"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "Color _sólido"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Fondo _transparente"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr "Imagen de Fondo"
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr "Archivo de Imagen de fondo:"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr "Elegir archivo"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr "S_hade de fondo:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ninguno</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Máximo</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Fondo de pantalla"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "La _barra de desplazamiento está:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Desplazar en la _salida"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Desplazar al pulsar _teclas"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Desplazamiento infinito"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "_Desplazar hacia atrás:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "líneas"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Desplazamiento"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
-"<small><i><b>Nota:</b> Estas opciones pueden causar que algunas aplicaciones"
-" se comporten incorrectamente. Sólo están aquí para permitirle trabajar con "
+"<small><i><b>Nota:</b> Estas opciones pueden causar que algunas aplicaciones "
+"se comporten incorrectamente. Sólo están aquí para permitirle trabajar con "
 "ciertas aplicaciones y sistemas operativos que esperan un comportamiento "
 "diferente del terminal.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "La tecla «_Retroceso» genera:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "La tecla «_Suprimir» genera:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Codificación:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 "_Reiniciar las opciones de compatibilidad a los valores predeterminados"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Compatibilidad"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Enfocado"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Inactivo"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Recibiendo"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "No mostrar el tamaño en el título"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Usar fuente del sistema"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Elija tipo de letra para la Barra de Titulo"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Perfiles"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Tipo"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Perfil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Comando personalizado:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Carpeta de trabajo:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Diseños"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Acción"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Combinación de teclas"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Asociaciones de teclas"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Complementos"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Este plugin no tiene opciones de configuración"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"El objetivo de este proyecto es crear una herramienta útil para organizar terminales. Esta inspirado por programas como gnome-multi-term, quadkonsole, etc. los cuales están enfocados principalmente en organizar terminales en cuadriculas (el método más común por defecto es el de pestañas, el cual Terminator también le da soporte).\n"
+"El objetivo de este proyecto es crear una herramienta útil para organizar "
+"terminales. Esta inspirado por programas como gnome-multi-term, quadkonsole, "
+"etc. los cuales están enfocados principalmente en organizar terminales en "
+"cuadriculas (el método más común por defecto es el de pestañas, el cual "
+"Terminator también le da soporte).\n"
 "\n"
-"Mucho del comportamiento de Terminator esta basado en el Terminal GNOME, y estamos agregando más opciones a medida que pasa el tiempo, pero también deseamos extendernos en diferentes direcciones con opciones útiles para administradores de sistemas y otros usuarios. Si tienes algunas sugerencias, por favor repórtalas en nuestro archivo de lista de deseos y de errores (ver a la izquierda para el enlace de Desarrollo)"
+"Mucho del comportamiento de Terminator esta basado en el Terminal GNOME, y "
+"estamos agregando más opciones a medida que pasa el tiempo, pero también "
+"deseamos extendernos en diferentes direcciones con opciones útiles para "
+"administradores de sistemas y otros usuarios. Si tienes algunas sugerencias, "
+"por favor repórtalas en nuestro archivo de lista de deseos y de errores (ver "
+"a la izquierda para el enlace de Desarrollo)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "EL Manual"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Desarrollo</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs/Mejoras</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs/"
+"Mejoras</a>"
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Acerca de"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Incrementar tamaño de letra"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Disminuir tamaño de letra"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Restaurar tamaño de letra"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr "Aumentar el tamaño de la letra en todas las terminales"
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr "Reducir el tamaño de la letra en todas las terminales"
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr "Restaurar el tamaño de la letra en todas las terminales"
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Crear una pestaña nueva"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Enfocar el terminal siguiente"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Enfocar el terminal anterior"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Enfocar el terminal superior"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Enfocar el terminal inferior"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Enfocar el terminal izquierdo"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Enfocar el terminal derecho"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Rotar los terminales en sentido de las agujas del reloj"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Rotar los terminales en sentido contrario de las agujas del reloj"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Dividir horizontalmente"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Dividir verticalmente"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Cerrar terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Copiar texto seleccionado"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Copiar al portapapeles"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1618,11 +1502,11 @@ msgstr "Abrir la ventana de Preferencias"
 msgid "Open the manual"
 msgstr "Abrir el manual"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Perfil nuevo"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nuevo Diseño"
 
@@ -1635,185 +1519,169 @@ msgstr "Buscar:"
 msgid "Close Search bar"
 msgstr "Cerrar Barra de Búsqueda"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Enviar correo a..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copiar dirección de correo electrónico"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Ll_amar a dirección VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copiar dirección VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "Abrir víncul_o"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copiar dirección"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Copiar"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "_Pegar"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Dividir h_orizontalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Dividir v_erticalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Abrir Pes_taña"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Abrir Pestaña de _Depuración"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Cerrar"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Agrandar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Maximizar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restaurar todas las terminales"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Agrupamiento"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr "Volver a ejecutar comando"
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Mostrar barra de de_splazamiento"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr "_Diseños..."
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Codificaciones"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Predeterminado"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definido por el usuario"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Otras codificaciones"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "Nu_evo grupo..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Ninguno"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Eliminar grupo %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Ag_rupar todos en una solapa"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Desagr_upar todo en pestaña"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Eliminar todos los grupos"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Cerrar grupo %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Difundir todo (_all)"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Difundir al _grupo"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Difusión desactivada (_off)"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "Dividir en éste grupo (_Split)"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Autolimpiar grupos (_clean)"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_Insertar número de terminal"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Insertar número de terminal de relleno (_padded)"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Imposible encontrar una terminal"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Imposible arrancar la terminal:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Renombrar ventana"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Introduzca un nuevo título para la ventana de Terminator..."
 
@@ -1921,12 +1789,123 @@ msgstr "Omega"
 msgid "window"
 msgstr "ventana"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Solapa %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Configuración regional actual"
+
+#~ msgid "Western"
+#~ msgstr "Occidental"
+
+#~ msgid "Central European"
+#~ msgstr "Europa central"
+
+#~ msgid "South European"
+#~ msgstr "Europa del sur"
+
+#~ msgid "Baltic"
+#~ msgstr "Báltico"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirílico"
+
+#~ msgid "Arabic"
+#~ msgstr "Árabe"
+
+#~ msgid "Greek"
+#~ msgstr "Griego"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebreo visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebreo"
+
+#~ msgid "Turkish"
+#~ msgstr "Turco"
+
+#~ msgid "Nordic"
+#~ msgstr "Nórdico"
+
+#~ msgid "Celtic"
+#~ msgstr "Céltico"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumano"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenio"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chino tradicional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cirílico/Ruso"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonés"
+
+#~ msgid "Korean"
+#~ msgstr "Coreano"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chino simplificado"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgiano"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirílico/Ucraniano"
+
+#~ msgid "Croatian"
+#~ msgstr "Croata"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindú"
+
+#~ msgid "Persian"
+#~ msgstr "Persa"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandés"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamita"
+
+#~ msgid "Thai"
+#~ msgstr "Tailandés"
+
+#~ msgid "Line Height:"
+#~ msgstr "Altura de la línea:"
+
+#~ msgid "Encoding:"
+#~ msgstr "Codificación:"
+
+#~ msgid "Encodings"
+#~ msgstr "Codificaciones"
+
+#~ msgid "Default"
+#~ msgstr "Predeterminado"
+
+#~ msgid "User defined"
+#~ msgstr "Definido por el usuario"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Otras codificaciones"

--- a/po/et.po
+++ b/po/et.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Estonian (https://www.transifex.com/terminator/teams/109338/et/)\n"
+"Language-Team: Estonian (https://www.transifex.com/terminator/teams/109338/"
+"et/)\n"
+"Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: et\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Mitu terminaali ühes aknas"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Käesolev lokaat"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Lääne"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Kesk-euroopa"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Lõuna-euroopa"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Balti"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kirillitsa"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Araabia"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Kreeka"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Heebrea visuaalne"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Heebrea"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Türgi"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Põhjamaad"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keldi"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumeenia"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unikood"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armeenia"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Hiina traditsiooniline"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kirillitsa/Vene"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Jaapani"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korea"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Hiina lihtsustatud"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gruusia"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kirillitsa/Ukraina"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Horvaadi"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Pärsia"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmuki"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandi"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnami"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tabulaator"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Saki sulgemine"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Eelistused"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Kõik"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiilid"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Uus profiil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Uus kujundus"
 
@@ -1594,185 +1467,169 @@ msgstr "Otsing:"
 msgid "Close Search bar"
 msgstr "Sulge otsingu riba"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Saada email ..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopeeri e-maili aadress"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "He_lista VoIP aadressile"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopeeri VoIP aadress"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "Ava _viide"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopeeri aaderess"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Poolita H_orisontaalselt"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Poolita V_ertikaalselt"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Ava vaheleht"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Ava veaanalüüsi vaheleht"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Suurenda terminaali"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Taasta kõik terminalid"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Rühmitamine"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Näita _kerimisriba"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kodeeringud"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Vaikimisi"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Kasutaja määratav"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Muud kodeeringud"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Eemalda %s grupp"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_rupeeri kõik vahelehed"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Eemalda kõik gruppid"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Sulge %s grupp"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Ei leitud shell-i"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Ei suudetud käivitada shell-i"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,117 @@ msgstr ""
 msgid "window"
 msgstr "aken"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Vaheleht %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Käesolev lokaat"
+
+#~ msgid "Western"
+#~ msgstr "Lääne"
+
+#~ msgid "Central European"
+#~ msgstr "Kesk-euroopa"
+
+#~ msgid "South European"
+#~ msgstr "Lõuna-euroopa"
+
+#~ msgid "Baltic"
+#~ msgstr "Balti"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kirillitsa"
+
+#~ msgid "Arabic"
+#~ msgstr "Araabia"
+
+#~ msgid "Greek"
+#~ msgstr "Kreeka"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Heebrea visuaalne"
+
+#~ msgid "Hebrew"
+#~ msgstr "Heebrea"
+
+#~ msgid "Turkish"
+#~ msgstr "Türgi"
+
+#~ msgid "Nordic"
+#~ msgstr "Põhjamaad"
+
+#~ msgid "Celtic"
+#~ msgstr "Keldi"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumeenia"
+
+#~ msgid "Unicode"
+#~ msgstr "Unikood"
+
+#~ msgid "Armenian"
+#~ msgstr "Armeenia"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Hiina traditsiooniline"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kirillitsa/Vene"
+
+#~ msgid "Japanese"
+#~ msgstr "Jaapani"
+
+#~ msgid "Korean"
+#~ msgstr "Korea"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Hiina lihtsustatud"
+
+#~ msgid "Georgian"
+#~ msgstr "Gruusia"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kirillitsa/Ukraina"
+
+#~ msgid "Croatian"
+#~ msgstr "Horvaadi"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Pärsia"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmuki"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandi"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnami"
+
+#~ msgid "Thai"
+#~ msgstr "Tai"
+
+#~ msgid "Encodings"
+#~ msgstr "Kodeeringud"
+
+#~ msgid "Default"
+#~ msgstr "Vaikimisi"
+
+#~ msgid "User defined"
+#~ msgstr "Kasutaja määratav"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Muud kodeeringud"

--- a/po/eu.po
+++ b/po/eu.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Basque (https://www.transifex.com/terminator/teams/109338/eu/)\n"
+"Language-Team: Basque (https://www.transifex.com/terminator/teams/109338/"
+"eu/)\n"
+"Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: eu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Hainbat terminal leiho bakarrean"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Ez erakutsi mezu hau hurrengo aldian"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Uneko lokala"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Mendebaldekoa"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europako erdialdekoa"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Europako hegoaldekoa"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltikoa"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Zirilikoa"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabiera"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Greziera"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebreera bisuala"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebreera"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turkiera"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordikoa"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Zeltiarra"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Errumaniera"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armeniera"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Txinera tradizionala"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Zirilikoa/Errusiera"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japoniera"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreera"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Txinera sinplifikatua"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgiera"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Zirilikoa/Ukrainera"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroaziera"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindia"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persiera"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujaratera"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandiera"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamera"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thailandiera"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "fitxa"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Itxi fitxa"
 
@@ -519,7 +376,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Hobespenak"
 
@@ -544,12 +401,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Komandoa"
 
@@ -655,7 +512,7 @@ msgid "Escape sequence"
 msgstr "Ihes-sekuentzia"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Guztiak"
 
@@ -872,43 +729,43 @@ msgid "Use custom URL handler"
 msgstr "Erabili URL maneiatzaile pertsonalizatua"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
+msgid "<b>Appearance</b>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Leihoaren ertzak"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -916,441 +773,457 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
+msgid "Tabs scroll buttons"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Globala"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profila"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Erabili sistemaren zabalera finkoko letra-tipoa"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Letra-tipoa:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Aukeratu terminalaren letra-tipoa"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Onartu testu lodia"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Erakutsi izenburu-barra"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Kopiatu hautatzean"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "_Hitz gisa hautatzeko karaktereak:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Kurtsorea</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal kanpaia</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Izenburu-barraren ikonoa"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Distira bisuala"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Txistu entzungarria"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Leiho zerrenda distira"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Orokorra"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Exekutatu komandoa saioa hasteko shell gisa"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "E_xekutatu komando pertsonalizatua shell-aren ordez"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Ko_mando pertsonalizatua:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Ko_mandoak amaitzen duenean:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Aurreko eta atzeko planoa</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "Erabili _sistemaren gaiaren koloreak"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "_Eskema inkorporatuak:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Eskema _inkorporatuak:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Kolore-_paleta:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Koloreak"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Kolore solidoa"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Atzeko plano _gardena"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Bat ere ez</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximoa</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Atzeko planoa"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Korritze-barraren posizioa:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Korritu _irteeran"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Korritu _tekla sakatutakoan"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Atzera korritze infinitua"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "_Atzera korritu:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "lerro"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Korritzea"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Oharra:</b> aukera hauek aplikazio batzuen funtzionamendua "
 "oztopa dezakete. Terminaletan beste portaera bat espero duten zenbait "
-"aplikazio eta sistema eragilerekin lan egin ahal izateko bakarrik eskaintzen"
-" dira.</i></small>"
+"aplikazio eta sistema eragilerekin lan egin ahal izateko bakarrik eskaintzen "
+"dira.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "'_Atzera-tekla' sakatutakoan:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "'_Ezabatu' tekla sakatutakoan:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Berrezarri bateragarritasun-aukerak lehenetsietara"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Bateragarritasuna"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profilak"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Diseinuak"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Laster-teklak"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Plugin honek ez dauka konfigurazioko aukerarik"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Pluginak"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1585,11 +1458,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Profil berria"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Diseinu berria"
 
@@ -1602,185 +1475,169 @@ msgstr "Bilatu:"
 msgid "Close Search bar"
 msgstr "Itxi bilaketa barra"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Bidali e-posta honi..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopiatu e-posta helbidea"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_Deitu VoIP helbidera"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopiatu VoIP helbidea"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Ireki esteka"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopiatu helbidea"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Zatitu _horizontalki"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Zatitu _bertikalki"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Ireki _fitxa"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Ireki _arazketa fitxa"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Egin zoom terminalean"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Leheneratu terminal guztiak"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Taldekatzea"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Erakutsi _korritze-barra"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kodeketak"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Lehenetsia"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Erabiltzaileak definitua"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Beste kodeketak"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Ezabatu taldea %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "_Taldekatu guztiak fitxa batean"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Kendu talde guztiak"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Itxi taldea %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Ezin izan da shell-ik topatu"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Ezin izan da shell-ik abiarazi:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Berrizendatu leihoa"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Sartu Terminator leihoaren izenburu berria..."
 
@@ -1888,12 +1745,117 @@ msgstr ""
 msgid "window"
 msgstr "leihoa"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Fitxa %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Uneko lokala"
+
+#~ msgid "Western"
+#~ msgstr "Mendebaldekoa"
+
+#~ msgid "Central European"
+#~ msgstr "Europako erdialdekoa"
+
+#~ msgid "South European"
+#~ msgstr "Europako hegoaldekoa"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltikoa"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Zirilikoa"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabiera"
+
+#~ msgid "Greek"
+#~ msgstr "Greziera"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebreera bisuala"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebreera"
+
+#~ msgid "Turkish"
+#~ msgstr "Turkiera"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordikoa"
+
+#~ msgid "Celtic"
+#~ msgstr "Zeltiarra"
+
+#~ msgid "Romanian"
+#~ msgstr "Errumaniera"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armeniera"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Txinera tradizionala"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Zirilikoa/Errusiera"
+
+#~ msgid "Japanese"
+#~ msgstr "Japoniera"
+
+#~ msgid "Korean"
+#~ msgstr "Koreera"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Txinera sinplifikatua"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgiera"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Zirilikoa/Ukrainera"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroaziera"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindia"
+
+#~ msgid "Persian"
+#~ msgstr "Persiera"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujaratera"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandiera"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamera"
+
+#~ msgid "Thai"
+#~ msgstr "Thailandiera"
+
+#~ msgid "Encodings"
+#~ msgstr "Kodeketak"
+
+#~ msgid "Default"
+#~ msgstr "Lehenetsia"
+
+#~ msgid "User defined"
+#~ msgstr "Erabiltzaileak definitua"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Beste kodeketak"

--- a/po/fa.po
+++ b/po/fa.po
@@ -2,24 +2,25 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Sahand Aslani <sahand.1380aslani@gmail.com>, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Sahand Aslani <sahand.1380aslani@gmail.com>, 2021\n"
-"Language-Team: Persian (https://www.transifex.com/terminator/teams/109338/fa/)\n"
+"Language-Team: Persian (https://www.transifex.com/terminator/teams/109338/"
+"fa/)\n"
+"Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fa\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. Command             uuid req.    Description
@@ -124,7 +125,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "ترمیناتور"
 
@@ -133,7 +134,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "ربات اینده ای پایانه است"
 
@@ -141,8 +142,8 @@ msgstr "ربات اینده ای پایانه است"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -226,156 +227,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "دفعه ای بعدی این پیام را نمایش نده"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "شرایط محلی فعلی"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "غربی"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "اروپای مرکزی"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "اروپای جنوبی"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "بالتیک"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "سریلی"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "عربی"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "یونانی"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "عبری دیداری"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "یهودی"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "ترکی"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "اسکاندیناویایی"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "سلتی"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "رومانیایی"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "یونی‌کد"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "ارمنی"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "چینی سنتی"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "سیریلی/روسی"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "ژاپنی"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "کره‌ای"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "چینی ساده‌شده"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "گرجی"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "سیریلی/اوکراینی"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "کرواتی"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "هندی"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "پارسی"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "گجراتی"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "گورموخی"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "ایسلندی"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "ویتنامی"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "تایلندی"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -383,11 +240,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "جهش"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "بستن زبانه"
 
@@ -517,7 +374,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_ترجیحات"
 
@@ -542,12 +399,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -653,7 +510,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "همگی"
 
@@ -870,43 +727,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -914,437 +771,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1579,11 +1452,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "تنظیمات جدید"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "طرح بندی جدید"
 
@@ -1596,185 +1469,169 @@ msgstr "جستجو:"
 msgid "Close Search bar"
 msgstr "بسن نوار جستجو"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_فرستادن ایمیل به ..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "ـ کپی ادرس ایمیل"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "ادرس زنـــگ VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_ کپی ادرس VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "ـ بازرکردن لینک"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "ـ کپی کردن ادرس"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "تقسیم به صورت افـــــقی"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "تقسیم به صورت عمودــــــي"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "بازکردن ـ زبانه"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "بازکردن - زبانه ای رفع اشکال"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "ـ بزرگــنمایه پایانه"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "بـــه حداکثــر رساندن پایانه"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_ بازگرداندن همه ای پایانه ها"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "نمایش-نوارسکرول"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "کدگذاری‌ها"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "پیش‌فرض"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "تعریف‌شده توسط کاربر"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "ج-دید گروه....."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "حذف گروه %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "گ-روه همه در زبانه"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "اخراج از گروه همه در زبانه"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "حذف تمامی گروه‌ها"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "بستن گروه %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "پخش-همه"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "پخش-گروه"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "پخش-خاموش"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "ـتقسیم این گروه"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "خودکار-گروها تمیزکن"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "ـ درج عدد به پایانه"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "درج-عدد خالی در پایانه"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "پیدا کردن پوسته شکست خورد"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "اجرای پوسته شکست خورد"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "تغییرنام پنجره"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "یک نام جدید برای پنجره پایانه ( Terminator) وارد کنید"
 
@@ -1882,12 +1739,114 @@ msgstr "اومگا"
 msgid "window"
 msgstr "پنجره"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "زبانه %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "شرایط محلی فعلی"
+
+#~ msgid "Western"
+#~ msgstr "غربی"
+
+#~ msgid "Central European"
+#~ msgstr "اروپای مرکزی"
+
+#~ msgid "South European"
+#~ msgstr "اروپای جنوبی"
+
+#~ msgid "Baltic"
+#~ msgstr "بالتیک"
+
+#~ msgid "Cyrillic"
+#~ msgstr "سریلی"
+
+#~ msgid "Arabic"
+#~ msgstr "عربی"
+
+#~ msgid "Greek"
+#~ msgstr "یونانی"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "عبری دیداری"
+
+#~ msgid "Hebrew"
+#~ msgstr "یهودی"
+
+#~ msgid "Turkish"
+#~ msgstr "ترکی"
+
+#~ msgid "Nordic"
+#~ msgstr "اسکاندیناویایی"
+
+#~ msgid "Celtic"
+#~ msgstr "سلتی"
+
+#~ msgid "Romanian"
+#~ msgstr "رومانیایی"
+
+#~ msgid "Unicode"
+#~ msgstr "یونی‌کد"
+
+#~ msgid "Armenian"
+#~ msgstr "ارمنی"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "چینی سنتی"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "سیریلی/روسی"
+
+#~ msgid "Japanese"
+#~ msgstr "ژاپنی"
+
+#~ msgid "Korean"
+#~ msgstr "کره‌ای"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "چینی ساده‌شده"
+
+#~ msgid "Georgian"
+#~ msgstr "گرجی"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "سیریلی/اوکراینی"
+
+#~ msgid "Croatian"
+#~ msgstr "کرواتی"
+
+#~ msgid "Hindi"
+#~ msgstr "هندی"
+
+#~ msgid "Persian"
+#~ msgstr "پارسی"
+
+#~ msgid "Gujarati"
+#~ msgstr "گجراتی"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "گورموخی"
+
+#~ msgid "Icelandic"
+#~ msgstr "ایسلندی"
+
+#~ msgid "Vietnamese"
+#~ msgstr "ویتنامی"
+
+#~ msgid "Thai"
+#~ msgstr "تایلندی"
+
+#~ msgid "Encodings"
+#~ msgstr "کدگذاری‌ها"
+
+#~ msgid "Default"
+#~ msgstr "پیش‌فرض"
+
+#~ msgid "User defined"
+#~ msgstr "تعریف‌شده توسط کاربر"

--- a/po/fi.po
+++ b/po/fi.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Finnish (https://www.transifex.com/terminator/teams/109338/fi/)\n"
+"Language-Team: Finnish (https://www.transifex.com/terminator/teams/109338/"
+"fi/)\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Useita päätteitä yhdessä ikkunassa"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Nykyiset maa-asetukset"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "länsimainen"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "keskieurooppalainen"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "eteläeurooppalainen"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "balttilainen"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "kyrillinen"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "arabialainen"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "kreikkalainen"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "heprea, visuaalinen"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "heprealainen"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "turkkilainen"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "pohjoismainen"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "kelttiläinen"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "romanialainen"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "armenialainen"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "perinteinen kiina"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "kyrillinen/venäläinen"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "japanilainen"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "korealainen"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "yksinkertaistettu kiina"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "georgialainen"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "kyrillinen/ukrainalainen"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "kroatialainen"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "persialainen"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "islantilainen"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "vietnamilainen"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "thaimaalainen"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "sarkain"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Sulje välilehti"
 
@@ -519,7 +376,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Asetukset"
 
@@ -544,12 +401,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -655,7 +512,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Kaikki"
 
@@ -872,43 +729,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -916,437 +773,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiilit"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1581,11 +1454,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Uusi profiili"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Uusi pohja"
 
@@ -1598,185 +1471,169 @@ msgstr "Etsi:"
 msgid "Close Search bar"
 msgstr "Sulje hakupalkki"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "Lähetä _sähköpostilla..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopioi sähköpostiosoite"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "So_ita VoIP osoitteeseen"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopioi VoIP osoite"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Avaa linkki"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopioi osoite"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Jaa _Vaakasuunnassa"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Jaa _Pystysuunnassa"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Avaa _välilehti"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Avaa _Vianjäljitysvälilehti"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Kasvata pääte-näkymää"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Palauta kaikki päätteet"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Ryhmittely"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Näytä _vierityspalkki"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Merkistöt"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Oletus"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Käyttäjän määrittelemä"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Muut merkistöt"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Poista ryhmä %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "R_yhmitä kaikki välilehdessä"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Poista kaikki ryhmät"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Sulje ryhmä %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Komentotulkkia ei löydy"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Komentotulkkia ei voitu käynnistää:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1884,12 +1741,117 @@ msgstr ""
 msgid "window"
 msgstr "ikkuna"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Välilehti %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Nykyiset maa-asetukset"
+
+#~ msgid "Western"
+#~ msgstr "länsimainen"
+
+#~ msgid "Central European"
+#~ msgstr "keskieurooppalainen"
+
+#~ msgid "South European"
+#~ msgstr "eteläeurooppalainen"
+
+#~ msgid "Baltic"
+#~ msgstr "balttilainen"
+
+#~ msgid "Cyrillic"
+#~ msgstr "kyrillinen"
+
+#~ msgid "Arabic"
+#~ msgstr "arabialainen"
+
+#~ msgid "Greek"
+#~ msgstr "kreikkalainen"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "heprea, visuaalinen"
+
+#~ msgid "Hebrew"
+#~ msgstr "heprealainen"
+
+#~ msgid "Turkish"
+#~ msgstr "turkkilainen"
+
+#~ msgid "Nordic"
+#~ msgstr "pohjoismainen"
+
+#~ msgid "Celtic"
+#~ msgstr "kelttiläinen"
+
+#~ msgid "Romanian"
+#~ msgstr "romanialainen"
+
+#~ msgid "Unicode"
+#~ msgstr "unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "armenialainen"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "perinteinen kiina"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "kyrillinen/venäläinen"
+
+#~ msgid "Japanese"
+#~ msgstr "japanilainen"
+
+#~ msgid "Korean"
+#~ msgstr "korealainen"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "yksinkertaistettu kiina"
+
+#~ msgid "Georgian"
+#~ msgstr "georgialainen"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "kyrillinen/ukrainalainen"
+
+#~ msgid "Croatian"
+#~ msgstr "kroatialainen"
+
+#~ msgid "Hindi"
+#~ msgstr "hindi"
+
+#~ msgid "Persian"
+#~ msgstr "persialainen"
+
+#~ msgid "Gujarati"
+#~ msgstr "gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "islantilainen"
+
+#~ msgid "Vietnamese"
+#~ msgstr "vietnamilainen"
+
+#~ msgid "Thai"
+#~ msgstr "thaimaalainen"
+
+#~ msgid "Encodings"
+#~ msgstr "Merkistöt"
+
+#~ msgid "Default"
+#~ msgstr "Oletus"
+
+#~ msgid "User defined"
+#~ msgstr "Käyttäjän määrittelemä"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Muut merkistöt"

--- a/po/fo.po
+++ b/po/fo.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Faroese (https://www.transifex.com/terminator/teams/109338/fo/)\n"
+"Language-Team: Faroese (https://www.transifex.com/terminator/teams/109338/"
+"fo/)\n"
+"Language: fo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fo\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Núverandi máløki"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Vesturlendskt"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Miðeuropeiskt"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Suðureuropeiskt"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kyrilliskt"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabiskt"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grikskt"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Sjónligt hebraiskt"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebraiskt"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turkiskt"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltiskt"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumenskt"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenskt"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Gamalt kinesiskt"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kyrilliskt/Russiskt"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japanskt"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreanskt"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Einfalt kinesiskt"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgiskt"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kyrilliskt/Ukrainskt"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroatiskt"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindiskt"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persiskt"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujaratiskt"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhiskt"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Íslendskt"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vjetnamesiskt"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tailendskt"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Lat teigin aftur"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Stillingar"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Alt"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nýggj uppsetan"
 
@@ -1594,185 +1467,169 @@ msgstr "Leita:"
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Send teldupost til..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Avrita teldupostadressu"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Vís _skrulliteig"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Strika bólkin %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Lat bólkin %s aftur"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,99 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Teigur %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Núverandi máløki"
+
+#~ msgid "Western"
+#~ msgstr "Vesturlendskt"
+
+#~ msgid "Central European"
+#~ msgstr "Miðeuropeiskt"
+
+#~ msgid "South European"
+#~ msgstr "Suðureuropeiskt"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kyrilliskt"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabiskt"
+
+#~ msgid "Greek"
+#~ msgstr "Grikskt"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Sjónligt hebraiskt"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebraiskt"
+
+#~ msgid "Turkish"
+#~ msgstr "Turkiskt"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltiskt"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumenskt"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenskt"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Gamalt kinesiskt"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kyrilliskt/Russiskt"
+
+#~ msgid "Japanese"
+#~ msgstr "Japanskt"
+
+#~ msgid "Korean"
+#~ msgstr "Koreanskt"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Einfalt kinesiskt"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgiskt"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kyrilliskt/Ukrainskt"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroatiskt"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindiskt"
+
+#~ msgid "Persian"
+#~ msgstr "Persiskt"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujaratiskt"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhiskt"
+
+#~ msgid "Icelandic"
+#~ msgstr "Íslendskt"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vjetnamesiskt"
+
+#~ msgid "Thai"
+#~ msgstr "Tailendskt"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,24 +2,25 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Samuël Weber/GwendalD <samuel.weber@normalesup.org>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Samuël Weber/GwendalD <samuel.weber@normalesup.org>, 2020\n"
-"Language-Team: French (https://www.transifex.com/terminator/teams/109338/fr/)\n"
+"Language-Team: French (https://www.transifex.com/terminator/teams/109338/"
+"fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. Command             uuid req.    Description
@@ -131,7 +132,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -140,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Permet d'avoir plusieurs terminaux en une seule fenêtre"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Le futur robot des terminaux."
 
@@ -148,8 +149,8 @@ msgstr "Le futur robot des terminaux."
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 "Un outil pour utilisateur et utilisatrice expérimenté⋅e d'organisation des "
 "terminaux. Il s'inspire des programmes tels que gnome-multi-term, "
@@ -249,156 +250,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Ne pas afficher ce message la prochaine fois"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Locale actuelle"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Occidentale"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europe centrale"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Europe du Sud"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Balte"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrillique"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabe"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grec"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hébreu visuel"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hébreu"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turc"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordique"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celte"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Roumain"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Arménien"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chinois traditionnel"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyrillique/russe"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonais"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coréen"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chinois simplifié"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Géorgien"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cyrillique/ukrainien"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croate"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persan"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandais"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamien"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thaï"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Lanceur de dispositions de Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Disposition"
 
@@ -406,11 +263,11 @@ msgstr "Disposition"
 msgid "Launch"
 msgstr "Lancer"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "onglet"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Fermer l'onglet"
 
@@ -545,7 +402,7 @@ msgstr "_Commandes personnalisées"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Préférences"
 
@@ -570,12 +427,12 @@ msgid "Enabled"
 msgstr "Activées"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Nom"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Commande"
 
@@ -681,7 +538,7 @@ msgid "Escape sequence"
 msgstr "Séquence d'échappement"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Tous"
 
@@ -898,491 +755,518 @@ msgid "Use custom URL handler"
 msgstr "Utiliser un gestionnaire d'URL personnalisée"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Gestionnaire d'URL personnalisée :"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr "PRIMAIRE"
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr "Presse-papier"
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Gestionnaire d'URL personnalisée :"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Apparence</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Bordures de fenêtre"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Luminosité de la police de caractère des terminaux non sélectionnés :"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Taille du séparateur de terminal :"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr "Hauteur de ligne :"
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Personnalisation extra (Suivant le thème)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Position de l'onglet :"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Onglets homogènes"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Ascenseur des onglets"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr "Barre de titre en bas (nécessite un redémarrage)"
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Utiliser la police à chasse fixe du système"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Police de caractères :"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Choisir la police de caractères du terminal"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Activer le texte en gras"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Afficher la barre de titre"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Copier la sélection"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Désactiver le zoom Ctrl+roulette"
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Sélectionner par caractères des _mots"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Curseur</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Forme :"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Clignotement"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Arrière-plan :"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Bip du terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Icône de la barre de titre"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Flash visuel"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Bip sonore"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Liste de fenêtres instantanée"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Général"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Lancer la commande en tant que shell de connexion"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Exécuter une comma_nde personnalisée au lieu de mon shell"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Co_mmande personnalisée :"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Quand la commande se _termine :"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Premier et arrière plans</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Utiliser les couleurs du thème système"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "_Palettes prédéfinies :"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Palette</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Pa_lettes prédéfinies :"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "P_alette de couleurs :"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr "Afficher les textes en gras en couleurs vives"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Couleurs"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "Couleur _unie"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Arrière-plan _transparent"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr "Choisir un fichier"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Aucun</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Arrière-plan"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "La _barre de défilement est :"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Défilement sur la _sortie"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Défilement sur _pression d'une touche"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Défilement infini"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Défilement récursif :"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "lignes"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Défilement"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Note :</b> ces options peuvent gêner le fonctionnement de "
-"certaines applications. Elles sont seulement là pour vous permettre de faire"
-" fonctionner certaines applications et systèmes d'exploitation qui attendent"
-" un comportement du terminal différent.</i></small>"
+"certaines applications. Elles sont seulement là pour vous permettre de faire "
+"fonctionner certaines applications et systèmes d'exploitation qui attendent "
+"un comportement du terminal différent.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "La touche « _Retour arrière » émet :"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "La touche « _Suppr » émet :"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Codage des caractères :"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Réinitialiser les options de compatibilité aux valeurs par défaut"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Compatibilité"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Actif"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Inactif"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Réception"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Masquer la taille du titre"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Utiliser la police de caractères système"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Choisissez une police de caractères pour la barre de titre"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profils"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Type"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil :"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Commande personnalisée :"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Dossier de travail :"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Dispositions"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Action"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Raccourci clavier"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Raccourcis clavier"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Greffon"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Ce greffon n'a pas d'options de configuration"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Greffons"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Le but de ce projet est de créer un outil puissant pour gèrer les terminaux. Il est inspiré de programmes tels que gnome-multi-term, quadkonsole, etc. car il se concentre aussi sur le fait de présenter les terminaux en grille (les onglets sont la méthode par défaut la plus répandue, ce qui est également supporté par terminator).\n"
+"Le but de ce projet est de créer un outil puissant pour gèrer les terminaux. "
+"Il est inspiré de programmes tels que gnome-multi-term, quadkonsole, etc. "
+"car il se concentre aussi sur le fait de présenter les terminaux en grille "
+"(les onglets sont la méthode par défaut la plus répandue, ce qui est "
+"également supporté par terminator).\n"
 "\n"
-"Une grande partie du comportement de Terminator est basée sur le terminal GNOME, nous ajoutons de nouvelles fonctionnalités au fil du temps, mais nous désirons également nous étendre dans différentes directions avec des capacités utiles aux administrateurs système et aux autres utilisateurs. Si vous avez des suggestions, merci de remplir un bug de souhait! (regardez a gauche pour le lien de développement)"
+"Une grande partie du comportement de Terminator est basée sur le terminal "
+"GNOME, nous ajoutons de nouvelles fonctionnalités au fil du temps, mais nous "
+"désirons également nous étendre dans différentes directions avec des "
+"capacités utiles aux administrateurs système et aux autres utilisateurs. Si "
+"vous avez des suggestions, merci de remplir un bug de souhait! (regardez a "
+"gauche pour le lien de développement)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "Le manuel"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Développement</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Améliorations</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator\">Développement</"
+"a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Améliorations</a>"
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "À propos"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Augmenter la taille de la police de caractères"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Réduire la taille de la police de caractères"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Restaurer la taille d'origine de la police de caractères"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Créer un nouvel onglet"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Mettre en évidence le prochain terminal"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Mettre en évidence le terminal précédent"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Mettre en évidence le terminal du dessus"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Mettre en évidence le terminal du dessous"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Mettre en évidence le terminal de gauche"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Mettre en évidence le terminal de droite"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Faire pivoter les terminaux dans le sens horaire"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Faire pivoter les terminaux dans le sens antihoraire"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Scinder horizontalement"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Scinder verticalement"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Fermer le terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Copier le texte sélectionné"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Coller le contenu du presse-papier"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1616,11 +1500,11 @@ msgstr "Ouvrir les préférences"
 msgid "Open the manual"
 msgstr "Ouvrir le manuel"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nouveau profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nouvel agencement"
 
@@ -1633,185 +1517,169 @@ msgstr "Rechercher :"
 msgid "Close Search bar"
 msgstr "Fermer la barre de recherche"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "Envoyer un couuriel à..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copier l'adresse électronique"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Appe_ller l'adresse VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copier l'adresse VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Ouvrir le lien"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copier l'adresse"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "Co_pier"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "C_oller"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Diviser h_orizontalement"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Diviser v_erticalement"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Ouvrir un ongle_t"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Ouvrir un onglet de _débogage"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Quitter"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zoomer le terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximiser le terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restaurer tous les terminaux"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Regroupement"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Afficher la barre de défilement"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr "_Organisations..."
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Codages"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Valeur par défaut"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Défini par l'utilisateur"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Autres  codages"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "Nouv_eau groupe..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "Aucu_n"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Supprimer le groupe %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Tout reg_rouper dans l'onglet"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Tout dégro_uper dans un onglet"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Supprimer tout les groupes"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Fermer le groupe %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Diffuser _tout"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Diffuser au _groupe"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Diffusion désactivée"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "_Scinder vers ce groupe"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Netto_yer automatiquement les groupes"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_Insérer le numéro du terminal"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Insérer le _numéro du terminal"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Impossible de trouver un shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Impossible de démarrer le shell :"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Renommer la fenêtre"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Saisir un nouveau titre pour la fenêtre Terminator..."
 
@@ -1919,12 +1787,123 @@ msgstr "Oméga"
 msgid "window"
 msgstr "fenêtre"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Onglet %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Locale actuelle"
+
+#~ msgid "Western"
+#~ msgstr "Occidentale"
+
+#~ msgid "Central European"
+#~ msgstr "Europe centrale"
+
+#~ msgid "South European"
+#~ msgstr "Europe du Sud"
+
+#~ msgid "Baltic"
+#~ msgstr "Balte"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrillique"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabe"
+
+#~ msgid "Greek"
+#~ msgstr "Grec"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hébreu visuel"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hébreu"
+
+#~ msgid "Turkish"
+#~ msgstr "Turc"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordique"
+
+#~ msgid "Celtic"
+#~ msgstr "Celte"
+
+#~ msgid "Romanian"
+#~ msgstr "Roumain"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Arménien"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chinois traditionnel"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyrillique/russe"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonais"
+
+#~ msgid "Korean"
+#~ msgstr "Coréen"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chinois simplifié"
+
+#~ msgid "Georgian"
+#~ msgstr "Géorgien"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cyrillique/ukrainien"
+
+#~ msgid "Croatian"
+#~ msgstr "Croate"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persan"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandais"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamien"
+
+#~ msgid "Thai"
+#~ msgstr "Thaï"
+
+#~ msgid "Line Height:"
+#~ msgstr "Hauteur de ligne :"
+
+#~ msgid "Encoding:"
+#~ msgstr "Codage des caractères :"
+
+#~ msgid "Encodings"
+#~ msgstr "Codages"
+
+#~ msgid "Default"
+#~ msgstr "Valeur par défaut"
+
+#~ msgid "User defined"
+#~ msgstr "Défini par l'utilisateur"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Autres  codages"

--- a/po/fy.po
+++ b/po/fy.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Western Frisian (https://www.transifex.com/terminator/teams/109338/fy/)\n"
+"Language-Team: Western Frisian (https://www.transifex.com/terminator/"
+"teams/109338/fy/)\n"
+"Language: fy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fy\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "H_orizontaal splitse"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "V_ertikaal splitse"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,12 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/ga.po
+++ b/po/ga.po
@@ -2,24 +2,26 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Irish (https://www.transifex.com/terminator/teams/109338/ga/)\n"
+"Language-Team: Irish (https://www.transifex.com/terminator/teams/109338/"
+"ga/)\n"
+"Language: ga\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ga\n"
-"Plural-Forms: nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4);\n"
+"Plural-Forms: nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : "
+"4);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -123,7 +125,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -132,7 +134,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +142,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +226,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +239,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +373,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +398,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +509,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +726,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +770,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1451,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1468,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1738,12 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Galician (https://www.transifex.com/terminator/teams/109338/gl/)\n"
+"Language-Team: Galician (https://www.transifex.com/terminator/teams/109338/"
+"gl/)\n"
+"Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: gl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminador"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Múltiples terminales nunha ventá"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Non mostrar esta mensaxe a próxima vez."
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Localización actual"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Occidental"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Central Europeo"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Sur de Europa"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Báltico"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirílico"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Árabe"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grego"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebreo visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebreo"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turco"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nórdico"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celta"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romanés"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenio"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chino Tradicional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cirílico/Ruso"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Xaponés"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coreano"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chino Simplificado"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Xeorxiano"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirílico/Ucraíno"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croata"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persa"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandés"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamita"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "lapela"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Pechar lapela"
 
@@ -443,8 +300,7 @@ msgstr "Definir o directorio de traballo"
 
 #: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
-msgstr ""
-"Estableza un icono personalizado para o diálogo (por ficheiro ou nome)"
+msgstr "Estableza un icono personalizado para o diálogo (por ficheiro ou nome)"
 
 #: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
@@ -518,7 +374,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferencias"
 
@@ -543,12 +399,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -654,7 +510,7 @@ msgid "Escape sequence"
 msgstr "Secuencia de escape"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Todo"
 
@@ -871,43 +727,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
+msgid "<b>Appearance</b>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Bordos da xanela"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -915,437 +771,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Perfís"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1580,11 +1452,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Novo perfil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nova capa"
 
@@ -1597,185 +1469,169 @@ msgstr "Procurar:"
 msgid "Close Search bar"
 msgstr "Pechar barra de procura"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Enviar correo a..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copiar enderezo do correo"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Di_rección de chamado VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copiar enderezo VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Abrir ligazón"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copiar enderezo"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Dividir H_orizontalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Dividir V_erticalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Abrir _lapela"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Abrir lapela de _depuración"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Dar zoom o terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restaurar todos os terminais"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Agrupamento"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Amosar _barra de desprazamento"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Codificacións"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Predefinido"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definida polo usuario"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Outras codificacións"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Grupo %s borrado"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "A_grupar nunha lapela"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Borrar todos os grupos"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Pechar grupo %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Incapaz de atopar unha consola"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Incapaz de arrincar a consola:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1883,12 +1739,117 @@ msgstr ""
 msgid "window"
 msgstr "xanela"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Lapela %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Localización actual"
+
+#~ msgid "Western"
+#~ msgstr "Occidental"
+
+#~ msgid "Central European"
+#~ msgstr "Central Europeo"
+
+#~ msgid "South European"
+#~ msgstr "Sur de Europa"
+
+#~ msgid "Baltic"
+#~ msgstr "Báltico"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirílico"
+
+#~ msgid "Arabic"
+#~ msgstr "Árabe"
+
+#~ msgid "Greek"
+#~ msgstr "Grego"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebreo visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebreo"
+
+#~ msgid "Turkish"
+#~ msgstr "Turco"
+
+#~ msgid "Nordic"
+#~ msgstr "Nórdico"
+
+#~ msgid "Celtic"
+#~ msgstr "Celta"
+
+#~ msgid "Romanian"
+#~ msgstr "Romanés"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenio"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chino Tradicional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cirílico/Ruso"
+
+#~ msgid "Japanese"
+#~ msgstr "Xaponés"
+
+#~ msgid "Korean"
+#~ msgstr "Coreano"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chino Simplificado"
+
+#~ msgid "Georgian"
+#~ msgstr "Xeorxiano"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirílico/Ucraíno"
+
+#~ msgid "Croatian"
+#~ msgstr "Croata"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persa"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandés"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamita"
+
+#~ msgid "Thai"
+#~ msgstr "Thai"
+
+#~ msgid "Encodings"
+#~ msgstr "Codificacións"
+
+#~ msgid "Default"
+#~ msgstr "Predefinido"
+
+#~ msgid "User defined"
+#~ msgstr "Definida polo usuario"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Outras codificacións"

--- a/po/he.po
+++ b/po/he.po
@@ -2,25 +2,27 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Yaron Shahrabani <sh.yaron@gmail.com>, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>, 2021\n"
-"Language-Team: Hebrew (https://www.transifex.com/terminator/teams/109338/he/)\n"
+"Language-Team: Hebrew (https://www.transifex.com/terminator/teams/109338/"
+"he/)\n"
+"Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: he\n"
-"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % 1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
+"1 == 0) ? 1: (n % 10 == 0 && n % 1 == 0 && n > 10) ? 2 : 3;\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -130,7 +132,7 @@ msgstr "שם לשונית להגדרה."
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -139,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "מסופים מרובים בחלון אחד"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "העתיד הרובוטי של המסופים"
 
@@ -147,12 +149,12 @@ msgstr "העתיד הרובוטי של המסופים"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
-"כלי למשתמשים מתקדמים לארגון מסופים. שאב השראה מתכניות כגון gnome-multi-"
-"term,‏ quadkonsole וכו׳ בכך שעיקר המיקוד הוא בסידור מסופים ברשת (לשוניות היא"
-" צורת בררת המחדל הנפוצה ביותר שגם היא נתמכת ב־Terminator)."
+"כלי למשתמשים מתקדמים לארגון מסופים. שאב השראה מתכניות כגון gnome-multi-term,‏ "
+"quadkonsole וכו׳ בכך שעיקר המיקוד הוא בסידור מסופים ברשת (לשוניות היא צורת "
+"בררת המחדל הנפוצה ביותר שגם היא נתמכת ב־Terminator)."
 
 #: ../data/terminator.appdata.xml.in.h:5
 msgid ""
@@ -238,156 +240,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "לא להציג הודעה זאת בפעם הבאה"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "הגדרות מיקום נוכחיות"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "מערבית"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "מרכז אירופאי"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "דרום אירופאי"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "בלטי"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "קירילי"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "ערבית"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "יוונית"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "עברית ויזואלית"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "עברית"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "טורקית"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "נורדית"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "קלטית"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "רומנית"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "יוניקוד"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "ארמנית"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "סינית מסורתית"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "קירילית/רוסית"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "יפנית"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "קוראנית"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "סינית מפושטת"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "גאורגית"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "קירילית/אוקראינית"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "קרואטית"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "הינדית"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "פרסית"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "גוג׳ראטית"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "גורמוקהי"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "איסלנדית"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "וייטנאמית"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "תאית"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "משגר פריסת Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "פריסה"
 
@@ -395,11 +253,11 @@ msgstr "פריסה"
 msgid "Launch"
 msgstr "הפעלה"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "לשונית"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "סגירת לשוניות"
 
@@ -530,7 +388,7 @@ msgstr "_פקודות מותאמות אישית"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "ה_עדפות"
 
@@ -555,12 +413,12 @@ msgid "Enabled"
 msgstr "מופעל"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "שם"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "פקודה"
 
@@ -666,7 +524,7 @@ msgid "Escape sequence"
 msgstr "רצף סליקה"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "הכול"
 
@@ -883,490 +741,512 @@ msgid "Use custom URL handler"
 msgstr "להשתמש במטפל כתובות מותאם אישית"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "מטפל כתובות מותאם אישית:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr "עיקרי"
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr "לוח גזירים"
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr "פינוי הבחירה עם ההעתקה"
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr "פותח קישורים בלחיצה בודדת (במקום עם Ctrl-לחיצה שמאלית)"
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "מטפל כתובות מותאם אישית:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>מראה</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "גבולות החלון"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "בהירות גופן במסוף שאינו במיקוד:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "גודל מפריד מסופים:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr "גובה שורה:"
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "עיצוב נוסף (תלוי ערכת עיצוב)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "מיקום לשוניות:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "לשוניות הומוגניות"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "כפתורי גלילת לשוניות"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr "פס כותרת בתחתית (דורש הפעלה מחדש)"
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "גלובלי"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "פרופיל"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "להשתמש בגופן ברוחב ה_אחיד של המערכת"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_גופן:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "נא לבחור גופן למסוף"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "ל_אפשר גופן מודגש"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "הצגת שורת כותרת"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "העתקה בעת הבחירה"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "השבתת Ctrl+גלגלת עכבר לתקריב"
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "תווים לבחירה ל_פי מילה:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>סמן</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_צורה:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "הבהוב"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr "להשתמש בצבעי בררת המחדל"
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr "חזית:"
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "רקע:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>פעמון מסוף</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "סמל בשורת הכותרת"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "הבזק חזותי"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "צפצוף"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "הבזק ברשימת החלונות"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "כללי"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "ה_רצת פקודה כמעטפת כניסה"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "ה_רצת פקודה מותאמת אישית במקום המעטפת שלי"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "_פקודה מותאמת אישית:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "כאשר הפקודה מ_סתיימת:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>חזית ורקע</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "להשתמש ב_צבעים מערכת העיצוב של המערכת"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "_סכמות מובנות:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr "_חזית:"
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr "_רקע:"
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>ערכת צבעים</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "_סכמות מובנות:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "_ערכות צבעים:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr "הצגת טקסט מו_דגש בצבעים בהירים"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "צבעים"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "צבע _אחיד"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "רקע _שקוף"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr "תמונת רקע"
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr "קובץ תמונת רקע:"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr "בחירת קובץ"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr "ה_צללת רקע:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>ללא</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>הכי הרבה</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "רקע"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "פס ה_גלילה מופיע:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "גלילה עם _פלט"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "גלילה עם ה_קלדה"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "היסטוריית מסוף אינסופית"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "היס_טוריית מסוף:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "שורות"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "גלילה"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>לתשומת לבך:</b> האפשרויות האלו עלולות לגרום לחלק מהיישומים "
 "להתנהג באופן חריג.  הן כאן רק כדי לאפשר לך לעקוף כל מיני יישומים ומערות "
 "הפעלה שמצפים להתנהגות שונה ממסוף.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "מק_ש Backspace מייצר:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "מ_קש Delete מייצר:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "קידוד:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_איפוס אפשרויות התאימות לבררות המחדל"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "תאימות"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "ממוקד"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "בלתי פעיל"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "מקבל"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "הסתרת הגודל מהכותרת"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "להשתמש בגופן המ_ערכת"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "בחירת גופן לשורת הכותרת"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr "שורת כותרת"
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "פרופילים"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "סוג"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "פרופיל:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "פקודה בהתאמה אישית:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "תיקיית עבודה:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "פריסות"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "פעולה"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "צירוף מקשים"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "צירופי מקשים"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "תוסף"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "לתוסף זה אין אפשרויות להגדרה"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "תוספים"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr "גירסה: 2.1.1"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"מטרת המיזם הזה היא לייצר כלי שימושי לארגון מסופים. המיזם שאב השראה מתכניות כגון gnome-multi-term,‏ quadkonsole וכו׳ בכך שעיקר המיקוד הוא בסידור מסופים ברשת (לשוניות היא צורת בררת המחדל הנפוצה ביותר שגם היא נתמכת ב־Terminator).\n"
+"מטרת המיזם הזה היא לייצר כלי שימושי לארגון מסופים. המיזם שאב השראה מתכניות "
+"כגון gnome-multi-term,‏ quadkonsole וכו׳ בכך שעיקר המיקוד הוא בסידור מסופים "
+"ברשת (לשוניות היא צורת בררת המחדל הנפוצה ביותר שגם היא נתמכת ב־Terminator).\n"
 "\n"
-"הרבה מההתנהגות של Terminator מבוססת על המסוף של GNOME ואנו מוסיפים תכונות נוספות עם הזמן אך אנו מעוניינים להתרחב לכיוונים נוספים עם תכונות שימושיות עבור מנהלי מערכת ומשתמשים אחרים. אם יש לך הצעות, נא להגיש תקלה לרשימת המשאלות! (בקישור לפיתוח משמאל) "
+"הרבה מההתנהגות של Terminator מבוססת על המסוף של GNOME ואנו מוסיפים תכונות "
+"נוספות עם הזמן אך אנו מעוניינים להתרחב לכיוונים נוספים עם תכונות שימושיות "
+"עבור מנהלי מערכת ומשתמשים אחרים. אם יש לך הצעות, נא להגיש תקלה לרשימת "
+"המשאלות! (בקישור לפיתוח משמאל) "
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "המדריך"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">פיתוח</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">תקלות / שיפורים</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">תקלות / "
+"שיפורים</a>"
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "על אודות"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "הגדלת הגופן"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "הקטנת הגופן"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "שחזור גודל הגופן המקורי"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr "להגדיל את הגופן בכל המסופים"
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr "להקטין את הגופן בכל המסופים"
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr "לשחזר את גודל הגופן המקורי בכל המסופים"
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "יצירת לשונית חדשה"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "התמקדות במסוף הבא"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "התמקדות במסוף הקודם"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "התמקדות במסוף שמעל"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "התמקדות במסוף שמתחת"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "התמקדות במסוף שמשמאל"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "התמקדות במסוף שמימין"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "הטיית המסופים עם כיוון השעון"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "הטיית המסופים נגד כיוון השעון"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "פיצול אופקי"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "פיצול אנכי"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "סגירת המסוף"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "העתקת הטקסט הנבחר"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "הדבקת לוח גזירים"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1600,11 +1480,11 @@ msgstr "פתיחה בחלון ההעדפות"
 msgid "Open the manual"
 msgstr "פתיחת המדריך"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "פרופיל חדש"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "פריסה חדשה"
 
@@ -1617,185 +1497,169 @@ msgstr "חיפוש:"
 msgid "Close Search bar"
 msgstr "סגירת סרגל החיפוש"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "שליחת דו_א״ל אל…"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "העתקת כתובת _דוא״ל"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "הת_קשרות לכתובת VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "ה_עתקת כתובת VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_פתיחת קישור"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "ה_עתק כתובת"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "ה_עתקה"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "ה_דבקה"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr "הגדרת _כותרת חלון"
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "פיצול או_פקית"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "פיצול א_נכית"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "פתיחת _לשונית"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "פתיחת לשונית _ניפוי שגיאות"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_סגירה"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "התק_רבות למסוף"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "ה_גדלת מסוף"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_שחזור כל המסופים"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "קיבוץ"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr "פקודת הפעלה מחדש"
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "הצגת _פס גלילה"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr "_פריסות…"
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "קידודים"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "בררת מחדל"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "בהגדרת המשתמש"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "קידודים אחרים"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "קבוצה _חדשה…"
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_ללא"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "הסרת הקבוצה %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr "_קיבוץ הכול בחלון"
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr "_פירוק הכול בחלון"
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "_קיבוץ הכול בלשונית"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "_פירוק כל מי שבלשונית"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "הסרת כל הקבוצות"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "סגירת הקבוצה %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "לשדר ל_כולם"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "_קבוצת שידור"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "_כיבוי השידור"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "_פיצול הקבוצה הזו"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "ל_נקות קבוצות אוטומטית"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "הו_ספת מספר מסוף"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "הוספת מספר מסוף מרופ_ד"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "לא ניתן למצוא מעטפת"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "לא ניתן להפעיל מעטפת:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "שינוי שם חלון"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "נא להקליד כותרת חדשה לחלון ה־Terminator…"
 
@@ -1903,12 +1767,123 @@ msgstr "אומגה"
 msgid "window"
 msgstr "חלון"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr "קבות חלונות %s"
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "לשונית %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "הגדרות מיקום נוכחיות"
+
+#~ msgid "Western"
+#~ msgstr "מערבית"
+
+#~ msgid "Central European"
+#~ msgstr "מרכז אירופאי"
+
+#~ msgid "South European"
+#~ msgstr "דרום אירופאי"
+
+#~ msgid "Baltic"
+#~ msgstr "בלטי"
+
+#~ msgid "Cyrillic"
+#~ msgstr "קירילי"
+
+#~ msgid "Arabic"
+#~ msgstr "ערבית"
+
+#~ msgid "Greek"
+#~ msgstr "יוונית"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "עברית ויזואלית"
+
+#~ msgid "Hebrew"
+#~ msgstr "עברית"
+
+#~ msgid "Turkish"
+#~ msgstr "טורקית"
+
+#~ msgid "Nordic"
+#~ msgstr "נורדית"
+
+#~ msgid "Celtic"
+#~ msgstr "קלטית"
+
+#~ msgid "Romanian"
+#~ msgstr "רומנית"
+
+#~ msgid "Unicode"
+#~ msgstr "יוניקוד"
+
+#~ msgid "Armenian"
+#~ msgstr "ארמנית"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "סינית מסורתית"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "קירילית/רוסית"
+
+#~ msgid "Japanese"
+#~ msgstr "יפנית"
+
+#~ msgid "Korean"
+#~ msgstr "קוראנית"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "סינית מפושטת"
+
+#~ msgid "Georgian"
+#~ msgstr "גאורגית"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "קירילית/אוקראינית"
+
+#~ msgid "Croatian"
+#~ msgstr "קרואטית"
+
+#~ msgid "Hindi"
+#~ msgstr "הינדית"
+
+#~ msgid "Persian"
+#~ msgstr "פרסית"
+
+#~ msgid "Gujarati"
+#~ msgstr "גוג׳ראטית"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "גורמוקהי"
+
+#~ msgid "Icelandic"
+#~ msgstr "איסלנדית"
+
+#~ msgid "Vietnamese"
+#~ msgstr "וייטנאמית"
+
+#~ msgid "Thai"
+#~ msgstr "תאית"
+
+#~ msgid "Line Height:"
+#~ msgstr "גובה שורה:"
+
+#~ msgid "Encoding:"
+#~ msgstr "קידוד:"
+
+#~ msgid "Encodings"
+#~ msgstr "קידודים"
+
+#~ msgid "Default"
+#~ msgstr "בררת מחדל"
+
+#~ msgid "User defined"
+#~ msgstr "בהגדרת המשתמש"
+
+#~ msgid "Other Encodings"
+#~ msgstr "קידודים אחרים"

--- a/po/hi.po
+++ b/po/hi.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Hindi (https://www.transifex.com/terminator/teams/109338/hi/)\n"
+"Language-Team: Hindi (https://www.transifex.com/terminator/teams/109338/"
+"hi/)\n"
+"Language: hi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "टर्मिनेटर"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "एक विंडो में अनेक  टर्मिनल"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "यह संदेश अगली बार ना दिखायें"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "वर्तमान लोकेल"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "पश्चिमी"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "मध्य यूरोपीय"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "दक्षिण यूरोपीय"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,24 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "वर्तमान लोकेल"
+
+#~ msgid "Western"
+#~ msgstr "पश्चिमी"
+
+#~ msgid "Central European"
+#~ msgstr "मध्य यूरोपीय"
+
+#~ msgid "South European"
+#~ msgstr "दक्षिण यूरोपीय"

--- a/po/hr.po
+++ b/po/hr.po
@@ -2,26 +2,28 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Marko Dzidic <mdzidic@gmail.com>, 2020
 # Markus Frosch <markus@lazyfrosch.de>, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Markus Frosch <markus@lazyfrosch.de>, 2021\n"
-"Language-Team: Croatian (https://www.transifex.com/terminator/teams/109338/hr/)\n"
+"Language-Team: Croatian (https://www.transifex.com/terminator/teams/109338/"
+"hr/)\n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hr\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -130,7 +132,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -139,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Višebrojni terminali u jednom prozoru"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Robotska budućnost terminala"
 
@@ -147,11 +149,11 @@ msgstr "Robotska budućnost terminala"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
-"Profesionalni korisnički alat za raspoređivanje terminala, slično programima"
-" poput gnome-multi-term, quadkonsole, itd., a glavna ideja je pločasto "
+"Profesionalni korisnički alat za raspoređivanje terminala, slično programima "
+"poput gnome-multi-term, quadkonsole, itd., a glavna ideja je pločasto "
 "raspoređivanje terminala (kartice su najraširenija metoda, koju Terminator "
 "također podržava)."
 
@@ -243,156 +245,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Ovu poruku više nemoj prikazivati"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Trenutačni jezik"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Zapadni"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Srednjoeuropski"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Južnoeuropski"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltički"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Ćirilični"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arapski"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grčki"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Vizualni hebrejski"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebrejski"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turski"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordijski"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltski"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumunjski"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unikod"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenski"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Kineski tradicionalni"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Ćirilica/Ruski"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japanski"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korejski"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Kineski pojednostavljeni"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gruzijski"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Ćirilica/Ukrajinski"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Hrvatski"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindski"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Perzijski"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gudžaratski"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmuki"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandski"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vijetnamski"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tajlandski"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Pokretanje rasporeda Terminatora"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Raspored"
 
@@ -400,11 +258,11 @@ msgstr "Raspored"
 msgid "Launch"
 msgstr "Pokreni"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "kartica"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Zatvori karticu"
 
@@ -446,8 +304,8 @@ msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
-"Koristi ostatak naredbenog retka kao naredbu za izvršavanje unutar terminala"
-" i njezine argumente"
+"Koristi ostatak naredbenog retka kao naredbu za izvršavanje unutar terminala "
+"i njezine argumente"
 
 #: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
@@ -537,7 +395,7 @@ msgstr "Prilagođene _naredbe"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Postavke"
 
@@ -562,12 +420,12 @@ msgid "Enabled"
 msgstr "Aktivirano"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Naziv"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Naredba"
 
@@ -673,7 +531,7 @@ msgid "Escape sequence"
 msgstr "Slijed kontrolnog znaka"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Sve"
 
@@ -890,491 +748,514 @@ msgid "Use custom URL handler"
 msgstr "Koristi prilagođeno baratanje URL-ovima"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Prilagođeno baratanje URL-ovima:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr "PRIMARNO"
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr "Međuspremnik"
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Prilagođeno baratanje URL-ovima:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Izgled</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Rubovi prozora"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Svjetlost fonta nefokusiranog terminala:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Veličina razdjeljivača terminala:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr "Prored:"
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Dodatno stiliziranje (ovisno o temi)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Položaj kartice:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Jednolične kartice"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Gumbovi klizača kartica"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr "Traka naslova dolje (program se mora ponovo pokrenuti)"
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Globalno"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Koristi font fiksne širine sustava"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Font:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Odaberi font za terminal"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Dopusti podebljani tekst"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Prikaži traku naslova"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Kopiraj pri odabiru"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Deaktiviraj zumiranje pomoću „Ctrl+okretanje kotačića miša”"
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Niz znakova _za označivanje:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Pokazivač</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Oblik:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Titranje"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Pozadina:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Zvono terminala</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Ikona u traci naslova"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Vizualni bljesak"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Zvučni signal"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Zabljesni popis prozora"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Opće"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Pokreni naredbu kao ljusku prijave"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Pokreni prilagođenu _naredbu umjesto moje ljuske"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Prilagođena na_redba:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Kad naredba _završi:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Prednja i stražnja boja</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Koristi boje iz teme sustava"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Ugrađene she_me:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Ugrađene _sheme:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Paleta b_oja:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr "Prikaži p_odebljani tekst svijetlim bojama"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Boje"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Puna boja"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Prozirna pozadina"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr "Odaberi datoteku"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Bez</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimalno</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Pozadina"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Klizna traka je:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Kliži pri _rezultatu"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Kliži pri _pritiskanju tipke"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Beskonačna povijest"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Po_vijest:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "redaka"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Klizanje"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Napomena:</b> Ove opcije mogu prouzrokovati neispravan rad "
 "nekih programa. Ovdje se nalaze samo kako bi se zaobišli problemi s "
 "određenim programima i operacijskim sustavima, koji očekuju drugačiji rad "
 "terminala.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Tipka _backspace generira:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Tipka _delete generira:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Kodiranje:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Postavi opcije kompatibilnosti na standardne vrijednosti"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Kompatibilnost"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Fokusirana"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Neaktivna"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Primajuća"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Sakrij veličinu iz naslova"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Koristi font sustava"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Odaberi font za traku naslova"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Vrsta"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Prilagođena naredba:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Radna mapa:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Rasporedi"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Radnja"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Tipkovnički prečac"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Tipkovnički prečaci"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Priključak"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Ovaj priključak nema opcija za konfiguraciju"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Priključci"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Cilj ovog projekta je proizvesti koristan alat za raspoređivanje terminala, slično programima poput gnome-multi-term, quadkonsole, itd., a glavna ideja je pločasto raspoređivanje terminala (kartice su najraširenija standardna metoda, koju Terminator također podržava).\n"
+"Cilj ovog projekta je proizvesti koristan alat za raspoređivanje terminala, "
+"slično programima poput gnome-multi-term, quadkonsole, itd., a glavna ideja "
+"je pločasto raspoređivanje terminala (kartice su najraširenija standardna "
+"metoda, koju Terminator također podržava).\n"
 "\n"
-"Terminator se uveliko temelji se na GNOME Terminalu i s vremenom dodajemo daljnje njegove funkcije, ali ga također razvijamo s raznim dodatnim korisnim funkcijama za administratore sustava i za ostale korisnike. Prijedlozi se mogu dodati u popis želja! (vidi lijevo poveznicu „Razvoj”)"
+"Terminator se uveliko temelji se na GNOME Terminalu i s vremenom dodajemo "
+"daljnje njegove funkcije, ali ga također razvijamo s raznim dodatnim "
+"korisnim funkcijama za administratore sustava i za ostale korisnike. "
+"Prijedlozi se mogu dodati u popis želja! (vidi lijevo poveznicu „Razvoj”)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "Priručnik"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Razvoj</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Greške i poboljšanja</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Greške i "
+"poboljšanja</a>"
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Informacije"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Povećaj veličinu fonta"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Smanji veličinu fonta"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Vrati izvornu veličinu fonta"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Stvori novu karticu"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Fokusiraj sljedeći terminal"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Fokusiraj prethodni terminal"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Fokusiraj gornji terminal"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Fokusiraj donji terminal"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Fokusiraj lijevi terminal"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Fokusiraj desni terminal"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Okreni terminale nadesno"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Okreni terminale nalijevo"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Rastavi vodoravno"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Rastavi okomito"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Zatvori terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Kopiraj odabrani tekst"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Umetni iz međuspremnika"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1608,11 +1489,11 @@ msgstr "Otvori prozor postavki"
 msgid "Open the manual"
 msgstr "Otvori priručnik"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Novi profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Novi raspored"
 
@@ -1625,185 +1506,169 @@ msgstr "Traži:"
 msgid "Close Search bar"
 msgstr "Zatvori traku pretraživanja"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Pošalji e-mail na …"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopiraj e-mail adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "N_azovi VoIP adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopiraj VoIP adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Otvori poveznicu"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopiraj adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Kopiraj"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "_Umetni"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Rastavi _vodoravno"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Rastavi _okomito"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Otvori _karticu"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Otvori _debug karticu"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Zatvori"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zumiraj terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Rast_vori terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Obnovi sve terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Grupiranje"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Prikaži _kliznu traku"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr "_Rasporedi …"
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kodiranja"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Standardno"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Korisnički određeno"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Ostala kodiranja"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "N_ova grupa …"
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Ništa"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Ukloni grupu %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_rupiraj sve u kartici"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Razdvoji sve _u kartici"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Ukloni sve grupe"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Zatvori grupu %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Šalji svim_a"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Šalji _grupi"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Slanje isključen_o"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "_Rastavi u ovu grupu"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Auto_matski ukloni grupe"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_Umetni broj terminala"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Umetni _broj terminala s predstavljenom nulom"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Nije moguće pronaći ljusku"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Nije moguće pokrenuti ljusku:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Preimenuj prozor"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Upiši novi naslov za prozor Terminatora …"
 
@@ -1911,12 +1776,123 @@ msgstr "Omega"
 msgid "window"
 msgstr "prozor"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Kartica %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Trenutačni jezik"
+
+#~ msgid "Western"
+#~ msgstr "Zapadni"
+
+#~ msgid "Central European"
+#~ msgstr "Srednjoeuropski"
+
+#~ msgid "South European"
+#~ msgstr "Južnoeuropski"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltički"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Ćirilični"
+
+#~ msgid "Arabic"
+#~ msgstr "Arapski"
+
+#~ msgid "Greek"
+#~ msgstr "Grčki"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Vizualni hebrejski"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebrejski"
+
+#~ msgid "Turkish"
+#~ msgstr "Turski"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordijski"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltski"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumunjski"
+
+#~ msgid "Unicode"
+#~ msgstr "Unikod"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenski"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Kineski tradicionalni"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Ćirilica/Ruski"
+
+#~ msgid "Japanese"
+#~ msgstr "Japanski"
+
+#~ msgid "Korean"
+#~ msgstr "Korejski"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Kineski pojednostavljeni"
+
+#~ msgid "Georgian"
+#~ msgstr "Gruzijski"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Ćirilica/Ukrajinski"
+
+#~ msgid "Croatian"
+#~ msgstr "Hrvatski"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindski"
+
+#~ msgid "Persian"
+#~ msgstr "Perzijski"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gudžaratski"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmuki"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandski"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vijetnamski"
+
+#~ msgid "Thai"
+#~ msgstr "Tajlandski"
+
+#~ msgid "Line Height:"
+#~ msgstr "Prored:"
+
+#~ msgid "Encoding:"
+#~ msgstr "Kodiranje:"
+
+#~ msgid "Encodings"
+#~ msgstr "Kodiranja"
+
+#~ msgid "Default"
+#~ msgstr "Standardno"
+
+#~ msgid "User defined"
+#~ msgstr "Korisnički određeno"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Ostala kodiranja"

--- a/po/hu.po
+++ b/po/hu.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Hungarian (https://www.transifex.com/terminator/teams/109338/hu/)\n"
+"Language-Team: Hungarian (https://www.transifex.com/terminator/teams/109338/"
+"hu/)\n"
+"Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hu\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Több terminál egy ablakban"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "A terminálok robot jövője"
 
@@ -140,8 +141,8 @@ msgstr "A terminálok robot jövője"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -226,156 +227,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Jelenlegi területi beállítás"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Nyugati"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Közép-európai"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Dél-európai"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Balti"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirill"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arab"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Görög"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Héber (képi)"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Héber"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Török"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Északi"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Kelta"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Román"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Örmény"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Kínai (hagyományos)"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cirill/orosz"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japán"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreai"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Kínai (egyszerűsített)"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Grúz"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirill/ukrán"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Horvát"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Perzsa"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gudzsaráti"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmuki"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Izlandi"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnámi"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Elrendezés"
 
@@ -383,11 +240,11 @@ msgstr "Elrendezés"
 msgid "Launch"
 msgstr "Indítás"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "lap"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Lap bezárása"
 
@@ -467,8 +324,7 @@ msgstr "DBus lekapcsolása"
 
 #: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
-msgstr ""
-"Hibakeresési információk engedélyezése (kétszer hibakereső szervernek)"
+msgstr "Hibakeresési információk engedélyezése (kétszer hibakereső szervernek)"
 
 #: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
@@ -518,7 +374,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -543,12 +399,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Parancs"
 
@@ -654,7 +510,7 @@ msgid "Escape sequence"
 msgstr "Escape szekvencia"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Összes"
 
@@ -871,43 +727,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
+msgid "<b>Appearance</b>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Ablak keretek"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -915,437 +771,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
-msgstr "Globális"
+msgid "Tabs scroll buttons"
+msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
-msgstr ""
+msgid "Global"
+msgstr "Globális"
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
-msgstr "Válassza ki a terminál betűkészletét"
+msgid "_Use the system fixed width font"
+msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
-msgstr "Címsor megjelenítése"
+msgid "Choose A Terminal Font"
+msgstr "Válassza ki a terminál betűkészletét"
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
-msgstr ""
+msgid "Show titlebar"
+msgstr "Címsor megjelenítése"
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
-msgstr "<b>Kurzor beállításai</b>"
+msgid "Disable Ctrl+mousewheel zoom"
+msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
-msgstr ""
+msgid "<b>Cursor</b>"
+msgstr "<b>Kurzor beállításai</b>"
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
+msgid "Foreground:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:92
+msgid "Background:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminál csengő</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Címsorbeli ikon"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Látható villanás"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Általános"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Parancs futtatása bejelentkezési parancsértelmezőként"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Rendszertéma színeinek használata"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Beépített sé_mák:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paletta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Beépített _sémák:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Háttér"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1580,11 +1452,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1597,185 +1469,169 @@ msgstr "Keresés:"
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "Hivatkozás _megnyitása"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Felosztás _vízszintesen"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Felosztás _függőlegesen"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "_Lap megnyitása"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Hibakereső fül megnyitása"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "Terminál nagyítása"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Gördítő_sáv megjelenítése"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kódolások"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Egyéb Kódolások"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Minden csoport eltávolítása"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Parancsértelmező nem található"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1883,12 +1739,111 @@ msgstr ""
 msgid "window"
 msgstr "ablak"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "Jelenlegi területi beállítás"
+
+#~ msgid "Western"
+#~ msgstr "Nyugati"
+
+#~ msgid "Central European"
+#~ msgstr "Közép-európai"
+
+#~ msgid "South European"
+#~ msgstr "Dél-európai"
+
+#~ msgid "Baltic"
+#~ msgstr "Balti"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirill"
+
+#~ msgid "Arabic"
+#~ msgstr "Arab"
+
+#~ msgid "Greek"
+#~ msgstr "Görög"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Héber (képi)"
+
+#~ msgid "Hebrew"
+#~ msgstr "Héber"
+
+#~ msgid "Turkish"
+#~ msgstr "Török"
+
+#~ msgid "Nordic"
+#~ msgstr "Északi"
+
+#~ msgid "Celtic"
+#~ msgstr "Kelta"
+
+#~ msgid "Romanian"
+#~ msgstr "Román"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Örmény"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Kínai (hagyományos)"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cirill/orosz"
+
+#~ msgid "Japanese"
+#~ msgstr "Japán"
+
+#~ msgid "Korean"
+#~ msgstr "Koreai"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Kínai (egyszerűsített)"
+
+#~ msgid "Georgian"
+#~ msgstr "Grúz"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirill/ukrán"
+
+#~ msgid "Croatian"
+#~ msgstr "Horvát"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Perzsa"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gudzsaráti"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmuki"
+
+#~ msgid "Icelandic"
+#~ msgstr "Izlandi"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnámi"
+
+#~ msgid "Thai"
+#~ msgstr "Thai"
+
+#~ msgid "Encodings"
+#~ msgstr "Kódolások"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Egyéb Kódolások"

--- a/po/hy.po
+++ b/po/hy.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Armenian (https://www.transifex.com/terminator/teams/109338/hy/)\n"
+"Language-Team: Armenian (https://www.transifex.com/terminator/teams/109338/"
+"hy/)\n"
+"Language: hy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hy\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Մի քանի տերմինալ մեկ պատուհանում"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Ցույց չտալ մյուս անգամ"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Ընթացիկ տեղայնք"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Արեվմտյան"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Կենտրոնական Եվրոպա"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Հարավեվրոպական"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Բալթիկ"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Կիրիլլիկ"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Արաբական"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Հունական"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Եբրայական"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Հրեական"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Թուրքական"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Նորդիկ"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Կելտական"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,51 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "Ընթացիկ տեղայնք"
+
+#~ msgid "Western"
+#~ msgstr "Արեվմտյան"
+
+#~ msgid "Central European"
+#~ msgstr "Կենտրոնական Եվրոպա"
+
+#~ msgid "South European"
+#~ msgstr "Հարավեվրոպական"
+
+#~ msgid "Baltic"
+#~ msgstr "Բալթիկ"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Կիրիլլիկ"
+
+#~ msgid "Arabic"
+#~ msgstr "Արաբական"
+
+#~ msgid "Greek"
+#~ msgstr "Հունական"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Եբրայական"
+
+#~ msgid "Hebrew"
+#~ msgstr "Հրեական"
+
+#~ msgid "Turkish"
+#~ msgstr "Թուրքական"
+
+#~ msgid "Nordic"
+#~ msgstr "Նորդիկ"
+
+#~ msgid "Celtic"
+#~ msgstr "Կելտական"

--- a/po/ia.po
+++ b/po/ia.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Interlingua (https://www.transifex.com/terminator/teams/109338/ia/)\n"
+"Language-Team: Interlingua (https://www.transifex.com/terminator/"
+"teams/109338/ia/)\n"
+"Language: ia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ia\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -126,7 +127,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -135,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Plure terminales in un fenestra"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Le robot futur del terminales"
 
@@ -143,8 +144,8 @@ msgstr "Le robot futur del terminales"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -227,156 +228,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Region actual"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Occidental"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europee central"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Sud europee"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltic"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrillic"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabe"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Greco"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebreo visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebreo"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turco"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordic"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtic"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romaniano"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenio"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chinese Traditional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyrillic/Russo"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonese"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coreano"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chinese Simplificate"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgian"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cyrillic/Ukrainiano"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croato"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Farsi (Perse)"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandese"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamese"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Disposition"
 
@@ -384,11 +241,11 @@ msgstr "Disposition"
 msgid "Launch"
 msgstr "Lancear"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "scheda"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Clauder scheda"
 
@@ -518,7 +375,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferentias"
 
@@ -543,12 +400,12 @@ msgid "Enabled"
 msgstr "Activate"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Nomine"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Commando"
 
@@ -654,7 +511,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Toto"
 
@@ -871,43 +728,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -915,437 +772,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
-msgstr "Position de scheda:"
+msgid "Cell Height:"
+msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
-msgstr ""
+msgid "Tab position:"
+msgstr "Position de scheda:"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
+msgid "Tabs scroll buttons"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profilo"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Palpebrar"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "General"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Colores"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Fundo"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "lineas"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Rolar"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Inactive"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Typo"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profilo:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Action"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "A  proposito"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Crear un nove scheda"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1580,11 +1453,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nove profilo"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1597,185 +1470,169 @@ msgstr "Cercar:"
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Copiar"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "Collar (_P)"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Clauder"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Gruppar"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Predefinite"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1883,12 +1740,108 @@ msgstr "Omega"
 msgid "window"
 msgstr "fenestra"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Scheda %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Region actual"
+
+#~ msgid "Western"
+#~ msgstr "Occidental"
+
+#~ msgid "Central European"
+#~ msgstr "Europee central"
+
+#~ msgid "South European"
+#~ msgstr "Sud europee"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltic"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrillic"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabe"
+
+#~ msgid "Greek"
+#~ msgstr "Greco"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebreo visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebreo"
+
+#~ msgid "Turkish"
+#~ msgstr "Turco"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordic"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtic"
+
+#~ msgid "Romanian"
+#~ msgstr "Romaniano"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenio"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chinese Traditional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyrillic/Russo"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonese"
+
+#~ msgid "Korean"
+#~ msgstr "Coreano"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chinese Simplificate"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgian"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cyrillic/Ukrainiano"
+
+#~ msgid "Croatian"
+#~ msgstr "Croato"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Farsi (Perse)"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandese"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamese"
+
+#~ msgid "Thai"
+#~ msgstr "Thai"
+
+#~ msgid "Default"
+#~ msgstr "Predefinite"

--- a/po/id.po
+++ b/po/id.po
@@ -2,24 +2,25 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Abdul Munif Hanafi <amunifhanafi@gmail.com>, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Abdul Munif Hanafi <amunifhanafi@gmail.com>, 2021\n"
-"Language-Team: Indonesian (https://www.transifex.com/terminator/teams/109338/id/)\n"
+"Language-Team: Indonesian (https://www.transifex.com/terminator/teams/109338/"
+"id/)\n"
+"Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: id\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -129,7 +130,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -138,7 +139,7 @@ msgid "Multiple terminals in one window"
 msgstr "Banyak terminal dalam satu window"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "The robot future of terminals"
 
@@ -146,8 +147,8 @@ msgstr "The robot future of terminals"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -232,156 +233,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Jangan tampilkan pesan ini lagi"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Lokal sekarang"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Barat"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Eropa Tengah"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Eropa Selatan"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltic"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrillic"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arab"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Yunani"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Ibrani Visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Ibrani"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turki"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordic"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtic"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumania"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenia"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Bahasa China Tradisional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyrillic/Rusia"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Jepang"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korea"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Bahasa China Sederhana"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgia"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Sirilik/Ukraina"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroasia"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "India"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persia"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarat"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandia"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnam"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thailand"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Terminator Layout Launcher"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Tata Letak"
 
@@ -389,11 +246,11 @@ msgstr "Tata Letak"
 msgid "Launch"
 msgstr "Luncurkan"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Tutup Tab"
 
@@ -424,8 +281,8 @@ msgstr "Tentukan judul untuk jendela"
 #: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
-"Tetapkan ukuran dan posisi yang diinginkan dari jendela(lihat halaman manual"
-" X)"
+"Tetapkan ukuran dan posisi yang diinginkan dari jendela(lihat halaman manual "
+"X)"
 
 #: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
@@ -527,7 +384,7 @@ msgstr "_Custom Commands"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferensi"
 
@@ -552,12 +409,12 @@ msgid "Enabled"
 msgstr "Aktifkan"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Nama"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Perintah"
 
@@ -663,7 +520,7 @@ msgid "Escape sequence"
 msgstr "Escape sequence"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Semuanya"
 
@@ -880,489 +737,512 @@ msgid "Use custom URL handler"
 msgstr "Gunakan pengelola URL yang lazim"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Custom URL handler:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr "Papan klip"
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr "Buka tautan dengan sekali klik (bukan Ctrl-klik kiri)"
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Custom URL handler:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Penampilan</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Batas jendela"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Unfocused terminal font brightness:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Terminal separator size:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr "Tinggi Baris:"
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Posisi tab:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Tabs homogeneous"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Tabs scroll buttons"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Gunakan lebar font sistem"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Huruf:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Pilih huruf untuk terminal"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "Perbolehk_an teks tebal"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Tampilkan titlebar"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Salin pada pilihan"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Pilih karakter _kata:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Shape:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Berkedip"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Latar belakang:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminal bell</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "ikon Titlebar"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Flash visual"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Terdengar beep"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Window list flash"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Umum"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Jalankan perintah dalam shell login"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Jalankan perintah tertent_u dan bukan shell"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Perintah ta_mbahan:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Saat perintah s_elesai dijalankan:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Latar Depan dan Latar Belakang</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "G_unakan warna dari tema sistem"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Ske_ma bawaan:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Skema-_skema bawaan:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "P_alet warna:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Warna"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "warna _Solid"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Latar belakang _transparan"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr "Gambar Latar Belakang"
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr "Berkas Gambar Latar Belakang:"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr "Pilih berkas"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Nihil</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimal</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Latar belakang"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Scrollbarnya:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Gulung saat ada _keluaran"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Gulung pada saat tombol _ditekan"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Gulung balik tak terbatas"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Gulung _balik:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "baris"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Menggulung"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Catat:</b>Pilihan ini dapat menyebabkan ada program yang tidak "
 "jalan dengan semestinya. Pilihan ini disediakan hanya untuk menyiasati "
-"beberapa aplikasi dan sistem operasi tertentu yang memiliki perilaku berbeda"
-" pada aplikasi terminalnya.</i></small>"
+"beberapa aplikasi dan sistem operasi tertentu yang memiliki perilaku berbeda "
+"pada aplikasi terminalnya.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Tom_bol backspace membangkitkan:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Tombol _delete membangkitkan:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Pengkodean:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Kembalikan pilihan kompatibilitas ke nilai bawaan"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Kompatibilitas"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Focused"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Tidak aktif"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Menerima"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Hide size from title"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Use the system font"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Choose A Titlebar Font"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Jenis"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Custom command:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Working directory:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Tata Letak"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Aksi"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Kaitan tombol"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Pengaya"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Plugin ini tidak memiliki pilihan konfigurasi"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr "Versi: 2.1.1"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "The Manual"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Tentang"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Increase font size"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Decrease font size"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Restore original font size"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr "Besarkan ukuran font di semua terminal"
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr "Kecilkan ukuran font di semua terminal"
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr "Kembalikan ukuran font asli di semua terminal"
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Buat tab baru"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Focus the next terminal"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Focus the previous terminal"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Focus the terminal above"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Focus the terminal below"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Focus the terminal left"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Focus the terminal right"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Rotate terminals clockwise"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Rotate terminals counter-clockwise"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Split horizontally"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Split vertically"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Close terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Salin teks yang dipilih"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Tempel papan klip"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1596,11 +1476,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Buka manual"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Profile Baru"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Tampilan Baru"
 
@@ -1613,185 +1493,169 @@ msgstr "Cari:"
 msgid "Close Search bar"
 msgstr "Tutup bar Pencarian"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "Kirim _Surel ke..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copy alamat surel"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Panggi_l alamat VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Salin alamat VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Buka tautan"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Salin alamat"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "Tem_pel"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Pecah secara H_orisontal"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Pecah secara V_ertikal"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Buka _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Buka tab _Debug"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "Tutup"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Perbesar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximize terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Kembalikan semua terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Pengelompokan"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Tunjukkan _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Pengodean"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Baku"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Ditetapkan pengguna"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Pengkodean Lainnya"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "N_ew group..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Nihil"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Hapus grup %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "K_elompokan semua dalam tab"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Ungro_up all in tab"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Hapus semua grup"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Tutup grup %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Broadcast _all"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Broadcast _group"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Broadcast _off"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "_Split to this group"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Auto_clean groups"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_Insert terminal number"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Insert _padded terminal number"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Tidak dapat menemukan sebuah shell."
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Tidak dapat menjalankan shell:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Namai jendela"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Masukkan judul baru untuk terminal"
 
@@ -1899,12 +1763,123 @@ msgstr "Omega"
 msgid "window"
 msgstr "jendela"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Lokal sekarang"
+
+#~ msgid "Western"
+#~ msgstr "Barat"
+
+#~ msgid "Central European"
+#~ msgstr "Eropa Tengah"
+
+#~ msgid "South European"
+#~ msgstr "Eropa Selatan"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltic"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrillic"
+
+#~ msgid "Arabic"
+#~ msgstr "Arab"
+
+#~ msgid "Greek"
+#~ msgstr "Yunani"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Ibrani Visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Ibrani"
+
+#~ msgid "Turkish"
+#~ msgstr "Turki"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordic"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtic"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumania"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenia"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Bahasa China Tradisional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyrillic/Rusia"
+
+#~ msgid "Japanese"
+#~ msgstr "Jepang"
+
+#~ msgid "Korean"
+#~ msgstr "Korea"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Bahasa China Sederhana"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgia"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Sirilik/Ukraina"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroasia"
+
+#~ msgid "Hindi"
+#~ msgstr "India"
+
+#~ msgid "Persian"
+#~ msgstr "Persia"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarat"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandia"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnam"
+
+#~ msgid "Thai"
+#~ msgstr "Thailand"
+
+#~ msgid "Line Height:"
+#~ msgstr "Tinggi Baris:"
+
+#~ msgid "Encoding:"
+#~ msgstr "Pengkodean:"
+
+#~ msgid "Encodings"
+#~ msgstr "Pengodean"
+
+#~ msgid "Default"
+#~ msgstr "Baku"
+
+#~ msgid "User defined"
+#~ msgstr "Ditetapkan pengguna"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Pengkodean Lainnya"

--- a/po/is.po
+++ b/po/is.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Icelandic (https://www.transifex.com/terminator/teams/109338/is/)\n"
+"Language-Team: Icelandic (https://www.transifex.com/terminator/teams/109338/"
+"is/)\n"
+"Language: is\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: is\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 != 1 || n % 100 == 11);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Margar útstöðvar í einum glugga"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Núverandi staðsetning"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Vestræn"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Mið-Evrópskt"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Suður-Evrópskt"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Eystrasalts"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kýrillískt"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabískt"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grískt"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebreskt sjónrænt"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebreskt"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Tyrknenskt"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Norðurlenskt"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltneskt"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rúmenskt"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenskt"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Hefðbundið Kínverskt"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kýrillískt/Rússneskt"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japanskt"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Kóreskt"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Einfaldað Kínverskt"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgískt"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kýrillískt/Úkraínskt"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Króatískt"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindverskt"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persneskt"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujaratískt"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukískt"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Íslenskt"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Víetnamskt"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tælenskt"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "flipi"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Loka Flipa"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Kjörstillingar"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Allir"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Uppsetning"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Ný Uppsetning"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nýtt Snið"
 
@@ -1594,185 +1467,169 @@ msgstr "Leit:"
 msgid "Close Search bar"
 msgstr "Loka leitarslá"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Senda tölvupóst til..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Afrita tölvupóstfáng"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_Hringja í VoIP-fang"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "A_frita VoIP-fang"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Opna slóð"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "Af_rita fang"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Deila _Lárétt"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Deila Lóðré_tt"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Opna fl_ipa"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Hópun"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Sýna _skrunslá"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kóðanir"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Sjálfgefið"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Skilgreint af notanda"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Aðrar kóðanir"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Fjarlægja hóp %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "_Hópa allar í flipa"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Fjarlægja alla hópa"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Loka hóp %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Getur ekki fundið skel"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Getur ekki ræst skel:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,117 @@ msgstr ""
 msgid "window"
 msgstr "gluggi"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Flipi %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Núverandi staðsetning"
+
+#~ msgid "Western"
+#~ msgstr "Vestræn"
+
+#~ msgid "Central European"
+#~ msgstr "Mið-Evrópskt"
+
+#~ msgid "South European"
+#~ msgstr "Suður-Evrópskt"
+
+#~ msgid "Baltic"
+#~ msgstr "Eystrasalts"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kýrillískt"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabískt"
+
+#~ msgid "Greek"
+#~ msgstr "Grískt"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebreskt sjónrænt"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebreskt"
+
+#~ msgid "Turkish"
+#~ msgstr "Tyrknenskt"
+
+#~ msgid "Nordic"
+#~ msgstr "Norðurlenskt"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltneskt"
+
+#~ msgid "Romanian"
+#~ msgstr "Rúmenskt"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenskt"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Hefðbundið Kínverskt"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kýrillískt/Rússneskt"
+
+#~ msgid "Japanese"
+#~ msgstr "Japanskt"
+
+#~ msgid "Korean"
+#~ msgstr "Kóreskt"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Einfaldað Kínverskt"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgískt"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kýrillískt/Úkraínskt"
+
+#~ msgid "Croatian"
+#~ msgstr "Króatískt"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindverskt"
+
+#~ msgid "Persian"
+#~ msgstr "Persneskt"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujaratískt"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukískt"
+
+#~ msgid "Icelandic"
+#~ msgstr "Íslenskt"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Víetnamskt"
+
+#~ msgid "Thai"
+#~ msgstr "Tælenskt"
+
+#~ msgid "Encodings"
+#~ msgstr "Kóðanir"
+
+#~ msgid "Default"
+#~ msgstr "Sjálfgefið"
+
+#~ msgid "User defined"
+#~ msgstr "Skilgreint af notanda"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Aðrar kóðanir"

--- a/po/it.po
+++ b/po/it.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Italian (https://www.transifex.com/terminator/teams/109338/it/)\n"
+"Language-Team: Italian (https://www.transifex.com/terminator/teams/109338/"
+"it/)\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -128,7 +129,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -137,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Molteplici terminali un una sola finestra"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Il futuro robot dei terminali"
 
@@ -145,8 +146,8 @@ msgstr "Il futuro robot dei terminali"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -179,8 +180,7 @@ msgstr "Quantità di scorciatoie da tastiera"
 
 #: ../data/terminator.appdata.xml.in.h:11
 msgid "Save multiple layouts and profiles via GUI preferences editor"
-msgstr ""
-"Salva i layout e profili multipli attraverso l'editor delle preferenze"
+msgstr "Salva i layout e profili multipli attraverso l'editor delle preferenze"
 
 #: ../data/terminator.appdata.xml.in.h:12
 msgid "Simultaneous typing to arbitrary groups of terminals"
@@ -230,156 +230,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Non visualizzare più questo messaggio"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Localizzazione in uso"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Occidentale"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europa centrale"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Europa meridionale"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltico"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirillico"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabo"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Greco"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Ebraico visuale"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Ebraico"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turco"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordico"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtico"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romeno"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armeno"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Cinese tradizionale"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cirillico/Russo"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Giapponese"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coreano"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Cinese semplificato"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgiano"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirillico/Ucraino"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croato"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persiano"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandese"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamita"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tailandese"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Disposizione"
 
@@ -387,11 +243,11 @@ msgstr "Disposizione"
 msgid "Launch"
 msgstr "Esegui"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "scheda"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Chiudi scheda"
 
@@ -434,8 +290,8 @@ msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
-"Usa il resto della riga di comando come un comando da eseguire nel terminale"
-" e i suoi argomenti"
+"Usa il resto della riga di comando come un comando da eseguire nel terminale "
+"e i suoi argomenti"
 
 #: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
@@ -475,8 +331,7 @@ msgstr "Disabilita DBus"
 
 #: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
-msgstr ""
-"Abilita informazioni di debug (due volte per fare il debug del server)"
+msgstr "Abilita informazioni di debug (due volte per fare il debug del server)"
 
 #: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
@@ -526,7 +381,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "Preferen_ze"
 
@@ -551,12 +406,12 @@ msgid "Enabled"
 msgstr "Attivato"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Nome"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Comando"
 
@@ -662,7 +517,7 @@ msgid "Escape sequence"
 msgstr "Sequenza di escape"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Tutti"
 
@@ -879,43 +734,43 @@ msgid "Use custom URL handler"
 msgstr "Usare gestore URL personalizzato"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Aspetto</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Bordi della finestra"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -923,442 +778,458 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
+msgid "Tabs scroll buttons"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Globali"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profilo"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Usare il tipo di carattere a larghezza fissa di sistema"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "Tipo di _carattere"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Scegliere un carattere"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "Consentire il testo in gr_assetto"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Mostrare la barra del titolo"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Copiare con la selezione"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Cara_tteri selezionabili come parola:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursore</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Avviso</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Icona nella barra del titolo"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Segnale luminoso"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Segnale acustico"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Illuminazione elenco finestre"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Generali"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Eseguire il comando come una shell di login"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Ese_guire un comando personalizzato invece della shell"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Co_mando personalizzato:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "_Quando il comando termina:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Primo piano e sfondo</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "Usare i colori del te_ma di sistema"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Schemi i_ncorporati:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Tavolozza</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "_Schemi incorporati:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Tavolo_zza dei colori:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Colori"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Tinta unita"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Sfondo _trasparente"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Nessuna</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Massima</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Sfondo"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "Barra di _scorrimento:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Sco_rrere in presenza di output"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "S_correre alla pressione dei tasti"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Illimitato"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Sc_orrimento all'indietro:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "righe"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Scorrimento"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Nota:</b> queste opzioni potrebbero provocare un funzionamento "
 "non corretto di alcune applicazioni. Sono state rese disponibili per quelle "
 "applicazioni e sistemi operativi che si aspettano un diverso funzionamento "
 "del terminale.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Il tasto _Backspace genera:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Il tasto _Canc genera:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Ripristina valori predefiniti per opzioni di compatibilità"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Compatibilità"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Cartella di lavoro:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Disposizioni"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Associazione tasti"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Questo plugin non ha opzioni di configurazione"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Plugin"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Aumenta dimensione carattere"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Diminuisci dimensione carattere"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Ruota i terminali in senso orario"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Ruota i terminali in senso antiorario"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Copia il testo selezionato"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Incolla dagli appunti"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1592,11 +1463,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Apri il manuale"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nuovo profilo"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nuova disposizione"
 
@@ -1609,185 +1480,169 @@ msgstr "Cerca:"
 msgid "Close Search bar"
 msgstr "Chiudi barra di ricerca"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Invia email a..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copia indirizzo email"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Chi_ama indirizzo VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copia indirizzo VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "Apri il collegament_o"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copia indirizzo"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Dividi o_rizzontalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Dividi v_erticalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Apri _scheda"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Apri scheda _debug"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Ingrandisci terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Ripristina tutti i terminali"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Raggruppamento"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Mostra _barra di scorrimento"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Codifiche"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Predefinito"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definito dall'utente"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Altre codifiche"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Rimuovi gruppo %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Ra_ggruppa tutto nella scheda"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Rimuovi tutti i gruppi"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Chiudi gruppo %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Impossibile trovare una shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Impossibile avviare la shell:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Rinomina finestra"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Inserisci un nuovo titolo per la finestra di Terminator..."
 
@@ -1895,12 +1750,117 @@ msgstr "Omega"
 msgid "window"
 msgstr "finestra"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Scheda %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Localizzazione in uso"
+
+#~ msgid "Western"
+#~ msgstr "Occidentale"
+
+#~ msgid "Central European"
+#~ msgstr "Europa centrale"
+
+#~ msgid "South European"
+#~ msgstr "Europa meridionale"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltico"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirillico"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabo"
+
+#~ msgid "Greek"
+#~ msgstr "Greco"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Ebraico visuale"
+
+#~ msgid "Hebrew"
+#~ msgstr "Ebraico"
+
+#~ msgid "Turkish"
+#~ msgstr "Turco"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordico"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtico"
+
+#~ msgid "Romanian"
+#~ msgstr "Romeno"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armeno"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Cinese tradizionale"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cirillico/Russo"
+
+#~ msgid "Japanese"
+#~ msgstr "Giapponese"
+
+#~ msgid "Korean"
+#~ msgstr "Coreano"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Cinese semplificato"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgiano"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirillico/Ucraino"
+
+#~ msgid "Croatian"
+#~ msgstr "Croato"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persiano"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandese"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamita"
+
+#~ msgid "Thai"
+#~ msgstr "Tailandese"
+
+#~ msgid "Encodings"
+#~ msgstr "Codifiche"
+
+#~ msgid "Default"
+#~ msgstr "Predefinito"
+
+#~ msgid "User defined"
+#~ msgstr "Definito dall'utente"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Altre codifiche"

--- a/po/ja.po
+++ b/po/ja.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Japanese (https://www.transifex.com/terminator/teams/109338/ja/)\n"
+"Language-Team: Japanese (https://www.transifex.com/terminator/teams/109338/"
+"ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "複数の端末を一つのウインドウに"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "次回からこのメッセージを表示しない"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "現在利用しているロケール"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "西ヨーロッパ言語"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "中央ヨーロッパ言語"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "南ヨーロッパ言語"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "バルト語"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "キリル語"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "アラブ語"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "ギリシア語"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "ヘブライ語 (論理表記)"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "ヘブライ語"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "トルコ語"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "スカンジナビア語"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "ケルト語"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "ルーマニア語"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "アルメニア語"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "中国語(繁体字)"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "キリル/ロシア語"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "日本語"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "韓国語"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "中国語(簡体字)"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "グルジア語"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "キリル/ウクライナ語"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "クロアチア語"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "ヒンディー語"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "ペルシア語"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "グジャラート語"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "グルムキー文字"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "アイスランド語"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "ベトナム語"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "タイ語"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "レイアウト"
 
@@ -381,11 +238,11 @@ msgstr "レイアウト"
 msgid "Launch"
 msgstr "実行"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "タブ"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "タブを閉じる"
 
@@ -515,7 +372,7 @@ msgstr "カスタムコマンド(_C)"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "設定(_P)"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "コマンド"
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr "Escape sequence"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "全て"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr "カスタムURLハンドラーを使う"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>外観</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "ウィンドウの枠"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,440 +769,457 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
-msgstr "タブの位置:"
+msgid "Cell Height:"
+msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
-msgstr ""
+msgid "Tab position:"
+msgstr "タブの位置:"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
+msgid "Tabs scroll buttons"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "一般"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "プロファイル"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "システムの固定幅フォントを使う(_U)"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "フォント(_F):"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "端末フォントの選択"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "太字フォントを有効にする(_A)"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "タイトルバー表示"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "選択をコピー"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "単語単位で選択する文字(_W):"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>カーソル</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "背景:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>端末のベル</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "タイトルバー・アイコン"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "画面の点滅"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "ビープ音"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "ウィンドウリスト点滅"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "一般"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "ログイン・シェルを実行(_R)"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "ログイン・シェルではなくカスタムコマンドを実行(_n)"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "カスタムコマンド(_m):"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "exitコマンドの動作(_e):"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>文字と背景</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "システムテーマを使う(_U)"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "既定の設定(_m):"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>パレット</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "既定の設定(_s):"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "カラーパレット(_a):"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "色"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "単色(_S)"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "背景を透過(_T)"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>なし</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>最大</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "背景"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "スクロールバー(_S):"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "出力でボトムにスクロール(_k)"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "キー入力でボトムにスクロール(_k)"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "無限のスクロールバック"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "スクロールバック(_b):"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "行"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "スクロール"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
-"<small><i><b>注意:</b> "
-"これらのオプションが影響して、いくつかのアプリケーションが正常に動作しなくなるかもしれません。これらのオプションは特定のアプリや OS "
-"上で異なった動作になってしまう問題を解決するために提供されています。</i></small>"
+"<small><i><b>注意:</b> これらのオプションが影響して、いくつかのアプリケーショ"
+"ンが正常に動作しなくなるかもしれません。これらのオプションは特定のアプリや "
+"OS 上で異なった動作になってしまう問題を解決するために提供されています。</i></"
+"small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "[BS] キーが生成するコード(_B):"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "[DEL] キーが生成するコード(_D):"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "互換性オプションを既定値に戻す(_R)"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "互換性"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "受信中"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "システムフォントを使う(_U)"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "プロファイル"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "プロファイル:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "作業ディレクトリ:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "レイアウト"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "キーバインド"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "キーの割り当て"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "プラグイン"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "このプラグインにオプション設定はありません"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "プラグイン"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "情報"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "文字サイズを拡大"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "文字サイズを縮小"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "オリジナル文字サイズに戻す"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "新しいタブを作成"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "次のターミナルにフォーカス"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "前のターミナルにフォーカス"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "上のターミナルにフォーカス"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "下のターミナルにフォーカス"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "左のターミナルにフォーカス"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "右のターミナルにフォーカス"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "水平方向に分割"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "垂直方向に分割"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "ターミナルを閉じる"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "選択した文字をコピー"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1580,11 +1454,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "新しいプロファイル"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "新しいレイアウト"
 
@@ -1597,185 +1471,169 @@ msgstr "検索:"
 msgid "Close Search bar"
 msgstr "検索バーを閉じる"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "メールを送信する(_S)"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "メールアドレスをコピー(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "VoIPアドレスに発信(_l)"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "VoIPアドレスをコピー(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "リンクを開く(_O)"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "アドレスをコピー(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "コピー(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "貼り付け(_P)"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "水平で分割(_O)"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "垂直で分割(_E)"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "タブを開く(_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "デバッグタブを開く(_D)"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "閉じる(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "端末をズーム(_Z)"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "全ての端末を復元(_R)"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "グループ化"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "スクロールバーを表示(_S)"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "エンコーディング"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "既定値"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "ユーザ定義"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "その他のエンコーディング"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "グループ%sを解除"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "全てのタブをグループ化(_r)"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "全てのグループ化を解除"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "グループ%sを閉じる"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "シェルが見つかりません"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "シェルを起動できません:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "ウィンドウ名の変更"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "新しいウィンドウのタイトルを入力..."
 
@@ -1883,12 +1741,117 @@ msgstr ""
 msgid "window"
 msgstr "ウィンドウ"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "タブ%d"
+
+#~ msgid "Current Locale"
+#~ msgstr "現在利用しているロケール"
+
+#~ msgid "Western"
+#~ msgstr "西ヨーロッパ言語"
+
+#~ msgid "Central European"
+#~ msgstr "中央ヨーロッパ言語"
+
+#~ msgid "South European"
+#~ msgstr "南ヨーロッパ言語"
+
+#~ msgid "Baltic"
+#~ msgstr "バルト語"
+
+#~ msgid "Cyrillic"
+#~ msgstr "キリル語"
+
+#~ msgid "Arabic"
+#~ msgstr "アラブ語"
+
+#~ msgid "Greek"
+#~ msgstr "ギリシア語"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "ヘブライ語 (論理表記)"
+
+#~ msgid "Hebrew"
+#~ msgstr "ヘブライ語"
+
+#~ msgid "Turkish"
+#~ msgstr "トルコ語"
+
+#~ msgid "Nordic"
+#~ msgstr "スカンジナビア語"
+
+#~ msgid "Celtic"
+#~ msgstr "ケルト語"
+
+#~ msgid "Romanian"
+#~ msgstr "ルーマニア語"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "アルメニア語"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "中国語(繁体字)"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "キリル/ロシア語"
+
+#~ msgid "Japanese"
+#~ msgstr "日本語"
+
+#~ msgid "Korean"
+#~ msgstr "韓国語"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "中国語(簡体字)"
+
+#~ msgid "Georgian"
+#~ msgstr "グルジア語"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "キリル/ウクライナ語"
+
+#~ msgid "Croatian"
+#~ msgstr "クロアチア語"
+
+#~ msgid "Hindi"
+#~ msgstr "ヒンディー語"
+
+#~ msgid "Persian"
+#~ msgstr "ペルシア語"
+
+#~ msgid "Gujarati"
+#~ msgstr "グジャラート語"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "グルムキー文字"
+
+#~ msgid "Icelandic"
+#~ msgstr "アイスランド語"
+
+#~ msgid "Vietnamese"
+#~ msgstr "ベトナム語"
+
+#~ msgid "Thai"
+#~ msgstr "タイ語"
+
+#~ msgid "Encodings"
+#~ msgstr "エンコーディング"
+
+#~ msgid "Default"
+#~ msgstr "既定値"
+
+#~ msgid "User defined"
+#~ msgstr "ユーザ定義"
+
+#~ msgid "Other Encodings"
+#~ msgstr "その他のエンコーディング"

--- a/po/jv.po
+++ b/po/jv.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Javanese (https://www.transifex.com/terminator/teams/109338/jv/)\n"
+"Language-Team: Javanese (https://www.transifex.com/terminator/teams/109338/"
+"jv/)\n"
+"Language: jv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: jv\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Akeh terminal ning sak jendelo"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Ojo tampilke pesan meneh"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Lokal saiki"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Kulonan"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Eropa Tengah"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Eropa Kidul"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltik"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrillic"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Basa Arab"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Basa Yunani"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Tampilan Ibrani"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Basa Ibrani"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Basa Turki"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordic / Eropa Lor"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtik"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Basa Rumania"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Basa Armenia"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Basa Cina tradisional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyrillic/Russian"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Basa Jepang"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Basa Korea"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Basa Cina sing disimpelake"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Basa Georgia"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cyrillic/Ukrainian"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Basa Krasia"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Basa Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Basa Persia"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Basa Gujarat"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Basa Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Basa Islandia"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Basa Vietnam"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Basa Thai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Tutup Tab"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Bahan-acuan"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Kabeh"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Profil anyar"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Totoruang anyar"
 
@@ -1594,185 +1467,169 @@ msgstr "Nggoleki:"
 msgid "Close Search bar"
 msgstr "Nutup batang panggolekan"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Ngirim email ring..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Njiplak alamat email"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Ca_ll alamat VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Njiplak alamate VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Mbukak link"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Njiplak alamat"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Dibagi H_orisonatl"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Dibagi V_ertikal"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Buka _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Buka Tab _Debug"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zum terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Mbalekno kabeh terminal-terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Ngelompokake"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Tampilake _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Nggawe Sandi"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Gawan-asline"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Pengguno didefinisikno"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Nggawe Sandi liyane"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "ngGuwaki kelompok %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_roup kabeh ning tab"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "ngGuwaki kabeh kelompok %s"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Nutupe kelompok %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Ora iso nemokake sell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,117 @@ msgstr ""
 msgid "window"
 msgstr "jendela"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "Lokal saiki"
+
+#~ msgid "Western"
+#~ msgstr "Kulonan"
+
+#~ msgid "Central European"
+#~ msgstr "Eropa Tengah"
+
+#~ msgid "South European"
+#~ msgstr "Eropa Kidul"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltik"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrillic"
+
+#~ msgid "Arabic"
+#~ msgstr "Basa Arab"
+
+#~ msgid "Greek"
+#~ msgstr "Basa Yunani"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Tampilan Ibrani"
+
+#~ msgid "Hebrew"
+#~ msgstr "Basa Ibrani"
+
+#~ msgid "Turkish"
+#~ msgstr "Basa Turki"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordic / Eropa Lor"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtik"
+
+#~ msgid "Romanian"
+#~ msgstr "Basa Rumania"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Basa Armenia"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Basa Cina tradisional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyrillic/Russian"
+
+#~ msgid "Japanese"
+#~ msgstr "Basa Jepang"
+
+#~ msgid "Korean"
+#~ msgstr "Basa Korea"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Basa Cina sing disimpelake"
+
+#~ msgid "Georgian"
+#~ msgstr "Basa Georgia"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cyrillic/Ukrainian"
+
+#~ msgid "Croatian"
+#~ msgstr "Basa Krasia"
+
+#~ msgid "Hindi"
+#~ msgstr "Basa Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Basa Persia"
+
+#~ msgid "Gujarati"
+#~ msgstr "Basa Gujarat"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Basa Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Basa Islandia"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Basa Vietnam"
+
+#~ msgid "Thai"
+#~ msgstr "Basa Thai"
+
+#~ msgid "Encodings"
+#~ msgstr "Nggawe Sandi"
+
+#~ msgid "Default"
+#~ msgstr "Gawan-asline"
+
+#~ msgid "User defined"
+#~ msgstr "Pengguno didefinisikno"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Nggawe Sandi liyane"

--- a/po/ka.po
+++ b/po/ka.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Georgian (https://www.transifex.com/terminator/teams/109338/ka/)\n"
+"Language-Team: Georgian (https://www.transifex.com/terminator/teams/109338/"
+"ka/)\n"
+"Language: ka\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ka\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "მრავალი ტერმინალები ერთ ფანჯარაში"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "მიმდინარე მოქმედება"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "დასავლეთის"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "ცენტრალური ევროპა"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "სამხრეთ ევროპული"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "ბალტიური"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "კირილიცა"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "არაბული"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "ბერძნული"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "ივრითი ვიზუალი"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "ივრითი"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "თურქული"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "სკანდინავიური"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "კელტური"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "რუმინული"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "უნიკოდი"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "სომხური"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "ჩინური ტრადიციული"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "კირილიცა/რუსული"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "იაპონური"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "კორეული"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "ჩინური გაადვილებული"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "ქართული"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "კირილიცა/უკრაინული"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "ჰორვატული"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "ჰინდი"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "სპარსული"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "გუჯარათი"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "გურმუხი"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "ისლანდიური"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "ვიეტნამური"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "ტაილანდური"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "ჩანართი"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "ჩანართის დახურვა"
 
@@ -517,7 +374,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -542,12 +399,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -653,7 +510,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -870,43 +727,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -914,437 +771,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1579,11 +1452,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "ახალი პროფილი"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "ახალი განლაგება"
 
@@ -1596,185 +1469,169 @@ msgstr "ძებნა:"
 msgid "Close Search bar"
 msgstr "ახლო ძიება ბარი"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1882,12 +1739,105 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "მიმდინარე მოქმედება"
+
+#~ msgid "Western"
+#~ msgstr "დასავლეთის"
+
+#~ msgid "Central European"
+#~ msgstr "ცენტრალური ევროპა"
+
+#~ msgid "South European"
+#~ msgstr "სამხრეთ ევროპული"
+
+#~ msgid "Baltic"
+#~ msgstr "ბალტიური"
+
+#~ msgid "Cyrillic"
+#~ msgstr "კირილიცა"
+
+#~ msgid "Arabic"
+#~ msgstr "არაბული"
+
+#~ msgid "Greek"
+#~ msgstr "ბერძნული"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "ივრითი ვიზუალი"
+
+#~ msgid "Hebrew"
+#~ msgstr "ივრითი"
+
+#~ msgid "Turkish"
+#~ msgstr "თურქული"
+
+#~ msgid "Nordic"
+#~ msgstr "სკანდინავიური"
+
+#~ msgid "Celtic"
+#~ msgstr "კელტური"
+
+#~ msgid "Romanian"
+#~ msgstr "რუმინული"
+
+#~ msgid "Unicode"
+#~ msgstr "უნიკოდი"
+
+#~ msgid "Armenian"
+#~ msgstr "სომხური"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "ჩინური ტრადიციული"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "კირილიცა/რუსული"
+
+#~ msgid "Japanese"
+#~ msgstr "იაპონური"
+
+#~ msgid "Korean"
+#~ msgstr "კორეული"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "ჩინური გაადვილებული"
+
+#~ msgid "Georgian"
+#~ msgstr "ქართული"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "კირილიცა/უკრაინული"
+
+#~ msgid "Croatian"
+#~ msgstr "ჰორვატული"
+
+#~ msgid "Hindi"
+#~ msgstr "ჰინდი"
+
+#~ msgid "Persian"
+#~ msgstr "სპარსული"
+
+#~ msgid "Gujarati"
+#~ msgstr "გუჯარათი"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "გურმუხი"
+
+#~ msgid "Icelandic"
+#~ msgstr "ისლანდიური"
+
+#~ msgid "Vietnamese"
+#~ msgstr "ვიეტნამური"
+
+#~ msgid "Thai"
+#~ msgstr "ტაილანდური"

--- a/po/kk.po
+++ b/po/kk.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Kazakh (https://www.transifex.com/terminator/teams/109338/kk/)\n"
+"Language-Team: Kazakh (https://www.transifex.com/terminator/teams/109338/"
+"kk/)\n"
+"Language: kk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: kk\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Терминатор"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Бір терезе ішінде көптік терминалдар"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Ағымдағы тіл (локализация)"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Батыс"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Орталық еуропалы"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Оңтүстік еуропалы"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Балтық"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Кириллица"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Араб"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Грек"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Түрік"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Юникод"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "табуляция"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Баптаулар"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Барлық"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Профильдер"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Жаңа профиль"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Жаңа қабат"
 
@@ -1594,185 +1467,169 @@ msgstr "Іздеу:"
 msgid "Close Search bar"
 msgstr "Іздеу панелін жабу"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "Электрондық поштаға хат _жіберу..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "Электрондық поштаны _алмастыру буферіне көшіру"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "VoIP-ге шалу"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "VoIP-ді _алмастыру буферіне көшіру"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "Cілтемені _ашу"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "Cілтемені алмастыру буферіне _көшіру"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Терезені көлбеу бөлу"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Терезені тігінен бөлу"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "Терминалды _ұлғайту"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "Барлық терминалдарды бастапқы _қалпыға әкелу"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Топтастыру"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "_Жылжыту жолағын көрсету"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Кодылау"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Қалыпты"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Пайдаланушымен анықталған"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Басқа кодылау"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "%s тобын жою"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Барлық топтарды жою"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "%s тобын жабу"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Қабықшаны табу мүмкін емес"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Қабықшаны ашу мүмкін емес:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,54 @@ msgstr ""
 msgid "window"
 msgstr "терезе"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "Ағымдағы тіл (локализация)"
+
+#~ msgid "Western"
+#~ msgstr "Батыс"
+
+#~ msgid "Central European"
+#~ msgstr "Орталық еуропалы"
+
+#~ msgid "South European"
+#~ msgstr "Оңтүстік еуропалы"
+
+#~ msgid "Baltic"
+#~ msgstr "Балтық"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Кириллица"
+
+#~ msgid "Arabic"
+#~ msgstr "Араб"
+
+#~ msgid "Greek"
+#~ msgstr "Грек"
+
+#~ msgid "Turkish"
+#~ msgstr "Түрік"
+
+#~ msgid "Unicode"
+#~ msgstr "Юникод"
+
+#~ msgid "Encodings"
+#~ msgstr "Кодылау"
+
+#~ msgid "Default"
+#~ msgstr "Қалыпты"
+
+#~ msgid "User defined"
+#~ msgstr "Пайдаланушымен анықталған"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Басқа кодылау"

--- a/po/ko.po
+++ b/po/ko.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Korean (https://www.transifex.com/terminator/teams/109338/ko/)\n"
+"Language-Team: Korean (https://www.transifex.com/terminator/teams/109338/"
+"ko/)\n"
+"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "터미네이터"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "창 하나에 터미널 여러 개 쓰기"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "터미널이 지배하는 미래 세상"
 
@@ -140,8 +141,8 @@ msgstr "터미널이 지배하는 미래 세상"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -212,168 +213,28 @@ msgstr "<big><b>여러 개의 터미널을 닫을까요?</b></big>"
 msgid ""
 "This window has several terminals open. Closing the window will also close "
 "all terminals within it."
-msgstr "이 창에는 터미널이 여러 개 열려 있습니다. 창을 닫으면 그 안의 모든 터미널이 닫히게 됩니다."
+msgstr ""
+"이 창에는 터미널이 여러 개 열려 있습니다. 창을 닫으면 그 안의 모든 터미널이 "
+"닫히게 됩니다."
 
 #: ../terminatorlib/container.py:178
 msgid ""
 "This tab has several terminals open. Closing the tab will also close all "
 "terminals within it."
-msgstr "이 탭에는 터미널이 여러 개 열려 있습니다. 탭을 닫으면 그 안의 모든 터미널이 닫히게 됩니다."
+msgstr ""
+"이 탭에는 터미널이 여러 개 열려 있습니다. 탭을 닫으면 그 안의 모든 터미널이 "
+"닫히게 됩니다."
 
 #: ../terminatorlib/container.py:198
 msgid "Do not show this message next time"
 msgstr "다음번에는 이 메시지를 표시하지 않기"
-
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "현재 로캘"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "서유럽어"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "중앙 유럽어"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "남부 유럽어"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "발트어"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "키릴어"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "아랍어"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "그리스어"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "히브리어 비주얼"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "히브리어"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "터키어"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "북유럽어"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "켈트어"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "루마니아어"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "유니코드"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "아르메니아어"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "중국어 번체"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "키릴어/러시아어"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "일본어"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "한국어"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "중국어 간체"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "그루지야어"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "키릴/우크라이나어"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "크로아티아어"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "힌디어"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "페르시아어"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "구자라트어"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "굴묵키어"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "아이슬란드어"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "베트남어"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "타이어"
 
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "형태"
 
@@ -381,11 +242,11 @@ msgstr "형태"
 msgid "Launch"
 msgstr "실행"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "탭"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "탭 닫기"
 
@@ -515,7 +376,7 @@ msgstr "사용자 정의 명령들"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "환경 설정(_P)"
 
@@ -540,12 +401,12 @@ msgid "Enabled"
 msgstr "사용"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "이름"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "명령"
 
@@ -651,7 +512,7 @@ msgid "Escape sequence"
 msgstr "이스케이프 시퀀스"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "전체"
 
@@ -868,484 +729,501 @@ msgid "Use custom URL handler"
 msgstr "사용자 URL 연결프로그램 사용하기"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "사용자 URL 연결 프로그램:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "사용자 URL 연결 프로그램:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>모양</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "창 테두리"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "비활성 터미널 폰트 밝기:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "터미널 구분자 두께:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "추가 스타일 적용 (테마에 따라 다름)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "탭 위치:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "탭들을 균일하게"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "탭 스크롤 버튼"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "일반설정"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "프로파일"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "시스템 고정폭 글꼴 사용(_U)"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "글꼴(_F):"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "터미널 글꼴 선택"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "굵은 글씨 허용(_A)"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "제목 보이기"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "선택하면 클립보드로"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "단어 단위 선택 문자(_W):"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>커서</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "모양:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "깜박이기"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "배경:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>터미널 벨</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "제목 아이콘"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "화면 깜빡거림"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "비프 음"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "창 목록 깜빡거림"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "일반 설정"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "로그인 쉘로 명령 실행(_R)"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "쉘 대신에 사용자 지정 명령 실행(_N)"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "사용자 지정 명령(_M):"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "명령이 끝날 때(_E):"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>글자색 및 바탕색</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "시스템 테마 색 사용(_U)"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "내장 색상표(_M):"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>팔레트</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "내장 색상표(_S):"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "색상표(_A)"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "색상"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "단색(_S)"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "투명 배경"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>없음</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>최대</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "배경"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "스크롤 막대 위치(_S):"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "출력이 있으면 스크롤(_O)"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "키를 누르면 스크롤(_K)"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "무제한 스크롤"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "스크롤 범위(_B):"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "줄"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "스크롤"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
-"<small><i><b>알림:</b> 다음 옵션을 켜면 일부 프로그램이 제대로 작동하지 않을 수도 있습니다. 다음 옵션은 터미널 기능을 "
-"다르게 이용하는 일부 프로그램과 운영체제의 문제를 피해가는 기능일 뿐입니다.</i></small>"
+"<small><i><b>알림:</b> 다음 옵션을 켜면 일부 프로그램이 제대로 작동하지 않을 "
+"수도 있습니다. 다음 옵션은 터미널 기능을 다르게 이용하는 일부 프로그램과 운영"
+"체제의 문제를 피해가는 기능일 뿐입니다.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "백스페이스 키를 누르면(_B):"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Delete 키를 누르면(_D):"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "인코딩:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "호환성 옵션을 기본값으로 되돌림(_R)"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "호환성"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "활성"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "비활성"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "수신 중"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "제목에 크기 감추기"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "시스템 글꼴 사용"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "제목 글꼴 선택"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "프로파일"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "유형"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "프로파일:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "사용자 지정 명령:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "작업 디렉터리:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "레이아웃"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "동작"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "단축키"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "키 설정"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "플러그인"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "이 플러그인은 옵션 설정이 없음"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "플러그인"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "설명서"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "소개"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "글꼴 크기 키우기"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "글꼴 크기 줄이기"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "원래 글꼴 크기로 돌아가기"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "새 탭 열기"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "다음 터미널로"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "이전 터미널로"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "위쪽 터미널로"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "아래쪽 터미널로"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "왼쪽 터미널로"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "오른쪽 터미널로"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "터미널들을 시계 방향으로 회전"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "터미널들을 시계 반대 방향으로 회전"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "상하로 나누기"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "좌우로 나누기"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "터미널 닫기"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "선택한 텍스트 복사"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "클립보드 붙여넣기"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1579,11 +1457,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "설명서 열기"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "새 프로파일"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "새 레이아웃"
 
@@ -1596,185 +1474,169 @@ msgstr "찾기:"
 msgid "Close Search bar"
 msgstr "검색창 닫기"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "이메일 전송(_S)..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "이메일 주소 복사(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "VoIP 주소로 전화(_L)"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "VoIP 주소 복사(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "링크 열기(_O)"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "주소 복사(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "복사(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "붙여넣기(_P)"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "상하로 나누기(_O)"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "좌우로 나누기(_E)"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "탭 열기(_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "디버깅 탭 열기(_D)"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "닫기(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "터미널 확대(_Z)"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "터미널 최대화(_X)"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "전체 터미널 복원(_R)"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "그룹화"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "스크롤 막대 표시(_S)"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "인코딩"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "기본"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "사용자 정의"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "기타 인코딩"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "새 그룹(_E)"
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "소속 없음"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "그룹 %s 지우기"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "탭 안의 모두를 그룹으로(_G)"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "탭 안의 모두를 그룹 해제(_U)"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "모든 그룹 지우기"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "그룹 %s 닫기"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "전체에게 동시 입력(_A)"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "그룹에 동시 입력(_G)"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "동시 입력 끄기(_O)"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "나눌 때 이 그룹으로(_S)"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "빈 그룹 자동 제거(_C)"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "터미널 번호 붙여넣기(_I)"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "0으로 채운 터미널 번호 붙여넣기(_P)"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "셸을 찾을 수 없음"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "셸을 시작할 수 없음:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "윈도우 이름 바꾸기"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "터미네이터 창의 새 제목을 입력하세요..."
 
@@ -1882,12 +1744,120 @@ msgstr "곤줄박이"
 msgid "window"
 msgstr "창"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "탭 %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "현재 로캘"
+
+#~ msgid "Western"
+#~ msgstr "서유럽어"
+
+#~ msgid "Central European"
+#~ msgstr "중앙 유럽어"
+
+#~ msgid "South European"
+#~ msgstr "남부 유럽어"
+
+#~ msgid "Baltic"
+#~ msgstr "발트어"
+
+#~ msgid "Cyrillic"
+#~ msgstr "키릴어"
+
+#~ msgid "Arabic"
+#~ msgstr "아랍어"
+
+#~ msgid "Greek"
+#~ msgstr "그리스어"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "히브리어 비주얼"
+
+#~ msgid "Hebrew"
+#~ msgstr "히브리어"
+
+#~ msgid "Turkish"
+#~ msgstr "터키어"
+
+#~ msgid "Nordic"
+#~ msgstr "북유럽어"
+
+#~ msgid "Celtic"
+#~ msgstr "켈트어"
+
+#~ msgid "Romanian"
+#~ msgstr "루마니아어"
+
+#~ msgid "Unicode"
+#~ msgstr "유니코드"
+
+#~ msgid "Armenian"
+#~ msgstr "아르메니아어"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "중국어 번체"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "키릴어/러시아어"
+
+#~ msgid "Japanese"
+#~ msgstr "일본어"
+
+#~ msgid "Korean"
+#~ msgstr "한국어"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "중국어 간체"
+
+#~ msgid "Georgian"
+#~ msgstr "그루지야어"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "키릴/우크라이나어"
+
+#~ msgid "Croatian"
+#~ msgstr "크로아티아어"
+
+#~ msgid "Hindi"
+#~ msgstr "힌디어"
+
+#~ msgid "Persian"
+#~ msgstr "페르시아어"
+
+#~ msgid "Gujarati"
+#~ msgstr "구자라트어"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "굴묵키어"
+
+#~ msgid "Icelandic"
+#~ msgstr "아이슬란드어"
+
+#~ msgid "Vietnamese"
+#~ msgstr "베트남어"
+
+#~ msgid "Thai"
+#~ msgstr "타이어"
+
+#~ msgid "Encoding:"
+#~ msgstr "인코딩:"
+
+#~ msgid "Encodings"
+#~ msgstr "인코딩"
+
+#~ msgid "Default"
+#~ msgstr "기본"
+
+#~ msgid "User defined"
+#~ msgstr "사용자 정의"
+
+#~ msgid "Other Encodings"
+#~ msgstr "기타 인코딩"

--- a/po/ku.po
+++ b/po/ku.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Kurdish (https://www.transifex.com/terminator/teams/109338/ku/)\n"
+"Language-Team: Kurdish (https://www.transifex.com/terminator/teams/109338/"
+"ku/)\n"
+"Language: ku\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ku\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Herêma derbasdar"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Rojavayî"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Ewropaya Navînî"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Ewropaya Başûrî"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltîkî"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kîrîlî"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Erebî"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Yûnanî"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Îbraniya Dîtbarî"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Îbranî"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Tirkî"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordîk"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltî"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romanî"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Ermenî"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Çîniya Kevneşopî"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kîrîlî/Rûsî"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonî"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreyî"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Çîniya Hêsankirî"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gurcî"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kîrîlî/Ûkraynî"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroatî"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindî"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Farisî"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gucaratî"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmuxî"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Îzlandî"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamî"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Taî"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Bicihkirin"
 
@@ -381,11 +238,11 @@ msgstr "Bicihkirin"
 msgid "Launch"
 msgstr "Destpêke"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Hilpekinê Dade"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Vebijark"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr "Çalake"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Nav"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Ferman"
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Giştî"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Xuyabûn</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
+msgid "Tabs scroll buttons"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Gerdûnî"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profîl"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "Bi curenivîsan re peytandiya pergalê bi kar bîne"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Cureyê nivîsê:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Ji Bo Termînalê Curenivîsekê Hilbijêre"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Destûrê bide nivîsa stûr"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Rûerd:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
+msgid "Focused"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Neçalak"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Tê wergirtin"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,105 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "Herêma derbasdar"
+
+#~ msgid "Western"
+#~ msgstr "Rojavayî"
+
+#~ msgid "Central European"
+#~ msgstr "Ewropaya Navînî"
+
+#~ msgid "South European"
+#~ msgstr "Ewropaya Başûrî"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltîkî"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kîrîlî"
+
+#~ msgid "Arabic"
+#~ msgstr "Erebî"
+
+#~ msgid "Greek"
+#~ msgstr "Yûnanî"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Îbraniya Dîtbarî"
+
+#~ msgid "Hebrew"
+#~ msgstr "Îbranî"
+
+#~ msgid "Turkish"
+#~ msgstr "Tirkî"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordîk"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltî"
+
+#~ msgid "Romanian"
+#~ msgstr "Romanî"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Ermenî"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Çîniya Kevneşopî"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kîrîlî/Rûsî"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonî"
+
+#~ msgid "Korean"
+#~ msgstr "Koreyî"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Çîniya Hêsankirî"
+
+#~ msgid "Georgian"
+#~ msgstr "Gurcî"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kîrîlî/Ûkraynî"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroatî"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindî"
+
+#~ msgid "Persian"
+#~ msgstr "Farisî"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gucaratî"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmuxî"
+
+#~ msgid "Icelandic"
+#~ msgstr "Îzlandî"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamî"
+
+#~ msgid "Thai"
+#~ msgstr "Taî"

--- a/po/la.po
+++ b/po/la.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Latin (https://www.transifex.com/terminator/teams/109338/la/)\n"
+"Language-Team: Latin (https://www.transifex.com/terminator/teams/109338/"
+"la/)\n"
+"Language: la\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: la\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Lingua Arabica"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Lingua Graeca"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Lingua Hebraica"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Lingua Turcica"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Lingua Dacoromana"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Lingua Iaponica"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Lingua Coreana"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Lingua Croatica"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,39 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Arabic"
+#~ msgstr "Lingua Arabica"
+
+#~ msgid "Greek"
+#~ msgstr "Lingua Graeca"
+
+#~ msgid "Hebrew"
+#~ msgstr "Lingua Hebraica"
+
+#~ msgid "Turkish"
+#~ msgstr "Lingua Turcica"
+
+#~ msgid "Romanian"
+#~ msgstr "Lingua Dacoromana"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Japanese"
+#~ msgstr "Lingua Iaponica"
+
+#~ msgid "Korean"
+#~ msgstr "Lingua Coreana"
+
+#~ msgid "Croatian"
+#~ msgstr "Lingua Croatica"

--- a/po/lt.po
+++ b/po/lt.po
@@ -2,24 +2,27 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Lithuanian (https://www.transifex.com/terminator/teams/109338/lt/)\n"
+"Language-Team: Lithuanian (https://www.transifex.com/terminator/teams/109338/"
+"lt/)\n"
+"Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lt\n"
-"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < 11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? 1 : n % 1 != 0 ? 2: 3);\n"
+"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < "
+"11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
+"1 : n % 1 != 0 ? 2: 3);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -123,7 +126,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +135,7 @@ msgid "Multiple terminals in one window"
 msgstr "Keli terminalai viename lange"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +143,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +227,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Dabartinė lokalė"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Vakarų"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Centrinės Europos"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Pietų Europos"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltų"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kirilica"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabų"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Graikų"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebrajų vizuali"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebrajų"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turkų"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Skandinavų"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltų"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumunų"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unikodas"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armėnų"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Kinų tradicinė"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kirilica/Rusų"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonų"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korėjiečių"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Kinų supaprastinta"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gruzinų"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kirilica/Ukrainiečių"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroatų"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persų"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gudžarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandų"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamiečių"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tajų"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +240,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "kortelė"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Užverti kortelę"
 
@@ -517,7 +376,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Nustatymai"
 
@@ -542,12 +401,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -653,7 +512,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Visi"
 
@@ -870,43 +729,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -914,437 +773,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiliai"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1579,11 +1454,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Naujas profilis"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Naujas išdėstymas"
 
@@ -1596,185 +1471,169 @@ msgstr "Ieškoti:"
 msgid "Close Search bar"
 msgstr "Užverti paieškos juostą"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Siųsti el. laišką į..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopijuoti el. pašto adresą"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Ska_mbinti VoIP adresui"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopijuoti VoIP adresą"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Atverti nuorodą"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopijuoti adresą"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Padalinti H_orizontaliai"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Padalinti V_ertikaliai"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Atverti _kortelę"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Atverti _derinimo kortelę"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Padidinti terminalą"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Atkurti visus terminalus"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Grupavimas"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Rodyti _slinkties juostą"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Koduotės"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Numatytoji"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Naudotojo nustatyta"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Kitos koduotės"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Šalinti grupę %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_rupuoti visus kortelėje"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Pašalinti visas grupes"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Uždaryti grupę %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Nepavyksta rasti komandų interpretatoriaus"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Nepavyksta paleisti komandų interpretatoriaus:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1882,12 +1741,117 @@ msgstr ""
 msgid "window"
 msgstr "langas"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Kortelė %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Dabartinė lokalė"
+
+#~ msgid "Western"
+#~ msgstr "Vakarų"
+
+#~ msgid "Central European"
+#~ msgstr "Centrinės Europos"
+
+#~ msgid "South European"
+#~ msgstr "Pietų Europos"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltų"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kirilica"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabų"
+
+#~ msgid "Greek"
+#~ msgstr "Graikų"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebrajų vizuali"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebrajų"
+
+#~ msgid "Turkish"
+#~ msgstr "Turkų"
+
+#~ msgid "Nordic"
+#~ msgstr "Skandinavų"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltų"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumunų"
+
+#~ msgid "Unicode"
+#~ msgstr "Unikodas"
+
+#~ msgid "Armenian"
+#~ msgstr "Armėnų"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Kinų tradicinė"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kirilica/Rusų"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonų"
+
+#~ msgid "Korean"
+#~ msgstr "Korėjiečių"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Kinų supaprastinta"
+
+#~ msgid "Georgian"
+#~ msgstr "Gruzinų"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kirilica/Ukrainiečių"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroatų"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persų"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gudžarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandų"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamiečių"
+
+#~ msgid "Thai"
+#~ msgstr "Tajų"
+
+#~ msgid "Encodings"
+#~ msgstr "Koduotės"
+
+#~ msgid "Default"
+#~ msgstr "Numatytoji"
+
+#~ msgid "User defined"
+#~ msgstr "Naudotojo nustatyta"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Kitos koduotės"

--- a/po/lv.po
+++ b/po/lv.po
@@ -2,24 +2,26 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Latvian (https://www.transifex.com/terminator/teams/109338/lv/)\n"
+"Language-Team: Latvian (https://www.transifex.com/terminator/teams/109338/"
+"lv/)\n"
+"Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lv\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -123,7 +125,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +134,7 @@ msgid "Multiple terminals in one window"
 msgstr "Daudzi termināļi vienā logā"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +142,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +226,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Pašreizējā lokāle"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Rietumu"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Centrāleiropiešu"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Dienvideiropiešu"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltijas"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kirilicas"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arābu"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grieķu"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Ivrita vizuālais"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Ebreju"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turku"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Skandināvu"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Ķeltu"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumāņu"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unikods"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armēņu"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Ķīniešu Tradicionālā"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kirilica/Krievu"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japāņu"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korejiešu"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Ķīniešu vienkāršotā"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gruzīnu"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kirilica/Ukraiņu"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Horvātu"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindu"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persiešu"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujaratu"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmuku"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Īslandiešu"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vjetnamiešu"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Taizemiešu"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +239,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Aizvērt cilni"
 
@@ -515,7 +373,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Iestatījumi"
 
@@ -540,12 +398,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +509,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Visi"
 
@@ -868,43 +726,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +770,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1451,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Jauns profils"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Jauns slānis"
 
@@ -1594,185 +1468,169 @@ msgstr "Meklēt:"
 msgid "Close Search bar"
 msgstr "Aizvērt meklešanas joslu"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Sūtīt e-pastu uz..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopēt e-pasta adresi"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_Zvanīt uz VoIP addresi"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopēt VoIP adresi"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Atvērt saiti"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopēt adresi"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Pārdalīt h_orizontāli"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Sadalīt v_ertikāli"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Atvērt _Cilni"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Atvērt atkļū_došanas cilni"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Tuvināt termināli"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "Atjaunot visus te_rmināļus"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Grupēšana"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Rādīt ritjo_slu"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kodējumi"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Noklusētais"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Lietotāja definēts"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Citi kodējumi"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Dzēst grupu %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_rupēt visu cilnē"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Dzēst visas grupas"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Aizvērt grupu %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Nav iespējams atrast čaulu"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Nav iespējams palaist čaulu:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1738,117 @@ msgstr ""
 msgid "window"
 msgstr "logs"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Cilne %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Pašreizējā lokāle"
+
+#~ msgid "Western"
+#~ msgstr "Rietumu"
+
+#~ msgid "Central European"
+#~ msgstr "Centrāleiropiešu"
+
+#~ msgid "South European"
+#~ msgstr "Dienvideiropiešu"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltijas"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kirilicas"
+
+#~ msgid "Arabic"
+#~ msgstr "Arābu"
+
+#~ msgid "Greek"
+#~ msgstr "Grieķu"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Ivrita vizuālais"
+
+#~ msgid "Hebrew"
+#~ msgstr "Ebreju"
+
+#~ msgid "Turkish"
+#~ msgstr "Turku"
+
+#~ msgid "Nordic"
+#~ msgstr "Skandināvu"
+
+#~ msgid "Celtic"
+#~ msgstr "Ķeltu"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumāņu"
+
+#~ msgid "Unicode"
+#~ msgstr "Unikods"
+
+#~ msgid "Armenian"
+#~ msgstr "Armēņu"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Ķīniešu Tradicionālā"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kirilica/Krievu"
+
+#~ msgid "Japanese"
+#~ msgstr "Japāņu"
+
+#~ msgid "Korean"
+#~ msgstr "Korejiešu"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Ķīniešu vienkāršotā"
+
+#~ msgid "Georgian"
+#~ msgstr "Gruzīnu"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kirilica/Ukraiņu"
+
+#~ msgid "Croatian"
+#~ msgstr "Horvātu"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindu"
+
+#~ msgid "Persian"
+#~ msgstr "Persiešu"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujaratu"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmuku"
+
+#~ msgid "Icelandic"
+#~ msgstr "Īslandiešu"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vjetnamiešu"
+
+#~ msgid "Thai"
+#~ msgstr "Taizemiešu"
+
+#~ msgid "Encodings"
+#~ msgstr "Kodējumi"
+
+#~ msgid "Default"
+#~ msgstr "Noklusētais"
+
+#~ msgid "User defined"
+#~ msgstr "Lietotāja definēts"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Citi kodējumi"

--- a/po/mk.po
+++ b/po/mk.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Macedonian (https://www.transifex.com/terminator/teams/109338/mk/)\n"
+"Language-Team: Macedonian (https://www.transifex.com/terminator/teams/109338/"
+"mk/)\n"
+"Language: mk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: mk\n"
 "Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Терминатор"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Повеќе терминали во еден прозорец"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Тековен локал"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Западен"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Централно Европски"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Јужно Европски"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Балтички"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Кирилица"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Арапски"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Грчки"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Хебрејски Визуелен"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Хебрејски"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Турски"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Нордиски"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Келтски"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Романски"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Уникод"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Ерменски"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Традиционален Кинески"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Кирилица/Руски"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Јапонски"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Корејски"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Упростен Кинески"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Грузијски"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Кирилица/Украински"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Хрватски"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Индиски"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Персиски"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Гуџарати"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Гурмукхи"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Исландски"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Виетнамски"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Таи"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "табулатор"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Затвори јазиче"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Опции"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Сѐ"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Профили"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Нов профил"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Нов распоред"
 
@@ -1594,185 +1467,169 @@ msgstr "Барање:"
 msgid "Close Search bar"
 msgstr "Затвори го полето за пребарување"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Прати е-пошта на..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Копирај ја адресата на е-пошта"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "По_викај VoIP адреса"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Копирај VoIP адреса"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Отвори врска"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Копирај адреса"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Подели хо_ризонтално"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Подели вер_тикално"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Отвори _јазиче"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Отвори _јазиче за отстранување грешки"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_зумирај терминал"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Врати ги сите терминали"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Групирање"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Покажи _лизгач"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Шифрирања"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Стандардно"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Кориснички дефенирано"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Други шифрирања"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Избриши ја групата %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Г_рупирај ги сите во табови"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Избриши ги сите групи"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Затвори група %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Неспособен да најде обвивка"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,117 @@ msgstr ""
 msgid "window"
 msgstr "прозорец"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Табот %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Тековен локал"
+
+#~ msgid "Western"
+#~ msgstr "Западен"
+
+#~ msgid "Central European"
+#~ msgstr "Централно Европски"
+
+#~ msgid "South European"
+#~ msgstr "Јужно Европски"
+
+#~ msgid "Baltic"
+#~ msgstr "Балтички"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Кирилица"
+
+#~ msgid "Arabic"
+#~ msgstr "Арапски"
+
+#~ msgid "Greek"
+#~ msgstr "Грчки"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Хебрејски Визуелен"
+
+#~ msgid "Hebrew"
+#~ msgstr "Хебрејски"
+
+#~ msgid "Turkish"
+#~ msgstr "Турски"
+
+#~ msgid "Nordic"
+#~ msgstr "Нордиски"
+
+#~ msgid "Celtic"
+#~ msgstr "Келтски"
+
+#~ msgid "Romanian"
+#~ msgstr "Романски"
+
+#~ msgid "Unicode"
+#~ msgstr "Уникод"
+
+#~ msgid "Armenian"
+#~ msgstr "Ерменски"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Традиционален Кинески"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Кирилица/Руски"
+
+#~ msgid "Japanese"
+#~ msgstr "Јапонски"
+
+#~ msgid "Korean"
+#~ msgstr "Корејски"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Упростен Кинески"
+
+#~ msgid "Georgian"
+#~ msgstr "Грузијски"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Кирилица/Украински"
+
+#~ msgid "Croatian"
+#~ msgstr "Хрватски"
+
+#~ msgid "Hindi"
+#~ msgstr "Индиски"
+
+#~ msgid "Persian"
+#~ msgstr "Персиски"
+
+#~ msgid "Gujarati"
+#~ msgstr "Гуџарати"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Гурмукхи"
+
+#~ msgid "Icelandic"
+#~ msgstr "Исландски"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Виетнамски"
+
+#~ msgid "Thai"
+#~ msgstr "Таи"
+
+#~ msgid "Encodings"
+#~ msgstr "Шифрирања"
+
+#~ msgid "Default"
+#~ msgstr "Стандардно"
+
+#~ msgid "User defined"
+#~ msgstr "Кориснички дефенирано"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Други шифрирања"

--- a/po/ml.po
+++ b/po/ml.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Malayalam (https://www.transifex.com/terminator/teams/109338/ml/)\n"
+"Language-Team: Malayalam (https://www.transifex.com/terminator/teams/109338/"
+"ml/)\n"
+"Language: ml\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ml\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "ടെര്‍മിനേറ്റര്‍"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "ഒരു ജാലകത്തില്‍ ഒന്നിലധികം ടെര്‍മിനലുകള്‍"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "നിലവിലുളള ലോക്കെയില്‍"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "പടിഞ്ഞാറന്‍"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "മധ്യയൂറോപ്പ്യന്‍"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "ദക്ഷിണയൂറോപ്പ്യന്‍"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "ബാള്‍ട്ടിക്"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "സിറിലിക്"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "അറബിക്"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "ഗ്രീക്ക്"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "ഹീബ്രു വിഷ്വല്‍"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "ഹീബ്രൂ"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "ടര്‍ക്കിഷ്"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "നോര്‍ഡിക്"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "സെല്‍റ്റിക്"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "റൊമേനിയന്‍"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "യൂണികോഡ്"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "അര്‍മേനിയന്‍"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "പരമ്പരാഗത ചൈനീസ്"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "സിറില്ലിക്ക്/റഷ്യന്‍"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "ജാപ്പനീസ്"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "കൊറിയന്‍"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "ലളിതമാക്കിയ ചൈനീസ്"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "ജോര്‍ജ്യന്‍"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "സിറിളിക്/ഉക്രേനിയന്‍"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "ക്രൊയേഷ്യന്‍"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "ഹിന്ദി"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "പേര്‍ഷ്യന്‍"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "ഗുജറാത്തി"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "ഗുര്‍മുഖി"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "ഐസ്‌ലൈന്‍ഡിക്"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "വിയറ്റ്നാമീസ്"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "തായി"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "ലേഔട്ട്"
 
@@ -381,11 +238,11 @@ msgstr "ലേഔട്ട്"
 msgid "Launch"
 msgstr "തുടങ്ങുക"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "ടാബ്"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "റ്റാബ് അടയ്‍ക്കുക"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "പുതിയ പ്രൊഫൈല്‍"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr "തിരയുക:"
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,105 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "നിലവിലുളള ലോക്കെയില്‍"
+
+#~ msgid "Western"
+#~ msgstr "പടിഞ്ഞാറന്‍"
+
+#~ msgid "Central European"
+#~ msgstr "മധ്യയൂറോപ്പ്യന്‍"
+
+#~ msgid "South European"
+#~ msgstr "ദക്ഷിണയൂറോപ്പ്യന്‍"
+
+#~ msgid "Baltic"
+#~ msgstr "ബാള്‍ട്ടിക്"
+
+#~ msgid "Cyrillic"
+#~ msgstr "സിറിലിക്"
+
+#~ msgid "Arabic"
+#~ msgstr "അറബിക്"
+
+#~ msgid "Greek"
+#~ msgstr "ഗ്രീക്ക്"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "ഹീബ്രു വിഷ്വല്‍"
+
+#~ msgid "Hebrew"
+#~ msgstr "ഹീബ്രൂ"
+
+#~ msgid "Turkish"
+#~ msgstr "ടര്‍ക്കിഷ്"
+
+#~ msgid "Nordic"
+#~ msgstr "നോര്‍ഡിക്"
+
+#~ msgid "Celtic"
+#~ msgstr "സെല്‍റ്റിക്"
+
+#~ msgid "Romanian"
+#~ msgstr "റൊമേനിയന്‍"
+
+#~ msgid "Unicode"
+#~ msgstr "യൂണികോഡ്"
+
+#~ msgid "Armenian"
+#~ msgstr "അര്‍മേനിയന്‍"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "പരമ്പരാഗത ചൈനീസ്"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "സിറില്ലിക്ക്/റഷ്യന്‍"
+
+#~ msgid "Japanese"
+#~ msgstr "ജാപ്പനീസ്"
+
+#~ msgid "Korean"
+#~ msgstr "കൊറിയന്‍"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "ലളിതമാക്കിയ ചൈനീസ്"
+
+#~ msgid "Georgian"
+#~ msgstr "ജോര്‍ജ്യന്‍"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "സിറിളിക്/ഉക്രേനിയന്‍"
+
+#~ msgid "Croatian"
+#~ msgstr "ക്രൊയേഷ്യന്‍"
+
+#~ msgid "Hindi"
+#~ msgstr "ഹിന്ദി"
+
+#~ msgid "Persian"
+#~ msgstr "പേര്‍ഷ്യന്‍"
+
+#~ msgid "Gujarati"
+#~ msgstr "ഗുജറാത്തി"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "ഗുര്‍മുഖി"
+
+#~ msgid "Icelandic"
+#~ msgstr "ഐസ്‌ലൈന്‍ഡിക്"
+
+#~ msgid "Vietnamese"
+#~ msgstr "വിയറ്റ്നാമീസ്"
+
+#~ msgid "Thai"
+#~ msgstr "തായി"

--- a/po/mr.po
+++ b/po/mr.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Marathi (https://www.transifex.com/terminator/teams/109338/mr/)\n"
+"Language-Team: Marathi (https://www.transifex.com/terminator/teams/109338/"
+"mr/)\n"
+"Language: mr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: mr\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,12 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/ms.po
+++ b/po/ms.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Malay (https://www.transifex.com/terminator/teams/109338/ms/)\n"
+"Language-Team: Malay (https://www.transifex.com/terminator/teams/109338/"
+"ms/)\n"
+"Language: ms\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ms\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -128,7 +129,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -137,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Kesemua terminal dalam satu tetingkap"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Terminal dari robot masa hadapan"
 
@@ -145,8 +146,8 @@ msgstr "Terminal dari robot masa hadapan"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -179,8 +180,7 @@ msgstr "Lebih banyak pintasan papan kekunci"
 
 #: ../data/terminator.appdata.xml.in.h:11
 msgid "Save multiple layouts and profiles via GUI preferences editor"
-msgstr ""
-"Simpan bentangan dan profil berbilang melalui penyunting keutamaan GUI"
+msgstr "Simpan bentangan dan profil berbilang melalui penyunting keutamaan GUI"
 
 #: ../data/terminator.appdata.xml.in.h:12
 msgid "Simultaneous typing to arbitrary groups of terminals"
@@ -230,156 +230,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Jangan papar mesej ini dilain kali"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Lokaliti Semasa"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Barat"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Eropah Tengah"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Eropah Selatan"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltik"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyril"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Bahasa Arab"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Bahasa Yunani"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Paparan Ibrani"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Bahasa Ibrani"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Bahasa Turki"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordic"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtic"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romania"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Bahasa Armenia"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Bahasa Cina Tradisi"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyril/Rusia"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Jepun"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Bahasa Korea"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Tulisan Cina Baru"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgia"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cyril/Ukraine"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croatia"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Parsi"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhī"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Iceland"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnam"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Bahasa Thailand"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Pelancar Bentangan Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Bentangan"
 
@@ -387,11 +243,11 @@ msgstr "Bentangan"
 msgid "Launch"
 msgstr "Lancar"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Tutup Tab"
 
@@ -474,8 +330,7 @@ msgstr "Lumpuhkan DBas"
 
 #: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
-msgstr ""
-"Benarkan maklumat penyahpepijatan (dua kali untuk pelayan nyahpepijat)"
+msgstr "Benarkan maklumat penyahpepijatan (dua kali untuk pelayan nyahpepijat)"
 
 #: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
@@ -525,7 +380,7 @@ msgstr "Perintah _Suai"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Keutamaan"
 
@@ -550,12 +405,12 @@ msgid "Enabled"
 msgstr "Dibenarkan"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Nama"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Perintah"
 
@@ -661,7 +516,7 @@ msgid "Escape sequence"
 msgstr "Jujukan Esc"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Semua"
 
@@ -878,489 +733,513 @@ msgid "Use custom URL handler"
 msgstr "Guna pengendali URL suai"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Pengendali URL suai:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Pengendali URL suai:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Penampilan</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Sempadan tetingkap"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Kecerahan fon terminal tidak fokus:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Saiz pemisah terminal:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Kedudukan tab:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Kehomogenan tab"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Butang tatal tab"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Sejagat"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Guna fon lebar-tetap sistem"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Fon:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Pilih Fon Terminal"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Benarkan teks tebal"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Papar palang tajuk"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Salin ke pemilihan"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Aksara _dipilih-ikut-perkataan:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Kursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Bentuk:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Kelip"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Latar Belakang:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "b>Loceng terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Ikon palang tajuk"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Denyar visual"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Bip boleh dengar"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Denyar senarai tetingkap"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Am"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Jalan perintah shell daftar masuk"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Jala_n perintah suai selain daripada shell"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Perintah s_uai:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Bila perintah _tamat:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Latar Hadapan dan Latar Belakang</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Guna warna mengikut tema sistem"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Skema terbina-dalam:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "_Skema terbina-dalam:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Warna p_alet:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Warna"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "Warna _tegar"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Latar belakang lutsinar"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Tiada</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Latar belakang"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "Palang tata_l adalah:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Tatal pada _output"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Tatal pada _ketukan kekunci"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Tatal Kembali Tak Terhingga"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Tatar _kembali:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "baris"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Penatalan"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Nota:</b> Pilihan ini akan menyebabkan sebahagian applikasi "
 "tidak berfungsi dengan sempurna. Ia membolehkan anda untuk bekerja di "
 "sekitar aplikasi dan sistem operasi tertentu yang mempunyai perilaku "
 "terminal yang berbeza.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Kekunci _Backspace menjana:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Kekunci _Del menjana:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Tetap semula pilihan keserasian kepada Lalai"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Keserasian"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Terfokus"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Tidak Aktif"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Penerimaan"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Sembunyi saiz dari tajuk"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "G_una fon sistem"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Pilih Fon Palang Tajuk"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Jenis"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Perintah suai:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Direktori kerja:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Bentangan"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Tindakan"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Pengikatan kekunci"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Pengikatan kekunci"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Pemalam"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Pemalam ini tidak mempunyai pilihan konfigurasi"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Pemalam"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Matlamat projek ini adalah untuk menghasilkan satu alat yang berguna untuk penyusunan terminal. Ia diilham dariy program seperti gnome-multi-term, quadkonsole, dan lain-lain. dan fokus utama adalah menyusun terminal dalam bentuk grid (tab masih menjadi kaedah lalai paling umum, yang juga disokong oleh Terminator).\n"
+"Matlamat projek ini adalah untuk menghasilkan satu alat yang berguna untuk "
+"penyusunan terminal. Ia diilham dariy program seperti gnome-multi-term, "
+"quadkonsole, dan lain-lain. dan fokus utama adalah menyusun terminal dalam "
+"bentuk grid (tab masih menjadi kaedah lalai paling umum, yang juga disokong "
+"oleh Terminator).\n"
 "\n"
-"Kebanyakan kelakuan Terminator adalah berdasarkan dari Terminal GNOME, dan kami telah menambah lagi fiitur serta melanjutkan dalam arah berbeza bersama-sama fitur berguna untuk pentadbir dan pengguna biasa. Jika anda mempunyai apa juag cadangan, sila failkan pepijat senarai idaman! (sila rujuk ke pautan Pembangunan)"
+"Kebanyakan kelakuan Terminator adalah berdasarkan dari Terminal GNOME, dan "
+"kami telah menambah lagi fiitur serta melanjutkan dalam arah berbeza bersama-"
+"sama fitur berguna untuk pentadbir dan pengguna biasa. Jika anda mempunyai "
+"apa juag cadangan, sila failkan pepijat senarai idaman! (sila rujuk ke "
+"pautan Pembangunan)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "Panduan"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Perihal"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Besarkan saiz fon"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Kecilkan saiz fon"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Pulih saiz fon asal"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Cipta tab baharu"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Fokus terminal berikutnya"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Fokus terminal terdahulu"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Fokus terminal di atas"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Fokus terminal di bawah"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Fokus terminal di kiri"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Fokus terminal di kanan"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Putar terminal mengikut jam"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Putar terminal melawan jam"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Pisah secara mengufuk"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Pisah secara menegak"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Tutup terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Salin teks terpilih"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Tampal papan keratan"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1594,11 +1473,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Buka panduan"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Profil Baru"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Bentangan Baru"
 
@@ -1611,185 +1490,169 @@ msgstr "Gelintar:"
 msgid "Close Search bar"
 msgstr "Tutup palang Gelintar"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Hantar emel ke..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Salin alamat emel"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "P_anggil alamat VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Salin alamat VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Buka pautan"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Salin alamat"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "Sa_lin"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "Tam_pal"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Bahagikan secara Mencancang"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "bahagikan secara Mendatar"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Buka _Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Buka _Debug Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Tutup"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Besarkan terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Pulih semua terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Pengumpulan"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Papar _scrollbar"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Mengenkodkan"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Lalai"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Ditakrif pengguna"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Pengenkodan Lain"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "Kumpulan _baharu..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Tiada"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Buang kumpulan %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "K_umpul semua dalam tab"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "N_yahkumpul semua dalam tab"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Buang semua kumpulan"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Tutup kumpulan %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Siar semu_a"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Siar _kumpulan"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Siaran _mati"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "_Pisah ke kumpulan ini"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Auto-k_osongkan kumpulan"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "S_isip bilangan terminal"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Sisip bilangan terminal ter_padat"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Gagal mencari shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Tidak boleh mulakan shell:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Nama Semula Tetingkap"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Masukkan tajuk baru untuk tetingkap Terminator..."
 
@@ -1897,12 +1760,117 @@ msgstr "Omega"
 msgid "window"
 msgstr "tetingkap"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Lokaliti Semasa"
+
+#~ msgid "Western"
+#~ msgstr "Barat"
+
+#~ msgid "Central European"
+#~ msgstr "Eropah Tengah"
+
+#~ msgid "South European"
+#~ msgstr "Eropah Selatan"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltik"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyril"
+
+#~ msgid "Arabic"
+#~ msgstr "Bahasa Arab"
+
+#~ msgid "Greek"
+#~ msgstr "Bahasa Yunani"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Paparan Ibrani"
+
+#~ msgid "Hebrew"
+#~ msgstr "Bahasa Ibrani"
+
+#~ msgid "Turkish"
+#~ msgstr "Bahasa Turki"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordic"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtic"
+
+#~ msgid "Romanian"
+#~ msgstr "Romania"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Bahasa Armenia"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Bahasa Cina Tradisi"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyril/Rusia"
+
+#~ msgid "Japanese"
+#~ msgstr "Jepun"
+
+#~ msgid "Korean"
+#~ msgstr "Bahasa Korea"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Tulisan Cina Baru"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgia"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cyril/Ukraine"
+
+#~ msgid "Croatian"
+#~ msgstr "Croatia"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Parsi"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhī"
+
+#~ msgid "Icelandic"
+#~ msgstr "Iceland"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnam"
+
+#~ msgid "Thai"
+#~ msgstr "Bahasa Thailand"
+
+#~ msgid "Encodings"
+#~ msgstr "Mengenkodkan"
+
+#~ msgid "Default"
+#~ msgstr "Lalai"
+
+#~ msgid "User defined"
+#~ msgstr "Ditakrif pengguna"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Pengenkodan Lain"

--- a/po/nb.po
+++ b/po/nb.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Norwegian Bokmål (https://www.transifex.com/terminator/teams/109338/nb/)\n"
+"Language-Team: Norwegian Bokmål (https://www.transifex.com/terminator/"
+"teams/109338/nb/)\n"
+"Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -126,7 +127,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -135,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Flere terminaler i ett vindu"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -143,8 +144,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -227,156 +228,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Ikke vis denne meldingen neste gang"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Nåværende lokale"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Vestlig"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Sentral-Europeisk"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Syd-europeisk"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltisk"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kyrillisk"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabisk"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Gresk"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Visuell hebraisk"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebraisk"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Tyrkisk"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordisk"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltisk"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumensk"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armensk"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Tradisjonell kinesisk"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kyrillisk/russisk"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japansk"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreansk"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Forenklet kinesisk"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgiansk"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kyrillisk/ukrainsk"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroatisk"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persisk"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandsk"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamesisk"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -384,11 +241,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "fane"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Lukk fane"
 
@@ -521,7 +378,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Innstillinger"
 
@@ -546,12 +403,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Kommando"
 
@@ -657,7 +514,7 @@ msgid "Escape sequence"
 msgstr "Escape-sekvens"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Alle"
 
@@ -874,43 +731,43 @@ msgid "Use custom URL handler"
 msgstr "Bruk selvvalgt behandling av nettadresser"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
+msgid "<b>Appearance</b>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Vindusrammer"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -918,442 +775,458 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
+msgid "Tabs scroll buttons"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Globalt"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Bruk systemets skrift med fast bredde"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Skrifttype:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Velg en skrifttype for terminalen"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Tillat uthevet tekst"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Vis tittellinje"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Kopier ved utvalg"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Velg-etter-_ord tegn:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Markør</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Varsellyd i terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Ikon i tittelinje"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Visuelt blink"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Hørbart pip"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Vindusliste blink"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Generelt"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Kjør kommandoen som et innloggingsskall"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Kjør sel_vvalgt kommando i stedet for skallet"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Selvvalgt ko_mmando:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Når kommandoen _avslutter:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Forgrunn og bakgrunn</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "Br_uk farger fra systemtemaet"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Innebygde oppsett:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Palett</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Innebygde opp_sett:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Fargep_alett:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Farger"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Helfylt farge"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Gjennomsik_tig bakgrunn"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ingen</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Bakgrunn"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Rullefeltet er:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Rull når noe skjer i terminalen"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Rull ned ved tastetry_kk"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Uendelig tilbakerulling"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Til_bakerulling:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "linjer"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Rulling"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Merk:</b> Disse brukervalgene kan forårsake at noen programmer "
 "ikke fungerer som de skal.  Valgene er gjort tilgjengelige for å "
 "tilfredsstille visse programmer og operativsystemer som forventer at "
-"terminaler fungerer annerledes enn dette programmet gjør som "
-"standard.</i></small>"
+"terminaler fungerer annerledes enn dette programmet gjør som standard.</i></"
+"small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Rettetasten genererer:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "_Delete-tasten genererer:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Sett kompatibilitetsalternativene til standard"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiler"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Utforminger"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Tastaturbindinger"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Dette programtillegget har ingen tilgjengelige brukervalg"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Programtillegg"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1588,11 +1461,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Ny Profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Ny Side"
 
@@ -1605,185 +1478,169 @@ msgstr "Søk:"
 msgid "Close Search bar"
 msgstr "Lukk Søk"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Send email til..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopier email adresse"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Ca_ll VoIP addresse"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopier VoIP adresse"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Åpne link"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopier adresse"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Kopier"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "_Lim inn"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Splitt H_orisontalt"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Splitt V_ertikalt"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Åpne _Fane"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Åpne :Debug Tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zoom inn på terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Gjenoppta alle terminaler"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Gruppering"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Vis _rullefelt"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Tegnkodinger"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Standard"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Brukerdefinert"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Andre tegnkodinger"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Fjern gruppe %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_ruppe alle i tab"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Fjern alle grupper"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Lukk gruppe %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Klarer ikke å finne et skall"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Kan ikke starte shell:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Gi nytt navn til vinduet"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Skriv en ny tittel på Terminator-vinduet..."
 
@@ -1891,12 +1748,117 @@ msgstr ""
 msgid "window"
 msgstr "vindu"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Nåværende lokale"
+
+#~ msgid "Western"
+#~ msgstr "Vestlig"
+
+#~ msgid "Central European"
+#~ msgstr "Sentral-Europeisk"
+
+#~ msgid "South European"
+#~ msgstr "Syd-europeisk"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltisk"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kyrillisk"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabisk"
+
+#~ msgid "Greek"
+#~ msgstr "Gresk"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Visuell hebraisk"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebraisk"
+
+#~ msgid "Turkish"
+#~ msgstr "Tyrkisk"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordisk"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltisk"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumensk"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armensk"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Tradisjonell kinesisk"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kyrillisk/russisk"
+
+#~ msgid "Japanese"
+#~ msgstr "Japansk"
+
+#~ msgid "Korean"
+#~ msgstr "Koreansk"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Forenklet kinesisk"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgiansk"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kyrillisk/ukrainsk"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroatisk"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persisk"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandsk"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamesisk"
+
+#~ msgid "Thai"
+#~ msgstr "Thai"
+
+#~ msgid "Encodings"
+#~ msgstr "Tegnkodinger"
+
+#~ msgid "Default"
+#~ msgstr "Standard"
+
+#~ msgid "User defined"
+#~ msgstr "Brukerdefinert"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Andre tegnkodinger"

--- a/po/nl.po
+++ b/po/nl.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Dutch (https://www.transifex.com/terminator/teams/109338/nl/)\n"
+"Language-Team: Dutch (https://www.transifex.com/terminator/teams/109338/"
+"nl/)\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -129,7 +130,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -138,7 +139,7 @@ msgid "Multiple terminals in one window"
 msgstr "Meerdere terminals in één venster"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "De robottoekomst van terminals"
 
@@ -146,8 +147,8 @@ msgstr "De robottoekomst van terminals"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -234,156 +235,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Laat dit bericht de volgende keer niet weer zien"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Huidig taalgebied"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Westers"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Centraal-Europees"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Zuid-Europees"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltisch"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrillisch"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabisch"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grieks"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebreeuws Visueel"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebreeuws"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turks"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Noord-Europees"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltisch"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Roemeens"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armeens"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chinees (traditioneel)"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyrillisch/Russisch"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japans"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreaans"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chinees (vereenvoudigd)"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgisch"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cyrillisch/Oekraïens"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroatisch"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Perzisch"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "IJslands"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamees"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thais"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Lay-out van de Terminator-starter"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Lay-out"
 
@@ -391,11 +248,11 @@ msgstr "Lay-out"
 msgid "Launch"
 msgstr "Voer uit"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tabblad"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Tabblad sluiten"
 
@@ -528,7 +385,7 @@ msgstr "_Eigen Commando's"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Voorkeuren"
 
@@ -553,12 +410,12 @@ msgid "Enabled"
 msgstr "Ingeschakeld"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Naam"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Commando"
 
@@ -664,7 +521,7 @@ msgid "Escape sequence"
 msgstr "Escape-reeks"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Alle"
 
@@ -881,489 +738,513 @@ msgid "Use custom URL handler"
 msgstr "Aangepaste URL-afhandeling gebruiken"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Aangepaste URL-afhandeling:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Aangepaste URL-afhandeling:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Weergave</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Vensterranden"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Doorzichtigheid van lettertype in ontfocuste terminal"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Scheidingslijngrootte van terminal:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Extra opmaak (afhankelijk van thema)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Tabbladpositie:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Gelijksoortige tabbladen"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Scrollknoppen op tabbladen"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Globaal"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profiel"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "Standaard vaste _breedte-lettertype gebruiken"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Lettertype:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Kies een terminalvenster-lettertype"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Vetgedrukte tekst toestaan"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Titelbalk weergeven"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Kopiëren wanneer tekst wordt geselecteerd"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "_Selecteer-op-woord tekens:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Vorm:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Knipperen"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Achtergrond:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminalbel</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Titelbalkpictogram"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Visuele flits"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Hoorbare pieptoon"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Vensterlijst-flits"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Algemeen"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "Opdracht _uitvoeren als inlogshell"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Aangepaste opdracht _uitvoeren in plaats van mijn shell"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Aangepaste _opdracht:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Wanneer opdracht _eindigt:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Voor- en achtergrond</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "Kleuren van het s_ysteemthema gebruiken"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "_Ingebouwde schema's:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Kleurenpalet</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Ingebouwde _schema's:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Kleuren_palet:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Kleuren"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Effen kleur"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Transparante achtergrond"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Geen</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Achtergrond"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Schuifbalk is:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "S_chuiven bij nieuwe uitvoer"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Schuiven _bij een toetsaanslag"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Oneindig terugschuiven"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "_Terugschuiven:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "regels"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Verschuiving"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Let op:</b> Door deze opties kunnen sommige toepassingen "
 "incorrect gedrag vertonen. Ze zijn er slechts zodat u om sommige "
-"toepassingen en besturingssystemen, die een ander terminalgedrag verwachten,"
-" heen kunt werken.</i></small>"
+"toepassingen en besturingssystemen, die een ander terminalgedrag verwachten, "
+"heen kunt werken.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "_Backspace-toets genereert:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "_Delete-toets genereert:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Tekenset:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Compatibiliteitsopties terugzetten op standaardwaarden"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Compatibiliteit"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Gefocust"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Inactief"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Bezig met ontvangen"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Grootte verbergen in titel"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "Systeemlettertype _gebruiken"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Kies een lettertype voor de titelbalk"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profielen"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Soort"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profiel:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Aangepaste opdracht:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Werkmap:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Indelingen"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Actie"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Toetsbinding"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Toetsbindingen"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Plug-in"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Deze plug-in heeft geen configuratieopties"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Het doel van dit project is om een nuttig gereedschap te maken om terminals the schikken. Het is geinspireerd door programma's zoals gnome-multi-term, quadkonsole, etc. om de belangrijkste focus te leggen in het schikken van terminals in roosters (tabs is de meest gebruikte standaard methode, die ook door Terminator ondersteund wordt).\n"
+"Het doel van dit project is om een nuttig gereedschap te maken om terminals "
+"the schikken. Het is geinspireerd door programma's zoals gnome-multi-term, "
+"quadkonsole, etc. om de belangrijkste focus te leggen in het schikken van "
+"terminals in roosters (tabs is de meest gebruikte standaard methode, die ook "
+"door Terminator ondersteund wordt).\n"
 "\n"
-"Veel van het gedrag van Terminator is gebaseerd op GNOME Terminal, en we voegen daarvan mettertijd meer functionaliteit toe, maar we breiden ook uit in andere richtingen met nuttige functies voor systeem beheerders en andere gebrukers. Als je suggesties hebt, gelieve dit te melden in de verlanglijst bugs! (zie links voor de ontwikkeling link)"
+"Veel van het gedrag van Terminator is gebaseerd op GNOME Terminal, en we "
+"voegen daarvan mettertijd meer functionaliteit toe, maar we breiden ook uit "
+"in andere richtingen met nuttige functies voor systeem beheerders en andere "
+"gebrukers. Als je suggesties hebt, gelieve dit te melden in de verlanglijst "
+"bugs! (zie links voor de ontwikkeling link)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "De handleiding"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Over"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Lettertype vergroten"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Lettertype verkleinen"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Originele lettertypegrootte herstellen"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Nieuw tabblad creëren"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Het volgende terminalvenster focussen"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Het vorige terminalvenster focussen"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Het bovenstaande terminalvenster focussen"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Het onderstaande terminal focussen"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Het linkerterminalvenster focussen"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Het rechterterminalvenster focussen"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Terminalvenster omdraaien met de klok mee"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Terminalvenster omdraaien tegen de klok in"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Horizontaal splitsen"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Verticaal splitsen"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Terminalvenster sluiten"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Geselecteerde tekst kopiëren"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Plakken vanuit klembord"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1597,11 +1478,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Handleiding openen"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nieuw profiel"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nieuwe lay-out"
 
@@ -1614,185 +1495,169 @@ msgstr "Zoeken:"
 msgid "Close Search bar"
 msgstr "Zoekbalk sluiten"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Stuur e-mail aan…"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "E-mailadres _kopiëren"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "VoIP-adres be_llen"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "VoIP-adres _kopiëren"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "Koppeling _openen"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "Adres _kopiëren"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Kopiëren"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "_Plakken"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Splits H_orizontaal"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Splits V_erticaal"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Nieuw _tabblad"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Open_Debug Tabblad"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Sluiten"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "Terminal in_zoomen"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Terminaal ma_ximaliseren"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "Alle terminals he_rstellen"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Groepering"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Laat scroll balk zien"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Tekensets"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Standaard"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Aangepast"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Andere tekensets"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "N_ieuwe groep..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Geen"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Groep %s verwijderen"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_roepeer alle terminals in het tabblad"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Alle groepen opheffen"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Sluit groep %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Broadcast _alle"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "uitzend_groep"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "uitzenden_af"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "_Splits naar deze groep"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Auto-opschonen groepen"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_voeg terminal nummer in"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Geen shell gevonden"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Kan shell niet starten:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Hernoem venster"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1900,12 +1765,120 @@ msgstr "Omega"
 msgid "window"
 msgstr "venster"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Tabblad %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Huidig taalgebied"
+
+#~ msgid "Western"
+#~ msgstr "Westers"
+
+#~ msgid "Central European"
+#~ msgstr "Centraal-Europees"
+
+#~ msgid "South European"
+#~ msgstr "Zuid-Europees"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltisch"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrillisch"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabisch"
+
+#~ msgid "Greek"
+#~ msgstr "Grieks"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebreeuws Visueel"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebreeuws"
+
+#~ msgid "Turkish"
+#~ msgstr "Turks"
+
+#~ msgid "Nordic"
+#~ msgstr "Noord-Europees"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltisch"
+
+#~ msgid "Romanian"
+#~ msgstr "Roemeens"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armeens"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chinees (traditioneel)"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyrillisch/Russisch"
+
+#~ msgid "Japanese"
+#~ msgstr "Japans"
+
+#~ msgid "Korean"
+#~ msgstr "Koreaans"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chinees (vereenvoudigd)"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgisch"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cyrillisch/Oekraïens"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroatisch"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Perzisch"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "IJslands"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamees"
+
+#~ msgid "Thai"
+#~ msgstr "Thais"
+
+#~ msgid "Encoding:"
+#~ msgstr "Tekenset:"
+
+#~ msgid "Encodings"
+#~ msgstr "Tekensets"
+
+#~ msgid "Default"
+#~ msgstr "Standaard"
+
+#~ msgid "User defined"
+#~ msgstr "Aangepast"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Andere tekensets"

--- a/po/nn.po
+++ b/po/nn.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Norwegian Nynorsk (https://www.transifex.com/terminator/teams/109338/nn/)\n"
+"Language-Team: Norwegian Nynorsk (https://www.transifex.com/terminator/"
+"teams/109338/nn/)\n"
+"Language: nn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nn\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Splitt H_orisontalt"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Splitt V_ertikalt"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,12 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/oc.po
+++ b/po/oc.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Occitan (post 1500) (https://www.transifex.com/terminator/teams/109338/oc/)\n"
+"Language-Team: Occitan (post 1500) (https://www.transifex.com/terminator/"
+"teams/109338/oc/)\n"
+"Language: oc\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: oc\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Permet d'aver mantun terminal dins una sola fenèstra"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Locala actuala"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Euròpa occidentala"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Euròpa centrala"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Euròpa del Sud"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltic"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirillic"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabi"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grèc"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Ebrèu visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Ebrèu"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turc"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordic"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtic"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romanés"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armèni"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chinés tradicional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cirillic/Rus"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonés"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Corean"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chinés simplificat"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgian"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirillic/Ucraïnian"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croat"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Indi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persan"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandés"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamian"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Presentacion"
 
@@ -381,11 +238,11 @@ msgstr "Presentacion"
 msgid "Launch"
 msgstr "Aviar"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tabulacion"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Tampar l'onglet"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferéncias"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Tot"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Perfils"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Perfil novèl"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Agençament novèl"
 
@@ -1594,185 +1467,169 @@ msgstr "Recercar :"
 msgid "Close Search bar"
 msgstr "Tampar la barra de recèrca"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "Mandar un corrièl a..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copiar l'adreça email"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Ape_lar l'adreça VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copiar l'adreça VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "D_obrir lo ligam"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copiar l'adreça"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Devesir _orizontalament"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Devesir v_erticalament"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Dobrir un ongle_t"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zoomar lo terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restablir totes los terminals"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Regropament"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Far veire la barra de desfilament"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Encodatges"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Per defaut"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definit per l'utilizaire"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Autres  Encodatges"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Suprimir lo grop %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Ag_ropar dins un sol tablèau"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Suprimir totes los gropes"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Tampar lo grop %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Impossible de trobar un shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,117 @@ msgstr ""
 msgid "window"
 msgstr "fenèstra"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Tablèu %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Locala actuala"
+
+#~ msgid "Western"
+#~ msgstr "Euròpa occidentala"
+
+#~ msgid "Central European"
+#~ msgstr "Euròpa centrala"
+
+#~ msgid "South European"
+#~ msgstr "Euròpa del Sud"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltic"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirillic"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabi"
+
+#~ msgid "Greek"
+#~ msgstr "Grèc"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Ebrèu visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Ebrèu"
+
+#~ msgid "Turkish"
+#~ msgstr "Turc"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordic"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtic"
+
+#~ msgid "Romanian"
+#~ msgstr "Romanés"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armèni"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chinés tradicional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cirillic/Rus"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonés"
+
+#~ msgid "Korean"
+#~ msgstr "Corean"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chinés simplificat"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgian"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirillic/Ucraïnian"
+
+#~ msgid "Croatian"
+#~ msgstr "Croat"
+
+#~ msgid "Hindi"
+#~ msgstr "Indi"
+
+#~ msgid "Persian"
+#~ msgstr "Persan"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandés"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamian"
+
+#~ msgid "Thai"
+#~ msgstr "Tai"
+
+#~ msgid "Encodings"
+#~ msgstr "Encodatges"
+
+#~ msgid "Default"
+#~ msgstr "Per defaut"
+
+#~ msgid "User defined"
+#~ msgstr "Definit per l'utilizaire"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Autres  Encodatges"

--- a/po/pl.po
+++ b/po/pl.po
@@ -2,26 +2,29 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Markus Frosch <markus@lazyfrosch.de>, 2021
 # Daniel Napora <napcok@gmail.com>, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Daniel Napora <napcok@gmail.com>, 2021\n"
-"Language-Team: Polish (https://www.transifex.com/terminator/teams/109338/pl/)\n"
+"Language-Team: Polish (https://www.transifex.com/terminator/teams/109338/"
+"pl/)\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pl\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
+"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
+"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -106,8 +109,7 @@ msgstr ""
 #: ../remotinator.py:77
 msgid "Terminal UUID for when not in env var TERMINATOR_UUID"
 msgstr ""
-"Terminal UUID jeśli nie znajduje się w zmiennej środowiskowej "
-"TERMINATOR_UUID"
+"Terminal UUID jeśli nie znajduje się w zmiennej środowiskowej TERMINATOR_UUID"
 
 #: ../remotinator.py:80
 msgid "Profile name to switch to"
@@ -132,7 +134,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -141,7 +143,7 @@ msgid "Multiple terminals in one window"
 msgstr "Wiele terminali w jednym oknie"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Robotyczna przyszłość terminali"
 
@@ -149,8 +151,8 @@ msgstr "Robotyczna przyszłość terminali"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 "Wszechstronne narzędzie do komponowania terminali. Inspirowane przez "
 "programy takie jak gnome-multi-term, quadkonsole, itp. w sposób, że główny "
@@ -245,156 +247,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Nie pokazuj tej wiadomości następnym razem"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Bieżące ustawienia regionalne"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Zachodni"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Środkowoeuropejskie"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Południowoeuropejskie"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Bałtycki"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrylica"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabski"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grecki"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebrajski (wizualnie)"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebrajski"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turecki"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordycki"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtycki"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumuńskie"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armeński"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chiński Tradycyjny"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cyrylica/Rosyjski"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japoński"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreański"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chiński Uproszczony"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gruziński"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cyrylica/Ukraiński"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Chorwacki"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hinduski"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Perski"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gudżarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandzki"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Wietnamski"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tajski"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Uruchamianie układu Terminatora"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Układ"
 
@@ -402,11 +260,11 @@ msgstr "Układ"
 msgid "Launch"
 msgstr "Uruchom"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "karta"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Zamknij kartę"
 
@@ -436,8 +294,7 @@ msgstr "Podaj tytuł (nazwę) okna"
 
 #: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
-msgstr ""
-"Ustaw żądany rozmiar i położenie okna (zobacz stronę podręcznika X-ów)"
+msgstr "Ustaw żądany rozmiar i położenie okna (zobacz stronę podręcznika X-ów)"
 
 #: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
@@ -493,8 +350,7 @@ msgstr "Włącz informacje debuggera  (podwójnie dla serwera debuggera)"
 
 #: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
-msgstr ""
-"Lista oddzielonych przecinkami klas w celu ograniczenia debugowania do"
+msgstr "Lista oddzielonych przecinkami klas w celu ograniczenia debugowania do"
 
 #: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
@@ -541,7 +397,7 @@ msgstr "_Niestandardowe komendy"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferencje"
 
@@ -566,12 +422,12 @@ msgid "Enabled"
 msgstr "Aktywne"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Nazwa"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Polecenie"
 
@@ -677,7 +533,7 @@ msgid "Escape sequence"
 msgstr "Sekwencja sterująca"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Wszystko"
 
@@ -894,491 +750,515 @@ msgid "Use custom URL handler"
 msgstr "Używaj obsługi URL"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Niestandardowy moduł obsługi adresów URL:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr "PRIMARY"
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr "Schowek"
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr "Wyczyść zaznaczenie podczas kopiowania"
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr "Otwieraj linki pojedynczym kliknięciem (zamiast Ctrl-lewy klik)"
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Niestandardowy moduł obsługi adresów URL:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Wygląd</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Obramowanie okna"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Jasność czcionki nieaktywnego terminala:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Rozmiar odstępu między terminalami:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr "Wysokość wiersza:"
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Dodatkowe stylowanie (zależne od motywu)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Położenie paska kart:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Karty jednorodne"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Przycisk przewijania kart"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr "Pasek tytułowy na dole (wymagany restart)"
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Ogólne"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Systemowa czcionka o stałej szerokości"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Czcionka:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Wybór czcionki terminala"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "Zezwolenie na pogru_biony tekst"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Pokaż pasek tytułowy"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Kopiuj zaznaczone"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Wyłącz zoom za pomocą Ctrl+kółko myszy"
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Znaki należące do _słowa przy zaznaczaniu:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Kursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "K_ształt:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Miganie"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Tło:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Dzwonek terminala</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Ikona paska tytułu"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Wizualny rozbłysk"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Sygnał dźwiękowy"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Lista aktywnych okien"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Ogólne"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Uruchomienie w roli powłoki startowej"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Uru_chamia własne polecenie zamiast powłoki"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Własne polecenie:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "_Po zakończeniu polecenia:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Pierwszy plan i tło</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Kolory z motywu systemowego"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "_Wbudowane schematy:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Wbudowane _schematy:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Paleta _kolorów:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr "Pokaż pogrubiony tekst jaskrawymi kolorami"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Kolory"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Jednolity kolor"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Przezroczyste tło"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr "Obrazek tła"
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr "Obrazek tła:"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr "Wybierz plik"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr "Zacienienie tła:"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Brak</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Tło"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Położenie paska przewijania:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Przewijanie przy pojawieniu się _nowych danych"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Przewijanie przy _naciśnięciu klawisza"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Nieskończone przewijanie"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "_Bufor przewijania:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "linii"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Przewijanie"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Uwaga:</b> Zmiana poniższych opcji może spowodować niepoprawne "
-"zachowanie pewnych programów. Istnieją one tylko w celu obejścia problemów z"
-" pewnymi programami i systemami operacyjnymi, które oczekują innego "
+"zachowanie pewnych programów. Istnieją one tylko w celu obejścia problemów z "
+"pewnymi programami i systemami operacyjnymi, które oczekują innego "
 "zachowania się terminala.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Klawisz _Backspace generuje:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Klawisz _Delete generuje:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Kodowanie:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Przywróć domyślne wartości opcji zgodności"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Zgodność"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Aktywny"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Nieaktywny"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Odbieranie"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Ukryj rozmiar w tytule"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Użyj czcionki systemowej"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Wybierz czcionkę paska tytułu"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profile"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Rodzaj"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Niestandardowe polecenie:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Katalog roboczy:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Układy"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Czynność"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Skrót klawiszowy"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Skróty klawiszowe"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Wtyczka"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Ta wtyczka nie ma żadnych opcji konfiguracyjnych"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Wtyczki"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr "Wersja: 2.1.1"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Celem tego projektu jest stworzenie użytecznego narzędzia do konfigurowania terminali. Jest inspirowany programami takimi jak gnome-multi-term, quad-konsola itp., w których główny nacisk kładziony jest na układanie terminali w siatkach (zakładki są najczęstszą metodą obsługiwaną przez Terminator).\n"
+"Celem tego projektu jest stworzenie użytecznego narzędzia do konfigurowania "
+"terminali. Jest inspirowany programami takimi jak gnome-multi-term, quad-"
+"konsola itp., w których główny nacisk kładziony jest na układanie terminali "
+"w siatkach (zakładki są najczęstszą metodą obsługiwaną przez Terminator).\n"
 "\n"
-"Wiele zachowań Terminatora opiera się na Terminalu GNOME, dodajemy kolejne funkcje z upływem czasu, ale chcemy również rozszerzać się w różnych kierunkach z przydatnymi funkcjami dla sysadminów i innych użytkowników. Jeśli masz jakieś sugestie, zgłoś błędy na liście życzeń! (link Development po lewej stronie)"
+"Wiele zachowań Terminatora opiera się na Terminalu GNOME, dodajemy kolejne "
+"funkcje z upływem czasu, ale chcemy również rozszerzać się w różnych "
+"kierunkach z przydatnymi funkcjami dla sysadminów i innych użytkowników. "
+"Jeśli masz jakieś sugestie, zgłoś błędy na liście życzeń! (link Development "
+"po lewej stronie)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "Podręcznik"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Rozwój</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Błędy / Poprawki</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Błędy / "
+"Poprawki</a>"
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "O programie"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Zwiększ rozmiar czcionki"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Zmniejsz rozmiar czcionki"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Przywróć oryginalny rozmiar czcionki"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr "Powiększ rozmiar czcionki we wszystkich terminalach"
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr "Zmniejsz rozmiar czcionki we wszystkich terminalach"
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr "Przywróć domyślny rozmiar czcionki we wszystkich terminalach"
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Tworzy nową kartę"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Aktywuj następny terminal"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Aktywuj poprzedni terminal"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Aktywuj terminal powyżej"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Aktywuj terminal poniżej"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Aktywuj terminal po lewej"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Aktywuj terminal po prawej"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Obróć terminale zgodnie z ruchem wskazówek zegara"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Obróć terminale przeciwnie do ruchu wskazówek zegara"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Podziel poziomo"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Podziel pionowo"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Zamknij terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Skopiuj zaznaczony tekst"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Wkleja zawartość schowka"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1612,11 +1492,11 @@ msgstr "Otwórz okno preferencji"
 msgid "Open the manual"
 msgstr "Otwiera podręcznik użytkownika"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nowy profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nowy układ"
 
@@ -1629,185 +1509,169 @@ msgstr "Wyszukiwanie:"
 msgid "Close Search bar"
 msgstr "Zamknij pasek wyszukiwania"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Wyślij email do..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopiuj adres email"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_Zadzwoń na adres VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopiuj adres VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Otwórz link"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopiuj adres"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Kopiuj"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "Wk_lej"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Podziel w p_oziomie"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Pozdziel w pioni_e"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "O_twórz kartę"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Otwórz kartę _debugowania"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Zamknij"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "Powięks_z terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "_Maksymalizuj terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Przywróć wszystkie terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Grupowanie"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr "Polecenie ponownego uruchomienia"
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Pokaż _pasek przewijania"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr "Układy..."
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kodowania"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Domyślne"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Zdefiniowane przez użytkownika"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Inne kodowania"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "Nowa grupa..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Brak"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Usuń grupę %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_rupuj wszystko w zakładkach"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Rozgrupuj wszytsko w zakładki"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Usuń wszystkie grupy"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Zamknij grupę %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Nadawanie do wszystkich"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Nadawanie do grupy"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Wyłącz nadawanie"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "Rozdziel do tej grupy"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Automatyczne czyszczenie grup"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "Wprowadź numer terminalu"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Wstaw _wyrównany numer terminala"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Nie można odnaleźć powłoki"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Nie można włączyć powłoki:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Zmiana nazwy okna"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Wpisz nowy tytuł dla okna Terminatora..."
 
@@ -1915,12 +1779,123 @@ msgstr "Omega"
 msgid "window"
 msgstr "okno"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Karta %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Bieżące ustawienia regionalne"
+
+#~ msgid "Western"
+#~ msgstr "Zachodni"
+
+#~ msgid "Central European"
+#~ msgstr "Środkowoeuropejskie"
+
+#~ msgid "South European"
+#~ msgstr "Południowoeuropejskie"
+
+#~ msgid "Baltic"
+#~ msgstr "Bałtycki"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrylica"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabski"
+
+#~ msgid "Greek"
+#~ msgstr "Grecki"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebrajski (wizualnie)"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebrajski"
+
+#~ msgid "Turkish"
+#~ msgstr "Turecki"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordycki"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtycki"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumuńskie"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armeński"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chiński Tradycyjny"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cyrylica/Rosyjski"
+
+#~ msgid "Japanese"
+#~ msgstr "Japoński"
+
+#~ msgid "Korean"
+#~ msgstr "Koreański"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chiński Uproszczony"
+
+#~ msgid "Georgian"
+#~ msgstr "Gruziński"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cyrylica/Ukraiński"
+
+#~ msgid "Croatian"
+#~ msgstr "Chorwacki"
+
+#~ msgid "Hindi"
+#~ msgstr "Hinduski"
+
+#~ msgid "Persian"
+#~ msgstr "Perski"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gudżarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandzki"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Wietnamski"
+
+#~ msgid "Thai"
+#~ msgstr "Tajski"
+
+#~ msgid "Line Height:"
+#~ msgstr "Wysokość wiersza:"
+
+#~ msgid "Encoding:"
+#~ msgstr "Kodowanie:"
+
+#~ msgid "Encodings"
+#~ msgstr "Kodowania"
+
+#~ msgid "Default"
+#~ msgstr "Domyślne"
+
+#~ msgid "User defined"
+#~ msgstr "Zdefiniowane przez użytkownika"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Inne kodowania"

--- a/po/pt.po
+++ b/po/pt.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Portuguese (https://www.transifex.com/terminator/teams/109338/pt/)\n"
+"Language-Team: Portuguese (https://www.transifex.com/terminator/teams/109338/"
+"pt/)\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -128,7 +129,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -137,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Múltiplos Terminais numa só janela"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "O robô futuro dos terminais"
 
@@ -145,8 +146,8 @@ msgstr "O robô futuro dos terminais"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -234,156 +235,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Não mostrar novamente a mensagem"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Configuração regional atual"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Ocidental"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europa Central"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Europa do Sul"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Báltico"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirílico"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Árabe"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grego"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebraico visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebraico"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turco"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nórdico"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Céltico"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romeno"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Arménio"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Mandarim tradicional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cirílico/Russo"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonês"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coreano"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Mandarim simplificado"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgiano"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirílico/Ucraniano"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croata"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindu"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persa"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandês"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamita"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tailandês"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Disposição"
 
@@ -391,11 +248,11 @@ msgstr "Disposição"
 msgid "Launch"
 msgstr "Iniciar"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "separador"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Fechar separador"
 
@@ -527,7 +384,7 @@ msgstr "_Comandos personalizados"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferências"
 
@@ -552,12 +409,12 @@ msgid "Enabled"
 msgstr "Ativo"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Nome"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Comando"
 
@@ -663,7 +520,7 @@ msgid "Escape sequence"
 msgstr "Sequência de escape"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Tudo"
 
@@ -880,489 +737,513 @@ msgid "Use custom URL handler"
 msgstr "Utilizar gestor de URL personalizado"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Gestor personalizado:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Gestor personalizado:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Aparência</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Contornos da janela"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Brilho do tipo de letra em terminais não focados:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Tamanho do separador:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Estilização extra (conforme o tema)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Posição do separador:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Separadores homogéneos"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Botões de deslocação dos separadores"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Perfil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Usar tipo de letra de largura fixa do sistema"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Tipo de letra:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Escolha o tipo de letra do terminal"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Permitir texto negrito"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Mostrar barra de título"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Copiar na seleção"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Selecionar _caracteres da palavra:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Forma:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Intermitente"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Fundo:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Notificação do terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Ícone da barra de título"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Visual"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Notificação sonora"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Intermitência na lista de janelas"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Geral"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "Executa_r comando numa consola"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Executar um coma_ndo personalizado em vez da minha consola"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Co_mando personalizado:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Ao sair do _comando:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Cor principal e secundária</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Usar cores do tema do sistema"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Esque_mas internos:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "E_squemas internos:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "P_aleta de cores:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Cores"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "Cor _sólida"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Fundo _transparente"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Nenhum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Máximo</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Fundo"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "Barra de _deslocação é:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Desl_ocar na saída de"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Deslocar ao premir a _tecla"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Deslocação infinita"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Deslocação para _trás:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "linhas"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Deslocação"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Note:</b> Estas opções podem fazer com que algumas aplicações "
 "se comportem de forma incorreta. Elas estão aqui apenas para permitir "
 "contornar determinadas aplicações e sistemas operativos que esperam um "
 "comportamento diferente do terminal.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Tecla _Backspace gera:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Tecla _Delete gera:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Codificação:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Reiniciar opções de compatibilidade originais"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Focado"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Inativo"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "A receber"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Ocultar tamanho do título"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Usar tipo de letra do sistema"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Escolha o tipo de letra para o título"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Perfis"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Tipo"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Perfil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Comando personalizado:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Diretório de trabalho:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Disposições"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Ação"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Associação de tecla"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Associação de teclas"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Este plug-in não tem opções de configuração"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Plugins"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"O objetivo deste projeto é produzir uma ferramenta útil para organizar os terminais. Este programa é inspirado em programas tais como  gnome-multi-term, quadkonsole, etc. onde o maior objetivo é organizar os terminais em grelha.\n"
+"O objetivo deste projeto é produzir uma ferramenta útil para organizar os "
+"terminais. Este programa é inspirado em programas tais como  gnome-multi-"
+"term, quadkonsole, etc. onde o maior objetivo é organizar os terminais em "
+"grelha.\n"
 "\n"
-"Grande parte do comportamento do Terminator é baseado no GNOME Terminal. Estamos a adicionar funcionalidades com o passar do tempo e também é nossa intenção expandir em diferentes direções com a criação de funcionalidades úteis para Administradores de Sistema e outros utilizadores. Caso tenha alguma sugestão, preencha a wishlist de erros.(ver à esquerda o link Development)"
+"Grande parte do comportamento do Terminator é baseado no GNOME Terminal. "
+"Estamos a adicionar funcionalidades com o passar do tempo e também é nossa "
+"intenção expandir em diferentes direções com a criação de funcionalidades "
+"úteis para Administradores de Sistema e outros utilizadores. Caso tenha "
+"alguma sugestão, preencha a wishlist de erros.(ver à esquerda o link "
+"Development)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "O Manual"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Acerca"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Aumentar tamanho do tipo de letra"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Diminuir tamanho do tipo de letra"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "restaurar tamanho padrão"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Criar novo separador"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Focar o terminal seguinte"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Focar o terminal anterior"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Focar o terminal acima"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Focar o terminal abaixo"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Focar o terminal à esquerda"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Focar o terminal à direita"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Rodar terminais para a direita"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Rodar terminais para a esquerda"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Dividir horizontalmente"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Dividir verticalmente"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Fechar terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Copiar texto selecionado"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Colar da área de transferência"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1596,11 +1477,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Abrir o manual"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Novo perfil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nova disposição"
 
@@ -1613,185 +1494,169 @@ msgstr "Pesquisar:"
 msgid "Close Search bar"
 msgstr "Fechar barra de pesquisa"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Enviar mensagem para..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copiar endereço de e-mail"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_Ligar para endereço VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copiar endereço VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "Abrir ligaçã_o"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copiar endereço"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Copiar"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "Co_lar"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Dividir h_orizontalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Dividir v_erticalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Abrir _separador"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Abrir separador de _depuração"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "Fe_char"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Ampliar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximizar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restaurar todos os terminais"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Agrupamento"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Mostrar barra de de_slocação"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Codificação"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Padrão"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definido pelo utilizador"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Outras codificações"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "N_ovo grupo..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Nenhum"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Remover o grupo %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Ag_rupar tudo num separador"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Desagr_upar tudo no separador"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Remover todos os grupos"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Fechar o grupo %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Difubdir tod_as"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Difundir _grupo"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Difusã_o desativada"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "_Separar este grupo"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Limpar grupos automati_camente"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_Inserir número do terminal"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Incapaz de encontrar a consola"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Incapaz de iniciar a consola:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Renomear janela"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Digite o novo título para a janela Terminator..."
 
@@ -1899,12 +1764,120 @@ msgstr "Ómega"
 msgid "window"
 msgstr "janela"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Separador %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Configuração regional atual"
+
+#~ msgid "Western"
+#~ msgstr "Ocidental"
+
+#~ msgid "Central European"
+#~ msgstr "Europa Central"
+
+#~ msgid "South European"
+#~ msgstr "Europa do Sul"
+
+#~ msgid "Baltic"
+#~ msgstr "Báltico"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirílico"
+
+#~ msgid "Arabic"
+#~ msgstr "Árabe"
+
+#~ msgid "Greek"
+#~ msgstr "Grego"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebraico visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebraico"
+
+#~ msgid "Turkish"
+#~ msgstr "Turco"
+
+#~ msgid "Nordic"
+#~ msgstr "Nórdico"
+
+#~ msgid "Celtic"
+#~ msgstr "Céltico"
+
+#~ msgid "Romanian"
+#~ msgstr "Romeno"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Arménio"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Mandarim tradicional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cirílico/Russo"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonês"
+
+#~ msgid "Korean"
+#~ msgstr "Coreano"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Mandarim simplificado"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgiano"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirílico/Ucraniano"
+
+#~ msgid "Croatian"
+#~ msgstr "Croata"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindu"
+
+#~ msgid "Persian"
+#~ msgstr "Persa"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandês"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamita"
+
+#~ msgid "Thai"
+#~ msgstr "Tailandês"
+
+#~ msgid "Encoding:"
+#~ msgstr "Codificação:"
+
+#~ msgid "Encodings"
+#~ msgstr "Codificação"
+
+#~ msgid "Default"
+#~ msgstr "Padrão"
+
+#~ msgid "User defined"
+#~ msgstr "Definido pelo utilizador"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Outras codificações"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2,24 +2,25 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Anthony Louis <anthony.physis@gmail.com>, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Anthony Louis <anthony.physis@gmail.com>, 2021\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/terminator/teams/109338/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/terminator/"
+"teams/109338/pt_BR/)\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. Command             uuid req.    Description
@@ -130,7 +131,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -139,7 +140,7 @@ msgid "Multiple terminals in one window"
 msgstr "Múltiplos terminais em uma janela"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "O robo do futuro dos terminais"
 
@@ -147,8 +148,8 @@ msgstr "O robo do futuro dos terminais"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 "Uma ferramenta destinada aos superusuários, útil para organização de "
 "terminais. Esta foi inspirada por programas como gnome-multi-term, "
@@ -163,8 +164,8 @@ msgid ""
 "users."
 msgstr ""
 "Muito do comportamento do Terminator é baseado no Terminal do Gnome, e "
-"estamos adicionando mais recursos com o passar do tempo, mas também queremos"
-" estender isso em diferentes recursos para administradores e sistemas e "
+"estamos adicionando mais recursos com o passar do tempo, mas também queremos "
+"estender isso em diferentes recursos para administradores e sistemas e "
 "outros usuários."
 
 #: ../data/terminator.appdata.xml.in.h:6
@@ -243,156 +244,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Não mostrar esta mensagem da próxima vez"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Localização atual"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Ocidental"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europa Central"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Sul da Europa"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Báltico"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirílico"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arábico"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grego"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Visual Hebraico"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebraico"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turco"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nórdico"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celta"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romeno"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armênio"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chinês tradicional"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cirílico/Russo"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonês"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coreano"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chinês simplificado"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Geórgio"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirílico/Ucraniano"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croata"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindu"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persa"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Guzarate"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandês"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamita"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tailandês"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Lançador de grupo de terminais"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Layout / Grupo"
 
@@ -400,11 +257,11 @@ msgstr "Layout / Grupo"
 msgid "Launch"
 msgstr "Iniciar"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "aba"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Fechar aba"
 
@@ -539,7 +396,7 @@ msgstr "_Comandos Personalizados"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferências"
 
@@ -564,12 +421,12 @@ msgid "Enabled"
 msgstr "Habilitado"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Nome"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Comando"
 
@@ -675,7 +532,7 @@ msgid "Escape sequence"
 msgstr "Sequência de escape"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Todos"
 
@@ -892,492 +749,518 @@ msgid "Use custom URL handler"
 msgstr "Utilizar manipulador de URL personalizado"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Customizar manipulador de URL"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr "PRIMÁRIO"
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr "Área de transferência"
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr "Limpar seleção ao copiar"
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 "Abrir links com um único clique(ao invés de utilizar Crtl-click com o botão "
 "esquerdo)"
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Customizar manipulador de URL"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Aparência</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Bordas da janela"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Desfocar brilho da fonte do terminal"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Tamanho do separador de terminal"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr "Altura da linha"
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Estilização extra(Depende do tema)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Posição da aba:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Aba homogênea"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Aba de botões de rolagem"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr "Barra de título na parte inferior(Necessita reiniciar o programa)"
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Perfil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Usar a fonte  padrão do sistema"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Fonte:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Escolha uma fonte para o terminal"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Permitir texto em negrito"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Mostra barra de título"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Copiar na seleção"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr "Desabilitar zoom para Ctrl+Scroll"
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Caracteres para selecionar por p_alavra:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Cursor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Forma"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Piscar"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Fundo:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Som do terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Ícone da barra de título"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Flash visual"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Som audível"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Piscar lista de janela"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Geral"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Executar comando como shell de login"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Executar um coma_ndo personalizado ao invés do shell padrão"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Co_mando personalizado:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Quando o comando _terminar:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Texto e Fundo</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "Usar cores do tema do s_istema"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Es_quemas embutidos:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "E_squemas embutidos:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "_Paleta de cores:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr "Mostrar texto em _negrito em cores brilhantes"
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Cores"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Cor Sólida"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Fundo Transparente"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr "Imagem de Fundo"
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr "Arquivo da Imagem de Fundo"
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr "Escolher arquivo"
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr "_Sombrear o plano de fundo"
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Nenhum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Máximo</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Plano de fundo"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Barra de rolagem:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "_Rolar com a saída"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Rolar ao _pressionar teclado"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Navegação Infinita"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "R_olar para trás:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "linhas"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Rolagem"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Nota:</b> Estas opções podem levar alguns aplicativos a se "
 "comportarem incorretamente. Elas existem apenas para permitir que você "
 "contorne certos aplicativos e sistemas operacionais que esperam um "
 "comportamento diferente do terminal.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Tecla _Backspace gera:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Tecla _Delete gera:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Codificação"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Restaurar padrões para as opções de compatibilidade"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Compatibilidade"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Foco"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Inativo"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Recebendo"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Esconder tamanho do título"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Utilizar a fonte do sistema"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Escolher Uma Fonte para Barra de Títulos"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Perfis"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Tipo"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Perfil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Comando personalizado"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Diretório de trabalho:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Disposições"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Ação"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Associação de tecla"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Associações de teclas"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Esse plug-in não tem opções de configuração"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr "Versão: 2.11"
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"O objetivo deste projeto é fornecer uma ferramenta útil para organização de terminais. Esta foi inspirada por programas como gnome-multi-term, quadkonsole, etc. em que o objetivo principal é organizar terminais em grades (abas é o método mais comum, o qual o Terminator também suporta).\n"
-"O comportamento do Terminator é baseado no Terminal do Gnome, e estamos adicionando mais recursos com o passar do tempo, mas também queremos estender isso em diferentes recursos para administradores e sistemas e outros usuários. Se você tem alguma sugestão, por favor, relate os bugs e possíveis melhorias na lista de desejo! (Veja a esquerda para o link para desenvolvimento)"
+"O objetivo deste projeto é fornecer uma ferramenta útil para organização de "
+"terminais. Esta foi inspirada por programas como gnome-multi-term, "
+"quadkonsole, etc. em que o objetivo principal é organizar terminais em "
+"grades (abas é o método mais comum, o qual o Terminator também suporta).\n"
+"O comportamento do Terminator é baseado no Terminal do Gnome, e estamos "
+"adicionando mais recursos com o passar do tempo, mas também queremos "
+"estender isso em diferentes recursos para administradores e sistemas e "
+"outros usuários. Se você tem alguma sugestão, por favor, relate os bugs e "
+"possíveis melhorias na lista de desejo! (Veja a esquerda para o link para "
+"desenvolvimento)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "O Manual"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Desenvolvimento</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Melhorias</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator\">Desenvolvimento</"
+"a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Melhorias</a>"
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Sobre"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Aumentar tamanho da fonte"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Diminuir tamanho da fonte"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Restaurar fonte para tamanho original"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr "Aumentar tamanho da fonte em todos os terminais"
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr "Diminuir o tamanho da fonte em todos os terminais"
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr "Restaurar fonte para tamanho original em todos os terminais"
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Criar uma nova aba"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Convergir o próximo terminal"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Convergir o terminal anterior"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Convergir o terminal acima"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Convergir o terminal abaixo"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Convergir o terminal à esqueda"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Convergir o terminal à direita"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Girar terminais no sentido horário"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Girar terminais no sentido anti-horário"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Dividir horizontalmente"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Dividir verticalmente"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Fechar terminal"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Copiar texto selecionado"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Colar área de transferência"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1611,11 +1494,11 @@ msgstr "Abrir janela de Preferências"
 msgid "Open the manual"
 msgstr "Abrir o manual"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Novo perfil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nova disposição"
 
@@ -1628,185 +1511,169 @@ msgstr "Pesquisar:"
 msgid "Close Search bar"
 msgstr "Fechar barra de pesquisa"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Enviar e-mail para..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copiar endereço de e-mail"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_Ligar para endereço VOIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copiar endereço VOIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Abrir link"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copiar endereço"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "_Copiar"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "_Colar"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Dividir H_orizontalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Dividir v_erticalmente"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Abrir _aba"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Abrir aba de _depuração"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "_Fechar"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zoom terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximizar terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restaurar todos os terminais"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Agrupando"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr "Reexecutar comando"
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Mostrar  _barras de rolagem"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr "_Layouts..."
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Codificações"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Padrão"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definido pelo usuário"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Outras codificações"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "Novo grupo..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Nenhum"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Remover grupo %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Ag_rupar tudo em uma aba"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Desagru_par todas as abas"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Remover todos grupos"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Fechar grupo %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Transmissão _todos"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Transmissão _grupo"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Transmissão_desativada"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "_Dividir para este grupo"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Limpar_grupos automaticamente"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_Inserir número do terminal"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Inserir _monte de números de terminal"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Incapaz de encontrar um shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Incapaz de iniciar o shell:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Renomear janela"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Insira um novo título para a janela do terminal"
 
@@ -1914,12 +1781,123 @@ msgstr "Omega"
 msgid "window"
 msgstr "janela"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Aba %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Localização atual"
+
+#~ msgid "Western"
+#~ msgstr "Ocidental"
+
+#~ msgid "Central European"
+#~ msgstr "Europa Central"
+
+#~ msgid "South European"
+#~ msgstr "Sul da Europa"
+
+#~ msgid "Baltic"
+#~ msgstr "Báltico"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirílico"
+
+#~ msgid "Arabic"
+#~ msgstr "Arábico"
+
+#~ msgid "Greek"
+#~ msgstr "Grego"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Visual Hebraico"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebraico"
+
+#~ msgid "Turkish"
+#~ msgstr "Turco"
+
+#~ msgid "Nordic"
+#~ msgstr "Nórdico"
+
+#~ msgid "Celtic"
+#~ msgstr "Celta"
+
+#~ msgid "Romanian"
+#~ msgstr "Romeno"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armênio"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chinês tradicional"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cirílico/Russo"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonês"
+
+#~ msgid "Korean"
+#~ msgstr "Coreano"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chinês simplificado"
+
+#~ msgid "Georgian"
+#~ msgstr "Geórgio"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirílico/Ucraniano"
+
+#~ msgid "Croatian"
+#~ msgstr "Croata"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindu"
+
+#~ msgid "Persian"
+#~ msgstr "Persa"
+
+#~ msgid "Gujarati"
+#~ msgstr "Guzarate"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandês"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamita"
+
+#~ msgid "Thai"
+#~ msgstr "Tailandês"
+
+#~ msgid "Line Height:"
+#~ msgstr "Altura da linha"
+
+#~ msgid "Encoding:"
+#~ msgstr "Codificação"
+
+#~ msgid "Encodings"
+#~ msgstr "Codificações"
+
+#~ msgid "Default"
+#~ msgstr "Padrão"
+
+#~ msgid "User defined"
+#~ msgstr "Definido pelo usuário"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Outras codificações"

--- a/po/ro.po
+++ b/po/ro.po
@@ -2,24 +2,26 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Romanian (https://www.transifex.com/terminator/teams/109338/ro/)\n"
+"Language-Team: Romanian (https://www.transifex.com/terminator/teams/109338/"
+"ro/)\n"
+"Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ro\n"
-"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
+"2:1));\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -130,7 +132,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -139,7 +141,7 @@ msgid "Multiple terminals in one window"
 msgstr "Terminale multiple într-o singură fereastră"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Viitorul robot al terminalelor"
 
@@ -147,8 +149,8 @@ msgstr "Viitorul robot al terminalelor"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -231,156 +233,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Configurări locale curente"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Occidentală"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europa centrală"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Europa de sud"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltică"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Chirilică"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabă"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Greacă"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Ebraică vizuală"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Ebraică"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turcă"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordică"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Celtă"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Română"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicod"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armeană"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Chineză tradițională"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Chirilică/Rusă"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japoneză"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Coreană"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Chineză simplificată"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgiană"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Chirilică/Ucraineană"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Croată"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindusă"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persană"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandeză"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnameză"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tailandeză"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -388,11 +246,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Închide tab"
 
@@ -433,8 +291,8 @@ msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
-"Folosește restul liniei de comandă ca un ordin pentru a executa în terminal,"
-" cu argumente"
+"Folosește restul liniei de comandă ca un ordin pentru a executa în terminal, "
+"cu argumente"
 
 #: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
@@ -474,8 +332,7 @@ msgstr "Dezactivează DBus"
 
 #: ../terminatorlib/optionparse.py:90
 msgid "Enable debugging information (twice for debug server)"
-msgstr ""
-"Permite informații depanatoare (de doua ori pentru serverul depanator)"
+msgstr "Permite informații depanatoare (de doua ori pentru serverul depanator)"
 
 #: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
@@ -525,7 +382,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Preferințe"
 
@@ -550,12 +407,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -661,7 +518,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Toate"
 
@@ -878,43 +735,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -922,437 +779,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profile"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1587,11 +1460,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Profil nou"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Mod de aranjare nou"
 
@@ -1604,185 +1477,169 @@ msgstr "Caută:"
 msgid "Close Search bar"
 msgstr "Închide bara de căutare"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Send email către..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Copiază adresa de email"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Ape_lează o adresă VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Copiază adresa de VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Deschide legătură"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Copiază adresă"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Împarte _orizontal"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Împarte v_ertical"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Deschide _tab"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Deschide tab de _depanare"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "Panoramea_ză terminalul"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Restaurează toate terminalele"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Grupare"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Arată _bara de derulare"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Codificări"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Implicit"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definit de utilizator"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Alte codificări"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Șterge grupul %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_rupează totul in tab"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Șterge toate grupele"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Închide grupa %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Nu s-a găsit niciun shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Imposibil de pornit shell-ul"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1890,12 +1747,117 @@ msgstr ""
 msgid "window"
 msgstr "fereastră"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Tab %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Configurări locale curente"
+
+#~ msgid "Western"
+#~ msgstr "Occidentală"
+
+#~ msgid "Central European"
+#~ msgstr "Europa centrală"
+
+#~ msgid "South European"
+#~ msgstr "Europa de sud"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltică"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Chirilică"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabă"
+
+#~ msgid "Greek"
+#~ msgstr "Greacă"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Ebraică vizuală"
+
+#~ msgid "Hebrew"
+#~ msgstr "Ebraică"
+
+#~ msgid "Turkish"
+#~ msgstr "Turcă"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordică"
+
+#~ msgid "Celtic"
+#~ msgstr "Celtă"
+
+#~ msgid "Romanian"
+#~ msgstr "Română"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicod"
+
+#~ msgid "Armenian"
+#~ msgstr "Armeană"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Chineză tradițională"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Chirilică/Rusă"
+
+#~ msgid "Japanese"
+#~ msgstr "Japoneză"
+
+#~ msgid "Korean"
+#~ msgstr "Coreană"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Chineză simplificată"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgiană"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Chirilică/Ucraineană"
+
+#~ msgid "Croatian"
+#~ msgstr "Croată"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindusă"
+
+#~ msgid "Persian"
+#~ msgstr "Persană"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandeză"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnameză"
+
+#~ msgid "Thai"
+#~ msgstr "Tailandeză"
+
+#~ msgid "Encodings"
+#~ msgstr "Codificări"
+
+#~ msgid "Default"
+#~ msgstr "Implicit"
+
+#~ msgid "User defined"
+#~ msgstr "Definit de utilizator"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Alte codificări"

--- a/po/ru.po
+++ b/po/ru.po
@@ -2,24 +2,27 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Russian (https://www.transifex.com/terminator/teams/109338/ru/)\n"
+"Language-Team: Russian (https://www.transifex.com/terminator/teams/109338/"
+"ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -130,7 +133,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -139,7 +142,7 @@ msgid "Multiple terminals in one window"
 msgstr "Несколько терминалов в одном окне"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Технологии будущего для терминалов"
 
@@ -147,8 +150,8 @@ msgstr "Технологии будущего для терминалов"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -237,156 +240,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Больше не показывать это сообщение"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Текущая языковая настройка"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Западная"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Центрально-европейская"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Южно-европейская"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Балтийская"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Кириллица"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Арабская"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Греческая"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Иврит (Визуальный)"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Иврит"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Турецкая"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Скандинавская"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Кельтская"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Румынская"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Юникод"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Армянская"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Традиционная китайская"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Кириллица/Русская"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Японская"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Корейская"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Упрощенная китайская"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Грузинская"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Кириллица/Украина"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Хорватская"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Хинди"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Персидская"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Гуарати (Индия)"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Гармукхи"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Исладнский"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Вьетнамский"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Тайский"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Запуск компоновки Terminator"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Компоновка"
 
@@ -394,11 +253,11 @@ msgstr "Компоновка"
 msgid "Launch"
 msgstr "Запустить"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "вкладка"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Закрыть вкладку"
 
@@ -440,8 +299,8 @@ msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
-"Использовать для выполнения в терминале остаток командной строки как команду"
-" и её аргументы"
+"Использовать для выполнения в терминале остаток командной строки как команду "
+"и её аргументы"
 
 #: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
@@ -457,8 +316,7 @@ msgstr "Установить рабочий каталог"
 
 #: ../terminatorlib/optionparse.py:77
 msgid "Set a custom icon for the window (by file or name)"
-msgstr ""
-"Установить пользовательский значок для этого окна (по файлу или имени)"
+msgstr "Установить пользовательский значок для этого окна (по файлу или имени)"
 
 #: ../terminatorlib/optionparse.py:80
 msgid "Set a custom WM_WINDOW_ROLE property on the window"
@@ -532,7 +390,7 @@ msgstr "_Свои команды"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Параметры"
 
@@ -557,12 +415,12 @@ msgid "Enabled"
 msgstr "Включено"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Название"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Команда"
 
@@ -668,7 +526,7 @@ msgid "Escape sequence"
 msgstr "Escape-последовательность"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Все"
 
@@ -885,489 +743,513 @@ msgid "Use custom URL handler"
 msgstr "Использовать пользовательский обработчик URL"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Обработчик URL:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Обработчик URL:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Внешний вид</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Рамки окон"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Яркость шрифта для терминала вне фокуса:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Размер разделителя терминалов:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "Дополнительные стили (зависит от темы)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Расположение вкладок:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Идентичные вкладки"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Кнопки переключения вкладок"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Общий"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Профиль"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Использовать системный моноширинный шрифт"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Шрифт:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Выбрать шрифт терминала"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "Р_азрешать полужирный текст"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Показать заголовок"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Копирование на выбор"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Выбор _слов по символам:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Курсор </b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Форма"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Мерцание"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Фон:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Сигнал терминала</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Иконка заголовка"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Видимый сигнал (мигание)"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Звуковой сигнал"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Мигание окном"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Общий"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "За_пускать команду как оболочку входа"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Зап_ускать другую команду вместо моей оболочки"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Пользовательская к_оманда:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "При в_ыходе из команды:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Переднего и заднего плана</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Использовать цвета из системной темы"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Встроенные с_хемы:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Палитра</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Встроенные сх_емы:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Цветовая _палитра:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Цвета"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Сплошной цвет"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Прозрачный фон"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Никакой</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Максимально</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Фон"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Полоса прокрутки:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Прокру_чивать при выводе"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Прок_ручивать при нажатии клавиши"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Бесконечная прокрутка"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "О_братная прокрутка:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "строки"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Прокрутка"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Замечание:</b> Эти параметры могут вызвать некорректную работу "
 "некоторых приложений. Они представлены только для того, чтобы позволить "
 "работать с некоторыми приложениями и операционными ситемами, ожидающими "
 "другого поведения терминала. </i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Клавиша _Backspace генерирует:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Клавиша _Delete генерирует:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "Кодировка:"
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Восстановить параметры совместимости по умолчанию"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Совместимость"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "В фокусе"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Неактивный"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Получение"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Убрать размер терминала из заголовка"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Использовать системный шрифт"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Укажите шрифт заголовка"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Профили"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Тип"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Профиль:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Пользовательская команда:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Рабочий каталог:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Шаблоны"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Действие"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Комбинация клавиш"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Комбинации клавиш"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Надстройка"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Этот плагин не имеет параметров конфигурации"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Модули"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Задачей данного проекта является создание удобного инструмента для совмещения терминалов. Вдохновленный такими программами как gnome-multi-term, quadkonsole и подобных, он прежде всего нацелен собирать терминалы в сетки (которые в свою очередь могут разноситься по вкладкам, которые, кстати Terminator так же поддерживает).\n"
+"Задачей данного проекта является создание удобного инструмента для "
+"совмещения терминалов. Вдохновленный такими программами как gnome-multi-"
+"term, quadkonsole и подобных, он прежде всего нацелен собирать терминалы в "
+"сетки (которые в свою очередь могут разноситься по вкладкам, которые, кстати "
+"Terminator так же поддерживает).\n"
 "\n"
-"Большая часть функционала заимствована из GNOME Terminal и мы со временем добавляем больше разных плюшек оттуда. Но хотелось бы как-то еще расширить его возможности для сисадминов и прочих пользователей. Если у вас есть какие-либо предложения, пожалуйста озвучьте их на багтрекере (wishlist bugs)! (см. сайт разработчиков)"
+"Большая часть функционала заимствована из GNOME Terminal и мы со временем "
+"добавляем больше разных плюшек оттуда. Но хотелось бы как-то еще расширить "
+"его возможности для сисадминов и прочих пользователей. Если у вас есть какие-"
+"либо предложения, пожалуйста озвучьте их на багтрекере (wishlist bugs)! (см. "
+"сайт разработчиков)"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "Руководство"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Сведения о программе"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Увеличить размер шрифта"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Уменьшить размер шрифта"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Восстановить размер шрифта"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Создать новую вкладку"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Сделать активным следующий терминал"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Сделать активным предыдущий терминал"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Сделать активным терминал выше"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Сделать активным терминал ниже"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Сделать активным терминал слева"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Сделать активным терминал справа"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Повернуть терминалы по часовой стрелке"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Повернуть терминалы против часовой стрелки"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Разделить по горизонтали"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Разделить по вертикали"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Закрыть терминал"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Копировать выделенный текст"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Вставить из буфера обмена"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1601,11 +1483,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Открыть руководство"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Создать профиль"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Новое расположение"
 
@@ -1618,185 +1500,169 @@ msgstr "Искать:"
 msgid "Close Search bar"
 msgstr "Закрыть панель поиска"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Отправить письмо..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Копировать адрес почты"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Позво_нить по VoIP-адресу"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Копировать VoIP-адрес"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Открыть ссылку"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Копировать адрес"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "Копировать"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "Вст_авить"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Разделить экран г_оризонтально"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Разделить экран в_ертикально"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Открыть _вкладку"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Открыть отла_дочную вкладку"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "За_крыть"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Увеличить терминал"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Раз_вернуть терминал"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "Восстановить все терминалы"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Группирование"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Показать полосу прокрутки"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Кодировки"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "По умолчанию"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Пользовательский"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Другие кодировки"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "Новая гр_уппа..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "_Ничего"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Удалить группу %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "С_группировать всё во вкладке"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Раз_рознить терминалы во вкладке"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Удалить все группы"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Закрыть группу %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Транслировать во вс_е терминалы"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "Транслировать гру_ппе"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Отключить трансляцию клавиш"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "Поделить на _эту группу"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Автос_тирание у групп"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "_Добавить номер терминала"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Вставить _номер терминала"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Не удается найти оболочку (shell)"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Не удается запустить оболочку:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Переименование окна"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Введите новое название для окна Terminator..."
 
@@ -1904,12 +1770,120 @@ msgstr "Омега"
 msgid "window"
 msgstr "окно"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Вкладка %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Текущая языковая настройка"
+
+#~ msgid "Western"
+#~ msgstr "Западная"
+
+#~ msgid "Central European"
+#~ msgstr "Центрально-европейская"
+
+#~ msgid "South European"
+#~ msgstr "Южно-европейская"
+
+#~ msgid "Baltic"
+#~ msgstr "Балтийская"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Кириллица"
+
+#~ msgid "Arabic"
+#~ msgstr "Арабская"
+
+#~ msgid "Greek"
+#~ msgstr "Греческая"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Иврит (Визуальный)"
+
+#~ msgid "Hebrew"
+#~ msgstr "Иврит"
+
+#~ msgid "Turkish"
+#~ msgstr "Турецкая"
+
+#~ msgid "Nordic"
+#~ msgstr "Скандинавская"
+
+#~ msgid "Celtic"
+#~ msgstr "Кельтская"
+
+#~ msgid "Romanian"
+#~ msgstr "Румынская"
+
+#~ msgid "Unicode"
+#~ msgstr "Юникод"
+
+#~ msgid "Armenian"
+#~ msgstr "Армянская"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Традиционная китайская"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Кириллица/Русская"
+
+#~ msgid "Japanese"
+#~ msgstr "Японская"
+
+#~ msgid "Korean"
+#~ msgstr "Корейская"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Упрощенная китайская"
+
+#~ msgid "Georgian"
+#~ msgstr "Грузинская"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Кириллица/Украина"
+
+#~ msgid "Croatian"
+#~ msgstr "Хорватская"
+
+#~ msgid "Hindi"
+#~ msgstr "Хинди"
+
+#~ msgid "Persian"
+#~ msgstr "Персидская"
+
+#~ msgid "Gujarati"
+#~ msgstr "Гуарати (Индия)"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Гармукхи"
+
+#~ msgid "Icelandic"
+#~ msgstr "Исладнский"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Вьетнамский"
+
+#~ msgid "Thai"
+#~ msgstr "Тайский"
+
+#~ msgid "Encoding:"
+#~ msgstr "Кодировка:"
+
+#~ msgid "Encodings"
+#~ msgstr "Кодировки"
+
+#~ msgid "Default"
+#~ msgstr "По умолчанию"
+
+#~ msgid "User defined"
+#~ msgstr "Пользовательский"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Другие кодировки"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -2,24 +2,27 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Russian (Russia) (https://www.transifex.com/terminator/teams/109338/ru_RU/)\n"
+"Language-Team: Russian (Russia) (https://www.transifex.com/terminator/"
+"teams/109338/ru_RU/)\n"
+"Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru_RU\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -123,7 +126,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Терминатор"
 
@@ -132,7 +135,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +143,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +227,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Центрально-европейская"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Южно-европейская"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Прибалтика"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Кириллическая"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Арабский"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Греческая"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Иврит"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Армянская"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +240,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "таб"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Закрыть вкладку"
 
@@ -515,7 +374,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +399,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +510,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +727,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +771,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1452,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1469,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1739,36 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Central European"
+#~ msgstr "Центрально-европейская"
+
+#~ msgid "South European"
+#~ msgstr "Южно-европейская"
+
+#~ msgid "Baltic"
+#~ msgstr "Прибалтика"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Кириллическая"
+
+#~ msgid "Arabic"
+#~ msgstr "Арабский"
+
+#~ msgid "Greek"
+#~ msgstr "Греческая"
+
+#~ msgid "Hebrew"
+#~ msgstr "Иврит"
+
+#~ msgid "Armenian"
+#~ msgstr "Армянская"

--- a/po/si.po
+++ b/po/si.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Sinhala (https://www.transifex.com/terminator/teams/109338/si/)\n"
+"Language-Team: Sinhala (https://www.transifex.com/terminator/teams/109338/"
+"si/)\n"
+"Language: si\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: si\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "ටර්මිනේටර්"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "එක් වින්ඩෝවක ටර්මිනල් රාශියක්"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "වර්තමාන ප්‍රදේශය"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "අපරදිග"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "මධ්‍යම යුරෝපීය"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "දකුණු යුරෝපයීය"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "බෝල්ටික්"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "සිරිලික්"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "අරාබි"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "ග්‍රීක"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "යුදෙව් දෘෂ්ටිය"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "යුදෙව්"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "තුර්කි"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "නෝඩික"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "කෙල්ටික"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "රොමානීය"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "යුනිකේත"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "ආර්මිනියානු"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "සම්ප්‍රදායික චීන"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "සිරිලික්/රුසියන්"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "ජපන්"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "කොරියන්"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "සුළු  චීන"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "ජෝර්ජියානු"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "සිරිලික්/යුක්රේනියානු"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "කොඒෂන්"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "හින්දි"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "පර්සියන්"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "ගුජරාටි"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "ගුර්මුක්ති"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "අයිස්ලන්ත"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "වියට්නාම"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "තායිලන්ත"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "ටැබය"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "ටැබය වසන්න"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "සමස්ත"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr "ගවේෂණය:"
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "ති_රස්ව කොටස්කිරීම"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "සිර_ස්ව කොටස්කිරීම"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "ටැබය_අරින්න"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "_Debug ටැබය විවෘතකරන්න"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "ටර්මිනලය _විශාලනය"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "ස්ක්‍රෝල්බාරය_පෙන්වන්න"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "කේතීකරණයන්"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "අනෙක් කේතීකරණයන්"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "ෙෂලය සොයාගැනීමට නොහැකිය"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,111 @@ msgstr ""
 msgid "window"
 msgstr "කවුළුව"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "වර්තමාන ප්‍රදේශය"
+
+#~ msgid "Western"
+#~ msgstr "අපරදිග"
+
+#~ msgid "Central European"
+#~ msgstr "මධ්‍යම යුරෝපීය"
+
+#~ msgid "South European"
+#~ msgstr "දකුණු යුරෝපයීය"
+
+#~ msgid "Baltic"
+#~ msgstr "බෝල්ටික්"
+
+#~ msgid "Cyrillic"
+#~ msgstr "සිරිලික්"
+
+#~ msgid "Arabic"
+#~ msgstr "අරාබි"
+
+#~ msgid "Greek"
+#~ msgstr "ග්‍රීක"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "යුදෙව් දෘෂ්ටිය"
+
+#~ msgid "Hebrew"
+#~ msgstr "යුදෙව්"
+
+#~ msgid "Turkish"
+#~ msgstr "තුර්කි"
+
+#~ msgid "Nordic"
+#~ msgstr "නෝඩික"
+
+#~ msgid "Celtic"
+#~ msgstr "කෙල්ටික"
+
+#~ msgid "Romanian"
+#~ msgstr "රොමානීය"
+
+#~ msgid "Unicode"
+#~ msgstr "යුනිකේත"
+
+#~ msgid "Armenian"
+#~ msgstr "ආර්මිනියානු"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "සම්ප්‍රදායික චීන"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "සිරිලික්/රුසියන්"
+
+#~ msgid "Japanese"
+#~ msgstr "ජපන්"
+
+#~ msgid "Korean"
+#~ msgstr "කොරියන්"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "සුළු  චීන"
+
+#~ msgid "Georgian"
+#~ msgstr "ජෝර්ජියානු"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "සිරිලික්/යුක්රේනියානු"
+
+#~ msgid "Croatian"
+#~ msgstr "කොඒෂන්"
+
+#~ msgid "Hindi"
+#~ msgstr "හින්දි"
+
+#~ msgid "Persian"
+#~ msgstr "පර්සියන්"
+
+#~ msgid "Gujarati"
+#~ msgstr "ගුජරාටි"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "ගුර්මුක්ති"
+
+#~ msgid "Icelandic"
+#~ msgstr "අයිස්ලන්ත"
+
+#~ msgid "Vietnamese"
+#~ msgstr "වියට්නාම"
+
+#~ msgid "Thai"
+#~ msgstr "තායිලන්ත"
+
+#~ msgid "Encodings"
+#~ msgstr "කේතීකරණයන්"
+
+#~ msgid "Other Encodings"
+#~ msgstr "අනෙක් කේතීකරණයන්"

--- a/po/sk.po
+++ b/po/sk.po
@@ -2,24 +2,26 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Slovak (https://www.transifex.com/terminator/teams/109338/sk/)\n"
+"Language-Team: Slovak (https://www.transifex.com/terminator/teams/109338/"
+"sk/)\n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sk\n"
-"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n >= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n "
+">= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -128,7 +130,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminátor"
 
@@ -137,7 +139,7 @@ msgid "Multiple terminals in one window"
 msgstr "Viaceré terminály v jednom okne"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Robotická budúcnosť terminálov"
 
@@ -145,8 +147,8 @@ msgstr "Robotická budúcnosť terminálov"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -229,156 +231,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Nezobrazovať správu nabudúce"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Aktuálne lokálne nastavenie"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "západné"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "stredoeurópske"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "juhoeurópske"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "pobaltské"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "azbuka"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "arabské"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "grécke"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "hebrejské vizuálne"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "hebrejské"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "turecké"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "nordické"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "keltské"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "rumunské"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "arménske"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "čínske (tradičné)"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "azbuka/ruské"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "japonské"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "kórejské"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "čínske (zjednodušené)"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "rumunské"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "azbuka/ukrajinské"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "chorvátske"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "hindské"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "perzské"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "guadžarátske"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "gurmukhské"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "islandské"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "vietnamské"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "thajské"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Spúšťač rozhraní Terminatora"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Rozloženie"
 
@@ -386,11 +244,11 @@ msgstr "Rozloženie"
 msgid "Launch"
 msgstr "Spustiť"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "karta"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Zatvoriť kartu"
 
@@ -431,8 +289,8 @@ msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
-"Použiť zvyšok príkazového riadku ako príkaz na vykonanie vnútri terminálu, a"
-" jeho argumenty"
+"Použiť zvyšok príkazového riadku ako príkaz na vykonanie vnútri terminálu, a "
+"jeho argumenty"
 
 #: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
@@ -523,7 +381,7 @@ msgstr "_Vlastné príkazy"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Nastavenia"
 
@@ -548,12 +406,12 @@ msgid "Enabled"
 msgstr "Povolené"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Názov"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Príkaz"
 
@@ -659,7 +517,7 @@ msgid "Escape sequence"
 msgstr "Escapovať sekvenciu"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Všetky"
 
@@ -876,488 +734,511 @@ msgid "Use custom URL handler"
 msgstr "Použiť vlastný ovládač adresy (URL)"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "Vlastná obsluha URL:"
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "Vlastná obsluha URL:"
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Vzhľad</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Ohraničenie okná"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "Jas nezaostreného písma terminálu:"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Veľkosť oddeľovača terminálu:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Pozícia kariet:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Homogénne karty"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "Tlačidlá posuvníkov kariet"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Všeobecné"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "Po_užívať systémové písmo s pevnou šírkou"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Písmo:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Vyberte písmo terminálu"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "Povoliť _tučný text"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Ukázať titulkový pruh"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Kopírovať pri výberu"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Znaky pre výber _slov:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Kurzor</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Tvar:"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Blikanie"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Pozadie:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Terminálový zvonček</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Ikona v titulkovém pruhu"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Viditeľný pablesk"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Počuteľné zvukové znamenie"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Pablesk zoznamu okien"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Hlavné"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Spustiť príkaz v prihlasovacom shelle"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Sp_ustiť tento program namiesto shellu"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "_Vlastný príkaz:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "Po s_končení príkazu:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Popredie a pozadie</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "Použiť farby _systémovej témy"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Zab_udované schémy:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Paleta</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Za_budované schémy:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Paleta _farieb:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Farby"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Plná farba"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "Prie_hľadné pozadie"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Žiadne</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximálne</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Pozadie"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "Po_suvník je:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "_Rolovať pri výstupe"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Rolovať pri stlačení _klávesu"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Nekonečná pamäť riadkov"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Počet pamätaných _riadkov:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "riadky"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Posúvanie"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Poznámka:</b> Tieto voľby môžu spôsobiť, že niektoré aplikácie "
-"nebudú fungovať správne. Sú tu iba preto, aby iné aplikácie mohli fungovať v"
-" prípade, že očakávajú iné chovanie terminálu.</i></small>"
+"nebudú fungovať správne. Sú tu iba preto, aby iné aplikácie mohli fungovať v "
+"prípade, že očakávajú iné chovanie terminálu.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Klávesa _Backspace generuje:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Kláves _Delete generuje:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Obnoviť predvolené hodnoty pre voľby kompatibility"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Kompatibilita"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Aktívne"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Neaktívne"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Príjem"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "Skryť veľkosť z názvu"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "_Použiť systémové písmo"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "Vybrať písmo titulku"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profily"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Typ"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "Vlastný príkaz:"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Pracovný adresár:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Rozloženia"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "Akcia"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "Klávesová skratka"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Klávesové skratky"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Zásuvný modul"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Tento plugin nemá žiadne možnosti konfigurácie"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Doplnky"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"Cieľom tohto projektu je vytvoriť užitočný nástroj na rozkladanie terminálov. Je inšpirovaný programami ako gnome-multi-term, quadkonsole atď. v tom, že hlavným zameraním je zoraďovanie terminálov do mriežky (karty sú najčastejším predvoleným spôsobom, ktorý Terminator tiež podporuje).\n"
+"Cieľom tohto projektu je vytvoriť užitočný nástroj na rozkladanie "
+"terminálov. Je inšpirovaný programami ako gnome-multi-term, quadkonsole atď. "
+"v tom, že hlavným zameraním je zoraďovanie terminálov do mriežky (karty sú "
+"najčastejším predvoleným spôsobom, ktorý Terminator tiež podporuje).\n"
 "\n"
-"Mnohé z funkcií aplikácie Terminator vychádzajú z GNOME Terminal a postupne z neho pridávanie ďalšie funkcie, ale tiež chceme Terminator rozširovať v rozličných smeroch užitočnými vlastnosťami pre správcov systémov a ďalších používateľov. Ak máte nejaké návrhy, prosím, pošlite vaše želanie do systému na hlásenie chýb (odkaz na Vývoj nájdete vľavo)."
+"Mnohé z funkcií aplikácie Terminator vychádzajú z GNOME Terminal a postupne "
+"z neho pridávanie ďalšie funkcie, ale tiež chceme Terminator rozširovať v "
+"rozličných smeroch užitočnými vlastnosťami pre správcov systémov a ďalších "
+"používateľov. Ak máte nejaké návrhy, prosím, pošlite vaše želanie do systému "
+"na hlásenie chýb (odkaz na Vývoj nájdete vľavo)."
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "Návod"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "O aplikácií"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Zväčšiť veľkosť písma"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Zmenšiť veľkosť písma"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "Obnoviť pôvodnú veľkosť písma"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Vytvoriť novú kartu"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "Aktivovať ďalší terminál"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "Aktivovať predošlý terminál"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "Aktivovať terminál hore"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "Aktivovať terminál dolu"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "Aktivovať terminál vľavo"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "Aktivovať terminál vpravo"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "Otočiť terminály v smere hodinových ručičiek"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "Otočiť terminály proti smeru hodinových ručičiek"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "Rozdeliť horizontálne"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "Rozdeliť vertikálne"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "Zatvoriť terminál"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Kopírovať vybraný text"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Vložiť zo schránky"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1591,11 +1472,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Otvoriť návod"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nový profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nový rozmiestnenie"
 
@@ -1608,185 +1489,169 @@ msgstr "Hľadať:"
 msgid "Close Search bar"
 msgstr "Zavrieť vyhľadávací panel"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "Po_slať email pre..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "Kopírovať emailovú adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Zavo_lať na VoIP adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "Kopírovať VoIP adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Otvoriť linku"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "Kopírovať adresu"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Rozdeliť v_odorovne"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Rozdeliť zvisl_e"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Otvoriť ka_rtu"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Otvoriť kartu La_denie"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Priblížiť terminál"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "Ma_ximalizovať terminál"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "Obnoviť všetky terminály"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Zoskupovanie"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Zobraziť po_suvník"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kódovania"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Predvolené"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Definované užívateľom"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Iné kódovania"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "N_ová skupina..."
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "Žiade_n"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Odobrať skupinu %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Zoskupiť všetko na karte"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "Odsk_upiť všetky v karte"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Odobrať všetky skupiny"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Zatvoriť skupinu %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "Vysiel_ať všetky"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "V_ysielať skupinu"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "Vysielanie _vypnuté"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "Rozdeliť na túto _skupinu"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "Automati_cky čistiť skupiny"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "Vložiť číslo term_inálu"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "Vložiť _zarovnané číslo terminálu"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Nepodarilo sa nájsť shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Nepodarilo sa spustiť shell:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Premenovať okno"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Zadajte nový názov pre okno Terminator..."
 
@@ -1894,12 +1759,117 @@ msgstr "Omega"
 msgid "window"
 msgstr "okno"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Karta %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Aktuálne lokálne nastavenie"
+
+#~ msgid "Western"
+#~ msgstr "západné"
+
+#~ msgid "Central European"
+#~ msgstr "stredoeurópske"
+
+#~ msgid "South European"
+#~ msgstr "juhoeurópske"
+
+#~ msgid "Baltic"
+#~ msgstr "pobaltské"
+
+#~ msgid "Cyrillic"
+#~ msgstr "azbuka"
+
+#~ msgid "Arabic"
+#~ msgstr "arabské"
+
+#~ msgid "Greek"
+#~ msgstr "grécke"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "hebrejské vizuálne"
+
+#~ msgid "Hebrew"
+#~ msgstr "hebrejské"
+
+#~ msgid "Turkish"
+#~ msgstr "turecké"
+
+#~ msgid "Nordic"
+#~ msgstr "nordické"
+
+#~ msgid "Celtic"
+#~ msgstr "keltské"
+
+#~ msgid "Romanian"
+#~ msgstr "rumunské"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "arménske"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "čínske (tradičné)"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "azbuka/ruské"
+
+#~ msgid "Japanese"
+#~ msgstr "japonské"
+
+#~ msgid "Korean"
+#~ msgstr "kórejské"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "čínske (zjednodušené)"
+
+#~ msgid "Georgian"
+#~ msgstr "rumunské"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "azbuka/ukrajinské"
+
+#~ msgid "Croatian"
+#~ msgstr "chorvátske"
+
+#~ msgid "Hindi"
+#~ msgstr "hindské"
+
+#~ msgid "Persian"
+#~ msgstr "perzské"
+
+#~ msgid "Gujarati"
+#~ msgstr "guadžarátske"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "gurmukhské"
+
+#~ msgid "Icelandic"
+#~ msgstr "islandské"
+
+#~ msgid "Vietnamese"
+#~ msgstr "vietnamské"
+
+#~ msgid "Thai"
+#~ msgstr "thajské"
+
+#~ msgid "Encodings"
+#~ msgstr "Kódovania"
+
+#~ msgid "Default"
+#~ msgstr "Predvolené"
+
+#~ msgid "User defined"
+#~ msgstr "Definované užívateľom"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Iné kódovania"

--- a/po/sl.po
+++ b/po/sl.po
@@ -2,24 +2,26 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Slovenian (https://www.transifex.com/terminator/teams/109338/sl/)\n"
+"Language-Team: Slovenian (https://www.transifex.com/terminator/teams/109338/"
+"sl/)\n"
+"Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sl\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -125,7 +127,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -134,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Več terminalov v enem oknu"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -142,8 +144,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -226,156 +228,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Naslednjič ne pokaži več tega sporočila"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Trenutna jezikovna nastavitev"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Zahodno"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Srednjeevropsko"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Južnoevropsko"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltsko"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirilica"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabsko"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grško"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebrejsko predočeno"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebrejsko"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turško"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordijsko"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltsko"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romunsko"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armensko"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Kitajsko tradicionalno"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Cirilica/Rusko"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonsko"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korejsko"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Kitajsko poenostavljeno"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gruzijsko"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirilica / Ukrajinsko"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Hrvaško"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindujsko"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Perzijsko"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Islandsko"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamsko"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tajsko"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -383,11 +241,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tabulator"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Zapri zavihek"
 
@@ -519,7 +377,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Nastavitve"
 
@@ -544,12 +402,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -655,7 +513,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Vse"
 
@@ -872,43 +730,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -916,437 +774,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profili"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1581,11 +1455,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Nov profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Nova postavitev"
 
@@ -1598,185 +1472,169 @@ msgstr "Iskanje:"
 msgid "Close Search bar"
 msgstr "Zapri iskalno vrstico"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Pošlji e-pošto na..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopiraj naslov elektronske pošte"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "K_liči VoIP naslov"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopiraj VoIP naslov"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "Odpri _povezavo"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopiraj naslov"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Razdeli H_orizontalno"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Razdeli V_ertikalno"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Odpri _zavihek"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Odpri_"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Povečaj terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Obnovi vse terminale"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Združevanje"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Pokaži _drsnik"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Nabori znakov"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Privzeto"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Uporabniško določeno"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Drugi nabori znakov"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Odstrani skupino %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Zd_ruži vse v zavihku"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Odstrani vse skupine"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Zapri skupino %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Ni možno najti lupine"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Ni možno zagnati lupine:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Preimenuj okno"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1884,12 +1742,117 @@ msgstr "Omega"
 msgid "window"
 msgstr "okno"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Zavihek %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Trenutna jezikovna nastavitev"
+
+#~ msgid "Western"
+#~ msgstr "Zahodno"
+
+#~ msgid "Central European"
+#~ msgstr "Srednjeevropsko"
+
+#~ msgid "South European"
+#~ msgstr "Južnoevropsko"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltsko"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirilica"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabsko"
+
+#~ msgid "Greek"
+#~ msgstr "Grško"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebrejsko predočeno"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebrejsko"
+
+#~ msgid "Turkish"
+#~ msgstr "Turško"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordijsko"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltsko"
+
+#~ msgid "Romanian"
+#~ msgstr "Romunsko"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armensko"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Kitajsko tradicionalno"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Cirilica/Rusko"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonsko"
+
+#~ msgid "Korean"
+#~ msgstr "Korejsko"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Kitajsko poenostavljeno"
+
+#~ msgid "Georgian"
+#~ msgstr "Gruzijsko"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirilica / Ukrajinsko"
+
+#~ msgid "Croatian"
+#~ msgstr "Hrvaško"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindujsko"
+
+#~ msgid "Persian"
+#~ msgstr "Perzijsko"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Islandsko"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamsko"
+
+#~ msgid "Thai"
+#~ msgstr "Tajsko"
+
+#~ msgid "Encodings"
+#~ msgstr "Nabori znakov"
+
+#~ msgid "Default"
+#~ msgstr "Privzeto"
+
+#~ msgid "User defined"
+#~ msgstr "Uporabniško določeno"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Drugi nabori znakov"

--- a/po/sq.po
+++ b/po/sq.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Albanian (https://www.transifex.com/terminator/teams/109338/sq/)\n"
+"Language-Team: Albanian (https://www.transifex.com/terminator/teams/109338/"
+"sq/)\n"
+"Language: sq\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sq\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Shumë terminale në një dritare"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Mos e shfaq këtë mesazh herën tjetër"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Parametrat lokal te perdorur aktualisht."
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Perëndimore"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Europa Qendrore"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Europa jugore"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltike"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cirilik"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabisht"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Greqisht"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebraike vizuale"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebraike"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turqisht"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordik"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Kelte"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumanisht"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armenisht"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Kineze tradicionale"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Qirilike/Rusisht"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonisht"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreane"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Kineze e thjeshtëzuar"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gjermane"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Cirilike/Ukraina"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroate"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persishte"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmuki"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnameze"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tai"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Mbylle skedën"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,99 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "Parametrat lokal te perdorur aktualisht."
+
+#~ msgid "Western"
+#~ msgstr "Perëndimore"
+
+#~ msgid "Central European"
+#~ msgstr "Europa Qendrore"
+
+#~ msgid "South European"
+#~ msgstr "Europa jugore"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltike"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cirilik"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabisht"
+
+#~ msgid "Greek"
+#~ msgstr "Greqisht"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebraike vizuale"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebraike"
+
+#~ msgid "Turkish"
+#~ msgstr "Turqisht"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordik"
+
+#~ msgid "Celtic"
+#~ msgstr "Kelte"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumanisht"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armenisht"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Kineze tradicionale"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Qirilike/Rusisht"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonisht"
+
+#~ msgid "Korean"
+#~ msgstr "Koreane"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Kineze e thjeshtëzuar"
+
+#~ msgid "Georgian"
+#~ msgstr "Gjermane"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Cirilike/Ukraina"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroate"
+
+#~ msgid "Persian"
+#~ msgstr "Persishte"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmuki"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnameze"
+
+#~ msgid "Thai"
+#~ msgstr "Tai"

--- a/po/sr.po
+++ b/po/sr.po
@@ -2,24 +2,26 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Serbian (https://www.transifex.com/terminator/teams/109338/sr/)\n"
+"Language-Team: Serbian (https://www.transifex.com/terminator/teams/109338/"
+"sr/)\n"
+"Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -123,7 +125,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Терминатор"
 
@@ -132,7 +134,7 @@ msgid "Multiple terminals in one window"
 msgstr "Више терминала у једном прозору"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +142,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +226,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Текући локалитет"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "западни"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "средњо-европски"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "јужноевропски"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "балтички"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "ћирилични"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "арапски"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "грчки"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "јеврејски визуелни"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "јеврејски"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "турски"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "нордијски"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "келтски"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "румунски"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "уникод"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "јерменски"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "кинески традиционални"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "ћирилични/руски"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "јапански"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "корејски"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "поједностављени кинески"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "грузијски"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "ћирилични/украјински"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "хрватски"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "хинду"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "персијски"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "гујарати"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "гурмуки"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "исландски"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "вијетнамски"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "тајландски"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +239,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "језичак"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Затвори језичак"
 
@@ -517,7 +375,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Поставке"
 
@@ -542,12 +400,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -653,7 +511,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Све"
 
@@ -870,43 +728,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -914,437 +772,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Профили"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1579,11 +1453,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Нови профил"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Нови изглед"
 
@@ -1596,185 +1470,169 @@ msgstr "Претрага:"
 msgid "Close Search bar"
 msgstr "Затвори поље за претрагу"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Пошаљи е-поруку..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Умножи е-адресу"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "По_зови VoIP адресу"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Умножи VoIP адресу"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Отвори везу"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Умножи адресу"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Раздвоји водо_равно"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Раздвоји у_справно"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Отвори _језичак"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Отвори _језичак за отклањање неисправности"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Приближи терминал"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Поврати све терминале"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Груписање"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Прикажи _препис"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Кодирања"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Подразумевано"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Кориснички дефинисано"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Друга кодирања"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Уклони %s групу"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Гру_пиши све у језичке"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Уклони све групе"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Затвори %s групу"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Љуска није пронађена"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Покретање љуске није успело:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1882,12 +1740,117 @@ msgstr ""
 msgid "window"
 msgstr "прозор"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "%d језичак"
+
+#~ msgid "Current Locale"
+#~ msgstr "Текући локалитет"
+
+#~ msgid "Western"
+#~ msgstr "западни"
+
+#~ msgid "Central European"
+#~ msgstr "средњо-европски"
+
+#~ msgid "South European"
+#~ msgstr "јужноевропски"
+
+#~ msgid "Baltic"
+#~ msgstr "балтички"
+
+#~ msgid "Cyrillic"
+#~ msgstr "ћирилични"
+
+#~ msgid "Arabic"
+#~ msgstr "арапски"
+
+#~ msgid "Greek"
+#~ msgstr "грчки"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "јеврејски визуелни"
+
+#~ msgid "Hebrew"
+#~ msgstr "јеврејски"
+
+#~ msgid "Turkish"
+#~ msgstr "турски"
+
+#~ msgid "Nordic"
+#~ msgstr "нордијски"
+
+#~ msgid "Celtic"
+#~ msgstr "келтски"
+
+#~ msgid "Romanian"
+#~ msgstr "румунски"
+
+#~ msgid "Unicode"
+#~ msgstr "уникод"
+
+#~ msgid "Armenian"
+#~ msgstr "јерменски"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "кинески традиционални"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "ћирилични/руски"
+
+#~ msgid "Japanese"
+#~ msgstr "јапански"
+
+#~ msgid "Korean"
+#~ msgstr "корејски"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "поједностављени кинески"
+
+#~ msgid "Georgian"
+#~ msgstr "грузијски"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "ћирилични/украјински"
+
+#~ msgid "Croatian"
+#~ msgstr "хрватски"
+
+#~ msgid "Hindi"
+#~ msgstr "хинду"
+
+#~ msgid "Persian"
+#~ msgstr "персијски"
+
+#~ msgid "Gujarati"
+#~ msgstr "гујарати"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "гурмуки"
+
+#~ msgid "Icelandic"
+#~ msgstr "исландски"
+
+#~ msgid "Vietnamese"
+#~ msgstr "вијетнамски"
+
+#~ msgid "Thai"
+#~ msgstr "тајландски"
+
+#~ msgid "Encodings"
+#~ msgstr "Кодирања"
+
+#~ msgid "Default"
+#~ msgstr "Подразумевано"
+
+#~ msgid "User defined"
+#~ msgstr "Кориснички дефинисано"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Друга кодирања"

--- a/po/su.po
+++ b/po/su.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Sundanese (https://www.transifex.com/terminator/teams/109338/su/)\n"
+"Language-Team: Sundanese (https://www.transifex.com/terminator/teams/109338/"
+"su/)\n"
+"Language: su\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: su\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Loba terminal dina hiji jandela"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Engké deui sumputkeun ieu talatah"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Lokal ayeuna"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Kulon"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Ėropa Tengah"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Ėropa Kidul"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltik"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arab"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Yunani"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Jepang"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,36 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "Lokal ayeuna"
+
+#~ msgid "Western"
+#~ msgstr "Kulon"
+
+#~ msgid "Central European"
+#~ msgstr "Ėropa Tengah"
+
+#~ msgid "South European"
+#~ msgstr "Ėropa Kidul"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltik"
+
+#~ msgid "Arabic"
+#~ msgstr "Arab"
+
+#~ msgid "Greek"
+#~ msgstr "Yunani"
+
+#~ msgid "Japanese"
+#~ msgstr "Jepang"

--- a/po/sv.po
+++ b/po/sv.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Swedish (https://www.transifex.com/terminator/teams/109338/sv/)\n"
+"Language-Team: Swedish (https://www.transifex.com/terminator/teams/109338/"
+"sv/)\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -126,7 +127,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -135,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Flera terminaler i ett fönster"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Robot-framtid för terminaler"
 
@@ -143,8 +144,8 @@ msgstr "Robot-framtid för terminaler"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -227,156 +228,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Visa inte det här meddelandet nästa gång"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Aktuell lokal"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Västerländsk"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Centraleuropeisk"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Sydeuropeisk"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltisk"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kyrillisk"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arabisk"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Grekisk"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Synlig hebreisk"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Hebreisk"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Turkisk"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Nordisk"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Keltisk"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Rumänsk"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Armensk"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Traditionell kinesisk"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kyrillisk/rysk"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japansk"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Koreansk"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Förenklad kinesisk"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgisk"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kyrillisk/ukrainsk"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Kroatisk"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hindi"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Persisk"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Isländsk"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamesisk"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Thailändsk"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Utformning"
 
@@ -384,11 +241,11 @@ msgstr "Utformning"
 msgid "Launch"
 msgstr "Starta"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "flik"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Stäng flik"
 
@@ -419,8 +276,8 @@ msgstr "Ange en titel för fönstret"
 #: ../terminatorlib/optionparse.py:57
 msgid "Set the preferred size and position of the window(see X man page)"
 msgstr ""
-"Ange föredragen storlek och position för fönstret (läs mer på \"x "
-"man\"-sidan)"
+"Ange föredragen storlek och position för fönstret (läs mer på \"x man\"-"
+"sidan)"
 
 #: ../terminatorlib/optionparse.py:61 ../terminatorlib/optionparse.py:64
 msgid "Specify a command to execute inside the terminal"
@@ -522,7 +379,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Inställningar"
 
@@ -547,12 +404,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Namn"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Kommando"
 
@@ -658,7 +515,7 @@ msgid "Escape sequence"
 msgstr "Undantagssekvens"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Alla"
 
@@ -875,43 +732,43 @@ msgid "Use custom URL handler"
 msgstr "Använd egen URL-hanterare"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Utseende</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Fönsterramar"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -919,442 +776,458 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
-msgstr "Flikplacering:"
+msgid "Cell Height:"
+msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
-msgstr ""
+msgid "Tab position:"
+msgstr "Flikplacering:"
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
+msgid "Tabs scroll buttons"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Global"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Använd systemets teckensnitt med fast breddsteg"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Teckensnitt:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Välj ett teckensnitt för terminalen"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Tillåt fet text"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Visa namnlisten"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Kopiera vid markering"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Tecken för _markering av ord:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Markör</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Blinka"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Bakgrund:"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Ringklocka för terminal</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Ikon i namnlisten"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Synlig blinkning"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Hörbart pip"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Blinkning med fönsterramen"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Allmänt"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Kör kommando som ett inloggningsskal"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Kö_r ett eget kommando istället för mitt skal"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Eget ko_mmando:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "När kommandot a_vslutas:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Förgrund och bakgrund</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "Använd färger från _datorns tema"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Inbyggda s_cheman:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Palett</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Inbyggda _scheman:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Färgp_alett:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Färger"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "_Enfärgad"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Transparent bakgrund"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ingen</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maximal</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Bakgrund"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "_Rullningslisten är:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Ru_lla vid utdata"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "Rulla vid _tangentnedtryckning"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Obegränsad rullningshistorik"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "Rullnings_historik:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "rader"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Rullning"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Observera:</b> Dessa alternativ kan orsaka att en del program "
 "inte beter sig som de ska. De finns endast här för att låta dig kunna "
 "använda vissa program och operativsystem som förväntar sig ett annat "
 "terminalbeteende.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "_Backstegstangenten genererar:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "_Delete-tangenten genererar:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Återställ kompatibilitetsalternativ till standardvärden"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Kompatibilitet"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiler"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "Typ"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "Profil:"
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "Arbetskatalog:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Layouter"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Tangentbindningar"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "Insticksmodul"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Denna insticksmodul har inga konfigureringsalternativ"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Insticksmoduler"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "Om"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "Öka teckenstorlek"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "Minska teckenstorlek"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "Skapa en ny flik"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "Kopiera markerad text"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "Klistra in urklipp"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1588,11 +1461,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "Öppna handboken"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Ny profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Ny layout"
 
@@ -1605,185 +1478,169 @@ msgstr "Sök:"
 msgid "Close Search bar"
 msgstr "Stäng sökfält"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Skicka e-post till..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Kopiera e-postadress"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "_Ring VoIP-adress"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Kopiera VoIP-adress"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Öppna länk"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Kopiera adress"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Dela h_orisontellt"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Dela v_ertikalt"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Öppna _flik"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Öppna _felsökningsflik"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Zooma in terminal"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Återställ alla terminaler"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Gruppering"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Visa _rullningslist"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Teckenkodningar"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Standard"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Användardefinierad"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Övriga teckenkodningar"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Ta bort grupp %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "G_ruppera alla i fliken"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Ta bort alla grupper"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Stäng grupp %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Kan inte hitta ett skal"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Kan inte starta skalet:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Byt namn på fönster"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Ange en ny rubrik för Terminator-fönstret …"
 
@@ -1891,12 +1748,117 @@ msgstr "Omega"
 msgid "window"
 msgstr "fönster"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Flik %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Aktuell lokal"
+
+#~ msgid "Western"
+#~ msgstr "Västerländsk"
+
+#~ msgid "Central European"
+#~ msgstr "Centraleuropeisk"
+
+#~ msgid "South European"
+#~ msgstr "Sydeuropeisk"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltisk"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kyrillisk"
+
+#~ msgid "Arabic"
+#~ msgstr "Arabisk"
+
+#~ msgid "Greek"
+#~ msgstr "Grekisk"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Synlig hebreisk"
+
+#~ msgid "Hebrew"
+#~ msgstr "Hebreisk"
+
+#~ msgid "Turkish"
+#~ msgstr "Turkisk"
+
+#~ msgid "Nordic"
+#~ msgstr "Nordisk"
+
+#~ msgid "Celtic"
+#~ msgstr "Keltisk"
+
+#~ msgid "Romanian"
+#~ msgstr "Rumänsk"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Armensk"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Traditionell kinesisk"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kyrillisk/rysk"
+
+#~ msgid "Japanese"
+#~ msgstr "Japansk"
+
+#~ msgid "Korean"
+#~ msgstr "Koreansk"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Förenklad kinesisk"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgisk"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kyrillisk/ukrainsk"
+
+#~ msgid "Croatian"
+#~ msgstr "Kroatisk"
+
+#~ msgid "Hindi"
+#~ msgstr "Hindi"
+
+#~ msgid "Persian"
+#~ msgstr "Persisk"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "Isländsk"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamesisk"
+
+#~ msgid "Thai"
+#~ msgstr "Thailändsk"
+
+#~ msgid "Encodings"
+#~ msgstr "Teckenkodningar"
+
+#~ msgid "Default"
+#~ msgstr "Standard"
+
+#~ msgid "User defined"
+#~ msgstr "Användardefinierad"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Övriga teckenkodningar"

--- a/po/sw.po
+++ b/po/sw.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Swahili (https://www.transifex.com/terminator/teams/109338/sw/)\n"
+"Language-Team: Swahili (https://www.transifex.com/terminator/teams/109338/"
+"sw/)\n"
+"Language: sw\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sw\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -128,7 +129,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -137,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "Tungo amri kadhaa kwenye window moja"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "Umbile ya kiroboti ya tungo amri"
 
@@ -145,8 +146,8 @@ msgstr "Umbile ya kiroboti ya tungo amri"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -229,156 +230,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -386,11 +243,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -520,7 +377,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -545,12 +402,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -656,7 +513,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -873,43 +730,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -917,437 +774,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1582,11 +1455,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1599,185 +1472,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1885,12 +1742,12 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Tamil (https://www.transifex.com/terminator/teams/109338/ta/)\n"
+"Language-Team: Tamil (https://www.transifex.com/terminator/teams/109338/"
+"ta/)\n"
+"Language: ta\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ta\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "முனையம்"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "ஒரு  சாளரத்தில் பல முனையங்கள்"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "இந்த செய்தியை அடுத்த முறை காண்பிக்க வேண்டாம்"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "தற்போதைய மொழி உள்ளமைவு"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "மேற்கத்திய"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "மத்திய ஐரோப்பா"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "தெற்கு ஐரோப்பா"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "பால்டிக்"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "சிரிலிக்"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "அராபிக்"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "கிரேக்க"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "ஹீப்ரு காட்சி"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "ஹீப்ரூ"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "துருக்கிய"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "நார்டிக்"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "செல்டிக்"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "ரோமேனியன்"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "யுனிகோட்"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "அர்மேனியன்"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "சீன மரபுவழி"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "சிரிலிக்/ரஷ்யன்"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "ஜப்பானிய"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "கொரியன்"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "எளிதாக்கிய சீனம்"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "ஜோர்ஜியன்"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "சிரிலிக்/உக்ரெயின்"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "குரோஷியன்"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "ஹிந்தி"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "பெர்சியன்"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "குஜராத்தி"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "குருமுகி"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "ஐஸ்லான்டிக்"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "வியட்னாமியன்"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "தாய்லாந்து"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "தத்தல்"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "தத்தலை மூடுக"
 
@@ -426,8 +283,7 @@ msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
-"முனையத்தில் உள்ள இயக்க ஒரு கட்டளை கட்டளை வரி பாக்கி, மற்றும் அதன் வாதங்களை "
-"பயன்படுத்த"
+"முனையத்தில் உள்ள இயக்க ஒரு கட்டளை கட்டளை வரி பாக்கி, மற்றும் அதன் வாதங்களை பயன்படுத்த"
 
 #: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
@@ -471,20 +327,15 @@ msgstr "பிழைத்திருத்த தகவலை இயக்க�
 
 #: ../terminatorlib/optionparse.py:92
 msgid "Comma separated list of classes to limit debugging to"
-msgstr ""
-"என்று பிழைத்திருத்தங்களுக்கும் கட்டுப்படுத்த வகுப்புகள் கமாவால் "
-"பிரிக்கப்பட்ட பட்டியல்"
+msgstr "என்று பிழைத்திருத்தங்களுக்கும் கட்டுப்படுத்த வகுப்புகள் கமாவால் பிரிக்கப்பட்ட பட்டியல்"
 
 #: ../terminatorlib/optionparse.py:94
 msgid "Comma separated list of methods to limit debugging to"
-msgstr ""
-"என்று பிழைத்திருத்தங்களுக்கும் கட்டுப்படுத்த முறைகள் கமாவால் பிரிக்கப்பட்ட "
-"பட்டியல்"
+msgstr "என்று பிழைத்திருத்தங்களுக்கும் கட்டுப்படுத்த முறைகள் கமாவால் பிரிக்கப்பட்ட பட்டியல்"
 
 #: ../terminatorlib/optionparse.py:96
 msgid "If Terminator is already running, just open a new tab"
-msgstr ""
-"முனையம் ஏற்கனவே இயக்கத்தில் இருந்தால், ஒரு புதிய தாவலை மட்டும் திறக்கவும்"
+msgstr "முனையம் ஏற்கனவே இயக்கத்தில் இருந்தால், ஒரு புதிய தாவலை மட்டும் திறக்கவும்"
 
 #: ../terminatorlib/optionparse.py:98
 msgid "If Terminator is already running, just unhide all hidden windows"
@@ -522,7 +373,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "முன்னுரிமைகள்"
 
@@ -547,12 +398,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -658,7 +509,7 @@ msgid "Escape sequence"
 msgstr "விடுபடு தொடர்"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "அனைத்து"
 
@@ -875,43 +726,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -919,437 +770,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
-msgstr "உலக"
+msgid "Tabs scroll buttons"
+msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
-msgstr ""
+msgid "Global"
+msgstr "உலக"
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
-msgstr "_ நகர்வு முக்கிய உருவாக்குகிறது:"
+msgid "Scrolling"
+msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
+msgid "_Backspace key generates:"
+msgstr "_ நகர்வு முக்கிய உருவாக்குகிறது:"
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "விவரக்குறிப்புகள்"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1584,11 +1451,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "புதிய விவரம்"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "புதிய வடிவமைப்பு"
 
@@ -1601,185 +1468,169 @@ msgstr "தேடல்:"
 msgid "Close Search bar"
 msgstr "தேடல் பட்டையை மூடு"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "மின்னஞ்சல் அனுப்ப"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "மின்னஞ்சல் முகவரியை நகலெடுக்கவும்"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "VoIP முகவரியை அழைக்கவும்"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "VoIP முகவரியை நகலெடுக்கவும்"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "திறந்த இணைப்பு"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "திறந்த இணைப்பு"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "சமதளத்தில் பிரி"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "நெடுதளமாக பிரி"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "திறந்த தாவல்"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "திறந்த பிழைத்திருத்த தாவல்"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "முனையத்தை பெரிதாக்க"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "அனைத்து முனயங்களையும்  திரும்பப்பெறு"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "குழுவாக்கம்"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "சுருள் பட்டியை காட்டு"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "குறியாக்கம்"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "முன்னிருப்பு"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "பயனர் வரையறுத்தது"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "ஏனைய குறியாக்கம்"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "குழுக்களை நீக்க %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "அனைத்து தாவலில் குழு"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "அனைத்து குழுக்களை நீக்க"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "குழுவை மூடு  %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "நிரப்பட்ட முனைய எண்ணை சேர்க்க"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "ஓட்டை  ஆரம்பிக்க முடியவில்லை:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1887,12 +1738,117 @@ msgstr ""
 msgid "window"
 msgstr "சாளரம்"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "தாவல் %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "தற்போதைய மொழி உள்ளமைவு"
+
+#~ msgid "Western"
+#~ msgstr "மேற்கத்திய"
+
+#~ msgid "Central European"
+#~ msgstr "மத்திய ஐரோப்பா"
+
+#~ msgid "South European"
+#~ msgstr "தெற்கு ஐரோப்பா"
+
+#~ msgid "Baltic"
+#~ msgstr "பால்டிக்"
+
+#~ msgid "Cyrillic"
+#~ msgstr "சிரிலிக்"
+
+#~ msgid "Arabic"
+#~ msgstr "அராபிக்"
+
+#~ msgid "Greek"
+#~ msgstr "கிரேக்க"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "ஹீப்ரு காட்சி"
+
+#~ msgid "Hebrew"
+#~ msgstr "ஹீப்ரூ"
+
+#~ msgid "Turkish"
+#~ msgstr "துருக்கிய"
+
+#~ msgid "Nordic"
+#~ msgstr "நார்டிக்"
+
+#~ msgid "Celtic"
+#~ msgstr "செல்டிக்"
+
+#~ msgid "Romanian"
+#~ msgstr "ரோமேனியன்"
+
+#~ msgid "Unicode"
+#~ msgstr "யுனிகோட்"
+
+#~ msgid "Armenian"
+#~ msgstr "அர்மேனியன்"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "சீன மரபுவழி"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "சிரிலிக்/ரஷ்யன்"
+
+#~ msgid "Japanese"
+#~ msgstr "ஜப்பானிய"
+
+#~ msgid "Korean"
+#~ msgstr "கொரியன்"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "எளிதாக்கிய சீனம்"
+
+#~ msgid "Georgian"
+#~ msgstr "ஜோர்ஜியன்"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "சிரிலிக்/உக்ரெயின்"
+
+#~ msgid "Croatian"
+#~ msgstr "குரோஷியன்"
+
+#~ msgid "Hindi"
+#~ msgstr "ஹிந்தி"
+
+#~ msgid "Persian"
+#~ msgstr "பெர்சியன்"
+
+#~ msgid "Gujarati"
+#~ msgstr "குஜராத்தி"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "குருமுகி"
+
+#~ msgid "Icelandic"
+#~ msgstr "ஐஸ்லான்டிக்"
+
+#~ msgid "Vietnamese"
+#~ msgstr "வியட்னாமியன்"
+
+#~ msgid "Thai"
+#~ msgstr "தாய்லாந்து"
+
+#~ msgid "Encodings"
+#~ msgstr "குறியாக்கம்"
+
+#~ msgid "Default"
+#~ msgstr "முன்னிருப்பு"
+
+#~ msgid "User defined"
+#~ msgstr "பயனர் வரையறுத்தது"
+
+#~ msgid "Other Encodings"
+#~ msgstr "ஏனைய குறியாக்கம்"

--- a/po/te.po
+++ b/po/te.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Telugu (https://www.transifex.com/terminator/teams/109338/te/)\n"
+"Language-Team: Telugu (https://www.transifex.com/terminator/teams/109338/"
+"te/)\n"
+"Language: te\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: te\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "టెర్మినేటర్"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "ఒకే విండోలో బహుళ టెర్మినల్స్"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "ప్రస్తుత స్థానికం"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "పాశ్చాత్య"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "మధ్య యూరోపియన్"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "దక్షిణ యూరోపియన్"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "బాల్టిక్"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "సిరిలిక్"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "అరబిక్"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "గ్రీకు"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "హిబ్రూ విజువల్"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "హిబ్రూ"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "టర్కిష్"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "నోర్డిక్"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "సెల్టిక్"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "రోమేనియన్"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "యునీకోడ్"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "ఆర్మేనియన్"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "సంప్రదాయ చైనీస్"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "సిరిలిక్/రష్యన్"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "జపనీస్"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "కొరియన్"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "సరళీకృత చైనీస్"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "జార్జియన్"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "సిరిలిక్/ఉక్రైనియన్"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "క్రోటియన్"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "హిందీ"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "పర్షియన్"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "గుజరాతీ"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "గురుముఖి"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "ఐస్‌లాండిక్"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "వియెత్నామీస్"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "థాయి"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "టాబ్"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "టాబ్‌ను మూసివెయ్యి"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "ప్రాధాన్యతలు (_P)"
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "అన్నీ"
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "ప్రొఫైల్స్"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "కొత్త ప్రొఫైల్"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "కొత్త నమూనా"
 
@@ -1594,185 +1467,169 @@ msgstr "శోధించు:"
 msgid "Close Search bar"
 msgstr "శోధన పట్టీని మూసివేయి"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "వీరికి మెయిల్ పంపు...(_S)"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "ఈమెయిల్ చిరునామాని నకలుతీయి (_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "VoIP చిరునామాను కాల్ చేయి (_l)"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "VoIP చిరునామాను నకలుతీయి (_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "లింకును తెరువు (_O)"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "చిరునామాను నకలుతీయి (_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "ట్యాబ్ తెరువు (_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "ఎన్‌కోడింగులు"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "అప్రమేయం"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,111 @@ msgstr ""
 msgid "window"
 msgstr "విండో"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "ప్రస్తుత స్థానికం"
+
+#~ msgid "Western"
+#~ msgstr "పాశ్చాత్య"
+
+#~ msgid "Central European"
+#~ msgstr "మధ్య యూరోపియన్"
+
+#~ msgid "South European"
+#~ msgstr "దక్షిణ యూరోపియన్"
+
+#~ msgid "Baltic"
+#~ msgstr "బాల్టిక్"
+
+#~ msgid "Cyrillic"
+#~ msgstr "సిరిలిక్"
+
+#~ msgid "Arabic"
+#~ msgstr "అరబిక్"
+
+#~ msgid "Greek"
+#~ msgstr "గ్రీకు"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "హిబ్రూ విజువల్"
+
+#~ msgid "Hebrew"
+#~ msgstr "హిబ్రూ"
+
+#~ msgid "Turkish"
+#~ msgstr "టర్కిష్"
+
+#~ msgid "Nordic"
+#~ msgstr "నోర్డిక్"
+
+#~ msgid "Celtic"
+#~ msgstr "సెల్టిక్"
+
+#~ msgid "Romanian"
+#~ msgstr "రోమేనియన్"
+
+#~ msgid "Unicode"
+#~ msgstr "యునీకోడ్"
+
+#~ msgid "Armenian"
+#~ msgstr "ఆర్మేనియన్"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "సంప్రదాయ చైనీస్"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "సిరిలిక్/రష్యన్"
+
+#~ msgid "Japanese"
+#~ msgstr "జపనీస్"
+
+#~ msgid "Korean"
+#~ msgstr "కొరియన్"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "సరళీకృత చైనీస్"
+
+#~ msgid "Georgian"
+#~ msgstr "జార్జియన్"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "సిరిలిక్/ఉక్రైనియన్"
+
+#~ msgid "Croatian"
+#~ msgstr "క్రోటియన్"
+
+#~ msgid "Hindi"
+#~ msgstr "హిందీ"
+
+#~ msgid "Persian"
+#~ msgstr "పర్షియన్"
+
+#~ msgid "Gujarati"
+#~ msgstr "గుజరాతీ"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "గురుముఖి"
+
+#~ msgid "Icelandic"
+#~ msgstr "ఐస్‌లాండిక్"
+
+#~ msgid "Vietnamese"
+#~ msgstr "వియెత్నామీస్"
+
+#~ msgid "Thai"
+#~ msgstr "థాయి"
+
+#~ msgid "Encodings"
+#~ msgstr "ఎన్‌కోడింగులు"
+
+#~ msgid "Default"
+#~ msgstr "అప్రమేయం"

--- a/po/terminator.pot
+++ b/po/terminator.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -119,7 +119,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -128,7 +128,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -220,156 +220,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -377,11 +233,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -511,7 +367,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -536,12 +392,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -647,7 +503,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -864,43 +720,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -908,230 +764,238 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
+msgid "lines"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:129
+msgid "Scrolling"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1139,108 +1003,104 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1254,99 +1114,103 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1581,11 +1445,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1598,185 +1462,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1884,12 +1732,12 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -2,23 +2,23 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Thai (https://www.transifex.com/terminator/teams/109338/th/)\n"
+"Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: th\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +123,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +132,7 @@ msgid "Multiple terminals in one window"
 msgstr "หลายเทอร์มินัลในหน้าต่างเดียว"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +140,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +224,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "โลแคลปัจจุบัน"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "ตะวันตก"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "ยุโรปตอนกลาง"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "ยุโรปตอนใต้"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "บอลติก"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "ไซริลลิค"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "อารบิก"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "กรีก"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "ฮีบรู (ซ้ายไปขวา)"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "ฮีบรู"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "ตรุกี"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "นอร์ดิก"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "เซลติก"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "โรมาเนีย"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "ยูนิโค้ด"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "อาร์เมเนีย"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "ไซริลลิก/รัซเซีย"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "ญี่ปุ่น"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "จอร์เจีย"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "ไซริลลิก/ยูเครน"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "โครเอเชีย"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "ฮินดี"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "เปอร์เซีย"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "ไอซ์แลนด์"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "เวียดนาม"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "ไทย"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +237,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "แท็บ"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "ปิดแท็ป"
 
@@ -515,7 +371,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +396,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +507,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "ทั้งหมด"
 
@@ -868,43 +724,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +768,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1449,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "โปรไฟล์ใหม่"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1466,169 @@ msgstr "ค้นหา:"
 msgid "Close Search bar"
 msgstr "ปิดแถมค้นหา"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "ลบกลุ่ม %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "ลบกลุ่มทั้งหมด"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "ปิดกลุ่ม %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1736,90 @@ msgstr ""
 msgid "window"
 msgstr "หน้าต่าง"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "โลแคลปัจจุบัน"
+
+#~ msgid "Western"
+#~ msgstr "ตะวันตก"
+
+#~ msgid "Central European"
+#~ msgstr "ยุโรปตอนกลาง"
+
+#~ msgid "South European"
+#~ msgstr "ยุโรปตอนใต้"
+
+#~ msgid "Baltic"
+#~ msgstr "บอลติก"
+
+#~ msgid "Cyrillic"
+#~ msgstr "ไซริลลิค"
+
+#~ msgid "Arabic"
+#~ msgstr "อารบิก"
+
+#~ msgid "Greek"
+#~ msgstr "กรีก"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "ฮีบรู (ซ้ายไปขวา)"
+
+#~ msgid "Hebrew"
+#~ msgstr "ฮีบรู"
+
+#~ msgid "Turkish"
+#~ msgstr "ตรุกี"
+
+#~ msgid "Nordic"
+#~ msgstr "นอร์ดิก"
+
+#~ msgid "Celtic"
+#~ msgstr "เซลติก"
+
+#~ msgid "Romanian"
+#~ msgstr "โรมาเนีย"
+
+#~ msgid "Unicode"
+#~ msgstr "ยูนิโค้ด"
+
+#~ msgid "Armenian"
+#~ msgstr "อาร์เมเนีย"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "ไซริลลิก/รัซเซีย"
+
+#~ msgid "Japanese"
+#~ msgstr "ญี่ปุ่น"
+
+#~ msgid "Georgian"
+#~ msgstr "จอร์เจีย"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "ไซริลลิก/ยูเครน"
+
+#~ msgid "Croatian"
+#~ msgstr "โครเอเชีย"
+
+#~ msgid "Hindi"
+#~ msgstr "ฮินดี"
+
+#~ msgid "Persian"
+#~ msgstr "เปอร์เซีย"
+
+#~ msgid "Icelandic"
+#~ msgstr "ไอซ์แลนด์"
+
+#~ msgid "Vietnamese"
+#~ msgstr "เวียดนาม"
+
+#~ msgid "Thai"
+#~ msgstr "ไทย"

--- a/po/tr.po
+++ b/po/tr.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Turkish (https://www.transifex.com/terminator/teams/109338/tr/)\n"
+"Language-Team: Turkish (https://www.transifex.com/terminator/teams/109338/"
+"tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. Command             uuid req.    Description
@@ -126,7 +127,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Uçbirim"
 
@@ -135,7 +136,7 @@ msgid "Multiple terminals in one window"
 msgstr "Tek pencerede birden çok uçbirim"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -143,8 +144,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -227,156 +228,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Bu mesajı bir dahaki sefere gösterme"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Şimdiki Yerel"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Batılı"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Orta Avrupa"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Güney Avrupa"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Baltık"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Kiril"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Arapça"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Yunanca"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Görsel İbranice"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "İbranice"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Türkçe"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "İskandinav"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Kelt"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Romanca"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Ermenice"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Geleneksel Çince"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Kiril/Rusça"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Japonca"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Korece"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Basitleştirilmiş Çince"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Gürcü Dili"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Kiril/Ukraynaca"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Hırvatça"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Hintçe"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Farsça"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Gujarati Dili"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Gurmukhi"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "İzlandaca"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Vietnamca"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tai Dili"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Terminator dizilim başlatıcı"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "Dizilim"
 
@@ -384,11 +241,11 @@ msgstr "Dizilim"
 msgid "Launch"
 msgstr "Çalıştır"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "sekme"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Sekmeyi Kapat"
 
@@ -521,7 +378,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Tercihler"
 
@@ -546,12 +403,12 @@ msgid "Enabled"
 msgstr "Etkin"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "Adı"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Komut"
 
@@ -657,7 +514,7 @@ msgid "Escape sequence"
 msgstr "Kaçış dizisi"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Tümü"
 
@@ -874,481 +731,497 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>Görünüm</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Pencere kenarlıkları"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "Terminal ayırıcı boyutu:"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "Sekme konumu:"
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "Homojen sekmeler"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Evrensel"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Profil"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "Sistemin sabit genişlikteki yazı tipini kullan."
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Yazı tipi:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Bir Uçbirim Yazıtipi Seçin"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Kalın metne izin ver"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Başlıkçubuğunu göster"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Seçimi kopyala"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>İmleç</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "_Biçim"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "Yanıp sönme"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "Arkaplan"
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Genel"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "_Giriş kabuğu yerine komut çalıştır"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Komutu özelleştir"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Önplan ve Arkaplan</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Sistem temasının renklerini kullan"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Palet</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Renkler"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Hiçbiri</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Maksimum</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Arkaplan"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "Kaydırma çubuğu:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Kaydırma"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Geri tuşuna basıldığında:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Sil tuşuna basıldığında:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Uyumluluk"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "Odaklanmış"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "Pasif"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "Alınıyor"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Profiller"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Eklentiler"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1583,11 +1456,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Yeni Profil"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Yeni Düzen"
 
@@ -1600,185 +1473,169 @@ msgstr "Ara:"
 msgid "Close Search bar"
 msgstr "Arama çubuğunu Kapat"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "Şuna e-posta _gönder:"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_E-posta adreslerini kopyala"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "VoIP adresi a_ra"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "VoIP adresini _kopyala"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Bağlantıyı aç"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Adresi kopyala"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Y_atay olarak Böl"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "D_ikey olarak Böl"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "_Sekme Aç"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "hata ayıkla"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "Uçbirimi _yakınlaştır"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "Tüm uçbirimleri _geri al"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Gruplandırma"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "K_aydırma çubuğunu göster"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Kodlamalar"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "Öntanımlı"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Kullanıcı tanımlı"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Diğer Kodlamalar"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "%s grubunu kaldır"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "Hepsini sekmede t_opla"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Tüm grupları kaldır"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "%s grubunu kapat"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Kabuk bulunamadı"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Kabuk başlatılamadı:"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1886,12 +1743,117 @@ msgstr ""
 msgid "window"
 msgstr "pencere"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Sekme %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Şimdiki Yerel"
+
+#~ msgid "Western"
+#~ msgstr "Batılı"
+
+#~ msgid "Central European"
+#~ msgstr "Orta Avrupa"
+
+#~ msgid "South European"
+#~ msgstr "Güney Avrupa"
+
+#~ msgid "Baltic"
+#~ msgstr "Baltık"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Kiril"
+
+#~ msgid "Arabic"
+#~ msgstr "Arapça"
+
+#~ msgid "Greek"
+#~ msgstr "Yunanca"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Görsel İbranice"
+
+#~ msgid "Hebrew"
+#~ msgstr "İbranice"
+
+#~ msgid "Turkish"
+#~ msgstr "Türkçe"
+
+#~ msgid "Nordic"
+#~ msgstr "İskandinav"
+
+#~ msgid "Celtic"
+#~ msgstr "Kelt"
+
+#~ msgid "Romanian"
+#~ msgstr "Romanca"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Ermenice"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Geleneksel Çince"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Kiril/Rusça"
+
+#~ msgid "Japanese"
+#~ msgstr "Japonca"
+
+#~ msgid "Korean"
+#~ msgstr "Korece"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Basitleştirilmiş Çince"
+
+#~ msgid "Georgian"
+#~ msgstr "Gürcü Dili"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Kiril/Ukraynaca"
+
+#~ msgid "Croatian"
+#~ msgstr "Hırvatça"
+
+#~ msgid "Hindi"
+#~ msgstr "Hintçe"
+
+#~ msgid "Persian"
+#~ msgstr "Farsça"
+
+#~ msgid "Gujarati"
+#~ msgstr "Gujarati Dili"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Gurmukhi"
+
+#~ msgid "Icelandic"
+#~ msgstr "İzlandaca"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Vietnamca"
+
+#~ msgid "Thai"
+#~ msgstr "Tai Dili"
+
+#~ msgid "Encodings"
+#~ msgstr "Kodlamalar"
+
+#~ msgid "Default"
+#~ msgstr "Öntanımlı"
+
+#~ msgid "User defined"
+#~ msgstr "Kullanıcı tanımlı"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Diğer Kodlamalar"

--- a/po/tyv.po
+++ b/po/tyv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: terminator\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2015-08-03 19:30+0000\n"
 "Last-Translator: boracasli <Unknown>\n"
 "Language-Team: Tuvinian <tyv@li.org>\n"
@@ -120,7 +120,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -221,156 +221,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Барыын"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Төп европа"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Мурнуу чүк европа"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -378,11 +234,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -512,7 +368,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -537,12 +393,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -648,7 +504,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -865,43 +721,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -909,230 +765,238 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
+msgid "lines"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:129
+msgid "Scrolling"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
@@ -1140,108 +1004,104 @@ msgid ""
 "i></small>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
 "The goal of this project is to produce a useful tool for arranging "
 "terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
@@ -1255,99 +1115,103 @@ msgid ""
 "the Development link)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
 "<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
 "Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1582,11 +1446,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1599,185 +1463,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1885,12 +1733,21 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Western"
+#~ msgstr "Барыын"
+
+#~ msgid "Central European"
+#~ msgstr "Төп европа"
+
+#~ msgid "South European"
+#~ msgstr "Мурнуу чүк европа"

--- a/po/ug.po
+++ b/po/ug.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Uyghur (https://www.transifex.com/terminator/teams/109338/ug/)\n"
+"Language-Team: Uyghur (https://www.transifex.com/terminator/teams/109338/"
+"ug/)\n"
+"Language: ug\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ug\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,12 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -2,25 +2,29 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
 # Artem Mikhmel, 2021
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Artem Mikhmel, 2021\n"
-"Language-Team: Ukrainian (https://www.transifex.com/terminator/teams/109338/uk/)\n"
+"Language-Team: Ukrainian (https://www.transifex.com/terminator/teams/109338/"
+"uk/)\n"
+"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: uk\n"
-"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != "
+"11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % "
+"100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || "
+"(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 
 #. Command             uuid req.    Description
 #: ../remotinator.py:39
@@ -129,7 +133,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -138,7 +142,7 @@ msgid "Multiple terminals in one window"
 msgstr "Кілька терміналів в одному вікні"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -146,8 +150,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -230,156 +234,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Більше не показувати це повідомлення"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Поточна локаль"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Захіно-європейська"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Центрально-європейська"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Південно-європейська"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Балтійська"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Кирилиця"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Арабська"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Грецька"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Єврейська візуальна"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Іврит"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "Турецька"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Скандинавські"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Кельтська"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Румунська"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Вірменська"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Традиційна китайська"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Кирилиця/Росія"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Японська"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Корейська"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Спрощена китайська"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Грузинська"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Кирилиця/Україна"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "Хорватська"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "Хінді"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "Перська"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "Гуджараті"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "Гурмухі"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "Ісландська"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "В'єтнамська"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Тайська"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -387,11 +247,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "вкладка"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Закрити вкладку"
 
@@ -433,8 +293,8 @@ msgid ""
 "Use the rest of the command line as a command to execute inside the "
 "terminal, and its arguments"
 msgstr ""
-"Використати залишок командного рядку як команду та її аргументи, що потрібно"
-" виконати в терміналі"
+"Використати залишок командного рядку як команду та її аргументи, що потрібно "
+"виконати в терміналі"
 
 #: ../terminatorlib/optionparse.py:69
 msgid "Specify a config file"
@@ -525,7 +385,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "_Налаштування"
 
@@ -550,12 +410,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "Команда"
 
@@ -661,7 +521,7 @@ msgid "Escape sequence"
 msgstr "Escape-послідовність"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "Усе"
 
@@ -878,43 +738,43 @@ msgid "Use custom URL handler"
 msgstr "Використовуйте користувальницький обробник URL"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
+msgid "<b>Appearance</b>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "Рамки вікон"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
-msgstr ""
-
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -922,441 +782,457 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
+msgid "Tabs scroll buttons"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:76
+msgid "Title bar at bottom (Require restart)"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "Загальний"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "Профіль"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "_Використовувати системний шрифт з фіксованою шириною"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "_Шрифт:"
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "Вибрати шрифт терміналу"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "_Дозволити жирний текст"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "Показати заголовок"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "Копіювання на вибір"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "Вибір _слів за символами:"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>Курсор </b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>Сигнал терміналу</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "Іконка заголовка"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "Помітний сигнал (блимання)"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "Звуковий сигнал"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "Блимання вікном"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "Загальний"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "За_пускати команду як  оболонку входу"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "Запускати _іншу команду замість моєї оболонки"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "Користувацька к_оманда:"
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "При _виході з команди:"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>Переднього і заднього плану</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "_Використати кольори з системної  теми"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "Вбудовані  схе_ми:"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>Палітра </b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "Вбудовані  с_хеми:"
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "Кольорова палітра:"
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "Кольори"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "Су_цільний  колір"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "_Прозорий фон"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>Ніякої</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>Максимальне </i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "Фон"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "С_муга  прокрутки:"
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "Про_кручувати  при виводі"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "_Прокручувати  при натисканні клавіші"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "Нескінченна прокрутка"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "З_воротна  прокрутка:"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "рядки"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "Прокрутка"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 "<small><i><b>Note:</b> Ці параметри можуть викликати некоректну роботу "
 "деяких додатків. Вони представлені тільки для того, щоб дозволити працювати "
-"з деякими програмами та операційними ситемами, які очікували іншої поведінки"
-" терміналу.</i></small>"
+"з деякими програмами та операційними ситемами, які очікували іншої поведінки "
+"терміналу.</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Клавіша  _Backspace генерує:"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Клавіша  _Delete генерує:"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "_Восстановить параметры совместимости по умолчанию"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "Сумісність"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "Профілі"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "Шаблони"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "Комбінації  клавіш"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "Цей плагін не має параметрів конфігурації"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "Плагіни"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1591,11 +1467,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "Новий профіль"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "Поточна локаль"
 
@@ -1608,185 +1484,169 @@ msgstr "Знайти:"
 msgid "Close Search bar"
 msgstr "Закрити панель пошуку"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "_Відправити email до..."
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "_Копіювати адресу email"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "Подз_вонити VoIP за адресою"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "_Копіювати адресу VoIP"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "_Відкрити посилання"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "_Копіювати адресу"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "Розділити горизонтально"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "Розділити вертикально"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "Відкрити в_кладку"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "Відкрити відла_годжувальну вкладку"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "_Збільшити термінал"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "_Відновити всі термінали"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "Групування"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "Показувати повзунок прокрутки"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "Кодування"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "За замовчуванням"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "Визначене користувачем"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "Інше кодування"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "Видалити групу %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "З_групувати все на вкладці"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "Видалити усі групи"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "Закрити групу %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "Не вдалося знайти командну оболонку"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "Неможливо запустити оболонку"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "Перейменування вікна"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "Введіть нову назву для вікна Terminator..."
 
@@ -1894,12 +1754,117 @@ msgstr ""
 msgid "window"
 msgstr "вікно"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "Вкладка %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "Поточна локаль"
+
+#~ msgid "Western"
+#~ msgstr "Захіно-європейська"
+
+#~ msgid "Central European"
+#~ msgstr "Центрально-європейська"
+
+#~ msgid "South European"
+#~ msgstr "Південно-європейська"
+
+#~ msgid "Baltic"
+#~ msgstr "Балтійська"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Кирилиця"
+
+#~ msgid "Arabic"
+#~ msgstr "Арабська"
+
+#~ msgid "Greek"
+#~ msgstr "Грецька"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Єврейська візуальна"
+
+#~ msgid "Hebrew"
+#~ msgstr "Іврит"
+
+#~ msgid "Turkish"
+#~ msgstr "Турецька"
+
+#~ msgid "Nordic"
+#~ msgstr "Скандинавські"
+
+#~ msgid "Celtic"
+#~ msgstr "Кельтська"
+
+#~ msgid "Romanian"
+#~ msgstr "Румунська"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Вірменська"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Традиційна китайська"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Кирилиця/Росія"
+
+#~ msgid "Japanese"
+#~ msgstr "Японська"
+
+#~ msgid "Korean"
+#~ msgstr "Корейська"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Спрощена китайська"
+
+#~ msgid "Georgian"
+#~ msgstr "Грузинська"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Кирилиця/Україна"
+
+#~ msgid "Croatian"
+#~ msgstr "Хорватська"
+
+#~ msgid "Hindi"
+#~ msgstr "Хінді"
+
+#~ msgid "Persian"
+#~ msgstr "Перська"
+
+#~ msgid "Gujarati"
+#~ msgstr "Гуджараті"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "Гурмухі"
+
+#~ msgid "Icelandic"
+#~ msgstr "Ісландська"
+
+#~ msgid "Vietnamese"
+#~ msgstr "В'єтнамська"
+
+#~ msgid "Thai"
+#~ msgstr "Тайська"
+
+#~ msgid "Encodings"
+#~ msgstr "Кодування"
+
+#~ msgid "Default"
+#~ msgstr "За замовчуванням"
+
+#~ msgid "User defined"
+#~ msgstr "Визначене користувачем"
+
+#~ msgid "Other Encodings"
+#~ msgstr "Інше кодування"

--- a/po/ur.po
+++ b/po/ur.po
@@ -2,23 +2,23 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
 "Language-Team: Urdu (https://www.transifex.com/terminator/teams/109338/ur/)\n"
+"Language: ur\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ur\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +123,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +132,7 @@ msgid "Multiple terminals in one window"
 msgstr "ایک دریچے میں ایک سے زیادہ ٹرمنل"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +140,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +224,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "موجودہ لوکیل"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "مغربی"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "مرکزی یورپی"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "جنوبی یورپ"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "بالٹک"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "سرلک"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "عربی"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "یونان"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "عبرانی گيا"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "ہیبرو"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "تركی"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "نارڈک"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "کیلٹک"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "رومینیائی"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "یونیکوڈ"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "آرمینیائی"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "چینی روایتی"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "سرلک/روسی"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "جاپانی"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "کوریائی"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "چين"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "جارجئین"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "سرلک/يوکرينی"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "کرو شين"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "ہندی"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "فارسی"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +237,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "ٹیب"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "ٹیب بند کریں"
 
@@ -515,7 +371,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +396,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +507,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +724,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +768,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1449,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1466,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1736,90 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "موجودہ لوکیل"
+
+#~ msgid "Western"
+#~ msgstr "مغربی"
+
+#~ msgid "Central European"
+#~ msgstr "مرکزی یورپی"
+
+#~ msgid "South European"
+#~ msgstr "جنوبی یورپ"
+
+#~ msgid "Baltic"
+#~ msgstr "بالٹک"
+
+#~ msgid "Cyrillic"
+#~ msgstr "سرلک"
+
+#~ msgid "Arabic"
+#~ msgstr "عربی"
+
+#~ msgid "Greek"
+#~ msgstr "یونان"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "عبرانی گيا"
+
+#~ msgid "Hebrew"
+#~ msgstr "ہیبرو"
+
+#~ msgid "Turkish"
+#~ msgstr "تركی"
+
+#~ msgid "Nordic"
+#~ msgstr "نارڈک"
+
+#~ msgid "Celtic"
+#~ msgstr "کیلٹک"
+
+#~ msgid "Romanian"
+#~ msgstr "رومینیائی"
+
+#~ msgid "Unicode"
+#~ msgstr "یونیکوڈ"
+
+#~ msgid "Armenian"
+#~ msgstr "آرمینیائی"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "چینی روایتی"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "سرلک/روسی"
+
+#~ msgid "Japanese"
+#~ msgstr "جاپانی"
+
+#~ msgid "Korean"
+#~ msgstr "کوریائی"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "چين"
+
+#~ msgid "Georgian"
+#~ msgstr "جارجئین"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "سرلک/يوکرينی"
+
+#~ msgid "Croatian"
+#~ msgstr "کرو شين"
+
+#~ msgid "Hindi"
+#~ msgstr "ہندی"
+
+#~ msgid "Persian"
+#~ msgstr "فارسی"

--- a/po/vi.po
+++ b/po/vi.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Vietnamese (https://www.transifex.com/terminator/teams/109338/vi/)\n"
+"Language-Team: Vietnamese (https://www.transifex.com/terminator/teams/109338/"
+"vi/)\n"
+"Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: vi\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr "Mở nhiều terminal trong cùng cửa sổ"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr "Không hiển thị tin nhắn này lần nữa"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "Ngôn ngữ hiện dùng"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "Phương Tây"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "Trung Âu"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "Nam Âu"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "Ban-tích"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "Cyrillic"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "Ả Rập"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "Hi Lạp"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "Hebrew Visual"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "Do Thái"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "TIếng Thổ Nhĩ Kỳ"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "Tiếng Bắc Âu"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "Tiếng Celtic"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "Tiếng Ru-ma-ni"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "Tiếng Acmênia"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "Tiếng Trung phồn thể"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "Chữ cái Kirin/Nga"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "Tiếng Nhật"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "Tiếng Hàn Quốc"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "Tiếng Trung giản thể"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "Georgia"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "Chữ cái Kirin/Ukraina"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "Tiếng Việt"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "Tiếng Thái"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "tab"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "Đóng tab"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,87 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "Ngôn ngữ hiện dùng"
+
+#~ msgid "Western"
+#~ msgstr "Phương Tây"
+
+#~ msgid "Central European"
+#~ msgstr "Trung Âu"
+
+#~ msgid "South European"
+#~ msgstr "Nam Âu"
+
+#~ msgid "Baltic"
+#~ msgstr "Ban-tích"
+
+#~ msgid "Cyrillic"
+#~ msgstr "Cyrillic"
+
+#~ msgid "Arabic"
+#~ msgstr "Ả Rập"
+
+#~ msgid "Greek"
+#~ msgstr "Hi Lạp"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "Hebrew Visual"
+
+#~ msgid "Hebrew"
+#~ msgstr "Do Thái"
+
+#~ msgid "Turkish"
+#~ msgstr "TIếng Thổ Nhĩ Kỳ"
+
+#~ msgid "Nordic"
+#~ msgstr "Tiếng Bắc Âu"
+
+#~ msgid "Celtic"
+#~ msgstr "Tiếng Celtic"
+
+#~ msgid "Romanian"
+#~ msgstr "Tiếng Ru-ma-ni"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "Tiếng Acmênia"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "Tiếng Trung phồn thể"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "Chữ cái Kirin/Nga"
+
+#~ msgid "Japanese"
+#~ msgstr "Tiếng Nhật"
+
+#~ msgid "Korean"
+#~ msgstr "Tiếng Hàn Quốc"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "Tiếng Trung giản thể"
+
+#~ msgid "Georgian"
+#~ msgstr "Georgia"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "Chữ cái Kirin/Ukraina"
+
+#~ msgid "Vietnamese"
+#~ msgstr "Tiếng Việt"
+
+#~ msgid "Thai"
+#~ msgstr "Tiếng Thái"

--- a/po/wa.po
+++ b/po/wa.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Walloon (https://www.transifex.com/terminator/teams/109338/wa/)\n"
+"Language-Team: Walloon (https://www.transifex.com/terminator/teams/109338/"
+"wa/)\n"
+"Language: wa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: wa\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr ""
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr ""
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr ""
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr ""
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr ""
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr ""
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr ""
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,12 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Chinese (China) (https://www.transifex.com/terminator/teams/109338/zh_CN/)\n"
+"Language-Team: Chinese (China) (https://www.transifex.com/terminator/"
+"teams/109338/zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -128,7 +129,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator 终端终结者"
 
@@ -137,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "一个窗口中的多个终端"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "高级终端的未来"
 
@@ -145,8 +146,8 @@ msgstr "高级终端的未来"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -229,156 +230,12 @@ msgstr "此标签页已开启多个终端，关闭标签页将同时关闭已开
 msgid "Do not show this message next time"
 msgstr "不再显示这条信息"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "当前 Locale"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "西文"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "中欧语系"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "南欧语系"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "波罗的海语系"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "西里尔文"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "阿拉伯语"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "希腊语"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "希伯来语 (视觉顺序)"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "希伯来语"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "土耳其语"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "日耳曼语"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "凯尔特语"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "罗马尼亚语"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "Unicode"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "亚美尼亚语"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "繁体中文"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "西里尔语/俄语"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "日语"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "朝鲜语"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "简体中文"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "格鲁吉亚语"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "西里尔语/乌克兰语"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "克罗地亚语"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "印地语"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "波斯语"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "古吉拉特语"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "果鲁穆奇语"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "冰岛语"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "越南语"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "泰语"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Terminator布局启动器"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "布局"
 
@@ -386,11 +243,11 @@ msgstr "布局"
 msgid "Launch"
 msgstr "启动"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "标签页"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "关闭标签"
 
@@ -520,7 +377,7 @@ msgstr "自定义命令(_C）"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "配置文件首选项(_P)"
 
@@ -545,12 +402,12 @@ msgid "Enabled"
 msgstr "已启用"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "名称"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "命令"
 
@@ -656,7 +513,7 @@ msgid "Escape sequence"
 msgstr "转义序列"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "全部"
 
@@ -873,485 +730,506 @@ msgid "Use custom URL handler"
 msgstr "使用自定义的URL处理程序"
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr "自定义URL处理程序："
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr "自定义URL处理程序："
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>外观</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "窗口边框"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "非活动终端字体亮度："
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "终端分隔线宽度："
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr "扩展样式 (主题依赖)"
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "标签位置："
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "固定大小的标签"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr "标签滚动按钮"
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "全局"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "配置"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "使用系统的等宽字体(_U)"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "字体(_F)："
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "选择终端字体"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "允许粗体字(_A)"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "显示标题栏"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "选中则复制"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "视作单词组成部分的字符(_W)："
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>光标</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr "形状(_S)"
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "闪烁"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "背景："
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr "<b>终端响铃</b>"
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "标题栏图标"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr "闪烁显示"
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr "发出哔声"
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr "闪烁窗口列表"
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "一般设定"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr "以登录 Shell 方式运行命令(_R)"
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "运行自定义命令而不是 Shell(_N)"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "自定义命令(_M)："
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "命令退出时(_E)："
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>前景与背景</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "使用系统主题中的颜色(_U)"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "内置方案(_M)："
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>调色板</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "内置方案(_S)："
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "调色板(_A)："
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "色彩"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "纯色(_S)"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "透明背景(_T)"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>无</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>最大</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "背景"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "滚动条(_S)："
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "输出时滚动(_O)"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "击键时滚动(_K)"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "无限回滚"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "回滚(_B)："
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "行"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "滚动"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
-"<small><i><b>注意：</b>这些选项可能造成一些应用程序产生不正确的行为。仅用于允许您在一些应用程序和操作系统中作调整以获得不同的终端行为。</i></small>"
+"<small><i><b>注意：</b>这些选项可能造成一些应用程序产生不正确的行为。仅用于允"
+"许您在一些应用程序和操作系统中作调整以获得不同的终端行为。</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "按 _Backspace 键产生："
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "按 _Delete 键产生："
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "编码："
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "重置兼容性选项为默认值(_R)"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "兼容性"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "聚焦的"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "非活动"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "接收中"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "在标题中隐藏大小"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "使用系统字体(_U)"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "选择标题栏字体"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "配置"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "类型"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "配置："
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "自定义命令："
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "工作目录:"
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "布局"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "动作"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "键绑定"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "快捷键"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "插件"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "此插件没有配置项"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "插件"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"一个用来管理终端的高级用户工具。它的灵感来自于gnome-multi-term，quadkonsole等程序。它致力于用格子来管理终端（最普遍的方法是用标签页，Terminator也支持）。\n"
-"Terminator的大部分行为基于GNOME Terminal，我们还在从中集成更多特性。但我们同时也希望向扩展更多不同方面的实用特性从而服务于系统管理员和其他用户。如果你有任何建议，请向wishlist中提交！（看左边的开发者链接）"
+"一个用来管理终端的高级用户工具。它的灵感来自于gnome-multi-term，quadkonsole等"
+"程序。它致力于用格子来管理终端（最普遍的方法是用标签页，Terminator也支"
+"持）。\n"
+"Terminator的大部分行为基于GNOME Terminal，我们还在从中集成更多特性。但我们同"
+"时也希望向扩展更多不同方面的实用特性从而服务于系统管理员和其他用户。如果你有"
+"任何建议，请向wishlist中提交！（看左边的开发者链接）"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "手册"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "关于"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "增大字号"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "减小字号"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "恢复为原始字体大小"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "创建一个新标签页"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "聚焦到下一个终端"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "聚焦到上一个终端"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "聚焦到上方的终端"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "聚焦到下方的终端"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "聚焦到左边的终端"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "聚焦到右边的终端"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "顺时针方向切换终端"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "逆时针方向切换终端"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "水平分割"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "垂直分割"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "关闭终端"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "复制所选的文本"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "粘贴剪贴板"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1585,11 +1463,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "打开手册"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "新配置"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "新布局"
 
@@ -1602,185 +1480,169 @@ msgstr "搜索："
 msgid "Close Search bar"
 msgstr "关闭搜索栏"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "发送邮件到...(_S)"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "复制邮件地址(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "呼叫(_L) Voip 地址"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "复制(_C) Voip 地址"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "打开连接(_O)"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "复制地址(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "复制(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "粘贴(_P)"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "水平分割(_H)"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "垂直分割(_V)"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "打开标签(_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "打开Debug标签(_D)"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "关闭(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "缩放终端(_Z)"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "最大化终端(_X)"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "还原所有终端(_R)"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "分组"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "显示滚动条"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "编码"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "默认"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "用户定义"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "其他编码"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "新分组……(e)"
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "无(_N)"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "移除组 %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "将所有标签页中的终端合为一组(_R)"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "解散标签页中的分组(_U)"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "移除所有的组"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "关闭组 %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "广播到所有(_A)"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "广播到组(_G)"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "不广播(_O)"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "在组内分割(_S)"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr "自动清理分组(_C)"
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "插入终端编号(_I)"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr "插入对齐的终端编号(_I)"
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "无法找到shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "无法启动shell："
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "重命名窗口"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "输入新的Terminator窗口标题"
 
@@ -1888,12 +1750,120 @@ msgstr "Omega"
 msgid "window"
 msgstr "窗口"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "标签 %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "当前 Locale"
+
+#~ msgid "Western"
+#~ msgstr "西文"
+
+#~ msgid "Central European"
+#~ msgstr "中欧语系"
+
+#~ msgid "South European"
+#~ msgstr "南欧语系"
+
+#~ msgid "Baltic"
+#~ msgstr "波罗的海语系"
+
+#~ msgid "Cyrillic"
+#~ msgstr "西里尔文"
+
+#~ msgid "Arabic"
+#~ msgstr "阿拉伯语"
+
+#~ msgid "Greek"
+#~ msgstr "希腊语"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "希伯来语 (视觉顺序)"
+
+#~ msgid "Hebrew"
+#~ msgstr "希伯来语"
+
+#~ msgid "Turkish"
+#~ msgstr "土耳其语"
+
+#~ msgid "Nordic"
+#~ msgstr "日耳曼语"
+
+#~ msgid "Celtic"
+#~ msgstr "凯尔特语"
+
+#~ msgid "Romanian"
+#~ msgstr "罗马尼亚语"
+
+#~ msgid "Unicode"
+#~ msgstr "Unicode"
+
+#~ msgid "Armenian"
+#~ msgstr "亚美尼亚语"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "繁体中文"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "西里尔语/俄语"
+
+#~ msgid "Japanese"
+#~ msgstr "日语"
+
+#~ msgid "Korean"
+#~ msgstr "朝鲜语"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "简体中文"
+
+#~ msgid "Georgian"
+#~ msgstr "格鲁吉亚语"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "西里尔语/乌克兰语"
+
+#~ msgid "Croatian"
+#~ msgstr "克罗地亚语"
+
+#~ msgid "Hindi"
+#~ msgstr "印地语"
+
+#~ msgid "Persian"
+#~ msgstr "波斯语"
+
+#~ msgid "Gujarati"
+#~ msgstr "古吉拉特语"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "果鲁穆奇语"
+
+#~ msgid "Icelandic"
+#~ msgstr "冰岛语"
+
+#~ msgid "Vietnamese"
+#~ msgstr "越南语"
+
+#~ msgid "Thai"
+#~ msgstr "泰语"
+
+#~ msgid "Encoding:"
+#~ msgstr "编码："
+
+#~ msgid "Encodings"
+#~ msgstr "编码"
+
+#~ msgid "Default"
+#~ msgstr "默认"
+
+#~ msgid "User defined"
+#~ msgstr "用户定义"
+
+#~ msgid "Other Encodings"
+#~ msgstr "其他编码"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Chinese (Hong Kong) (https://www.transifex.com/terminator/teams/109338/zh_HK/)\n"
+"Language-Team: Chinese (Hong Kong) (https://www.transifex.com/terminator/"
+"teams/109338/zh_HK/)\n"
+"Language: zh_HK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_HK\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -123,7 +124,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr ""
 
@@ -132,7 +133,7 @@ msgid "Multiple terminals in one window"
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr ""
 
@@ -140,8 +141,8 @@ msgstr ""
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -224,156 +225,12 @@ msgstr ""
 msgid "Do not show this message next time"
 msgstr ""
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "目前的地區語言"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "西歐地區"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "中歐地區"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "南歐地區"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "波羅的海語系"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "斯拉夫語系"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "阿拉伯文"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "希臘文"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "希伯來文（左至右）"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "希伯來文"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "土耳其語"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "北歐語系"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "塞爾特語系"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "羅馬尼亞語"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "萬國碼"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "亞美尼亞文"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "中文（繁體）"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "斯拉夫文字/俄文"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "日文"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "韓文"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "中文（簡體）"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "格魯吉亞文"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "斯拉夫文/烏克蘭文"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "克羅地亞文"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "印地語"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "波斯語"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "古吉拉特語"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "古爾穆奇文"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "冰島語"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "越南語"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "泰文"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr ""
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr ""
 
@@ -381,11 +238,11 @@ msgstr ""
 msgid "Launch"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr ""
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "關閉分頁"
 
@@ -515,7 +372,7 @@ msgstr ""
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr ""
 
@@ -540,12 +397,12 @@ msgid "Enabled"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr ""
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr ""
 
@@ -651,7 +508,7 @@ msgid "Escape sequence"
 msgstr ""
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr ""
 
@@ -868,43 +725,43 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
-msgid "<b>Appearance</b>"
+msgid "Custom URL handler:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:66
-msgid "Window borders"
+msgid "<b>Appearance</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:67
-msgid "Unfocused terminal font brightness:"
+msgid "Window borders"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:68
-msgid "Terminal separator size:"
+msgid "Unfocused terminal font brightness:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
+msgid "Terminal separator size:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
@@ -912,437 +769,453 @@ msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
-msgid "Tab position:"
+msgid "Cell Height:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:72
-msgid "Tabs homogeneous"
+msgid "Cell Width:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:73
-msgid "Tabs scroll buttons"
+msgid "Tab position:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:74
-msgid "Title bar at bottom (Require restart)"
+msgid "Tabs homogeneous"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:75
-msgid "Global"
+msgid "Tabs scroll buttons"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:76
-msgid "Profile"
+msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:77
-msgid "_Use the system fixed width font"
+msgid "Global"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:78
-msgid "_Font:"
+msgid "Profile"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:79
-msgid "Choose A Terminal Font"
+msgid "_Use the system fixed width font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:80
-msgid "_Allow bold text"
+msgid "_Font:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:81
-msgid "Show titlebar"
+msgid "Choose A Terminal Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:82
-msgid "Copy on selection"
+msgid "_Allow bold text"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:83
-msgid "Disable Ctrl+mousewheel zoom"
+msgid "Show titlebar"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:84
-msgid "Select-by-_word characters:"
+msgid "Copy on selection"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:85
-msgid "<b>Cursor</b>"
+msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:86
-msgid "_Shape:"
+msgid "Select-by-_word characters:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:87
-msgid "Blink"
+msgid "<b>Cursor</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:88
-msgid "Use default colors"
+msgid "_Shape:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:89
-msgid "Foreground:"
+msgid "Blink"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:90
-msgid "Background:"
+msgid "Use default colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:91
-msgid "<b>Terminal bell</b>"
+msgid "Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:92
-msgid "Titlebar icon"
+msgid "Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:93
-msgid "Visual flash"
+msgid "<b>Terminal bell</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:94
-msgid "Audible beep"
+msgid "Titlebar icon"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:95
-msgid "Window list flash"
+msgid "Visual flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:96
-msgid "General"
+msgid "Audible beep"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:97
-msgid "_Run command as a login shell"
+msgid "Window list flash"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:98
-msgid "Ru_n a custom command instead of my shell"
+msgid "General"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:99
-msgid "Custom co_mmand:"
+msgid "_Run command as a login shell"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:100
-msgid "When command _exits:"
+msgid "Ru_n a custom command instead of my shell"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:101
+msgid "Custom co_mmand:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:102
-msgid "<b>Foreground and Background</b>"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:103
-msgid "_Use colors from system theme"
+msgid "When command _exits:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:104
-msgid "Built-in sche_mes:"
+msgid "<b>Foreground and Background</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:105
-msgid "_Foreground:"
+msgid "_Use colors from system theme"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:106
-msgid "_Background:"
+msgid "Built-in sche_mes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:107
-msgid "<b>Palette</b>"
+msgid "_Foreground:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:108
-msgid "Built-in _schemes:"
+msgid "_Background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:109
-msgid "Color p_alette:"
+msgid "<b>Palette</b>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:110
-msgid "Show b_old text in bright colors"
+msgid "Built-in _schemes:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:111
-msgid "Colors"
+msgid "Color p_alette:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:112
-msgid "_Solid color"
+msgid "Show b_old text in bright colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:113
-msgid "_Transparent background"
+msgid "Colors"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:114
-msgid "Background Image"
+msgid "_Solid color"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:115
-msgid "Background Image File:"
+msgid "_Transparent background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:116
-msgid "Choose file"
+msgid "Background Image"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:117
-msgid "S_hade background:"
+msgid "Background Image File:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:118
-msgid "<small><i>None</i></small>"
+msgid "Choose file"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:119
-msgid "<small><i>Maximum</i></small>"
+msgid "S_hade background:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:120
-msgid "Background"
+msgid "<small><i>None</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:121
-msgid "_Scrollbar is:"
+msgid "<small><i>Maximum</i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:122
-msgid "Scroll on _output"
+msgid "Background"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:123
-msgid "Scroll on _keystroke"
+msgid "_Scrollbar is:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:124
-msgid "Infinite Scrollback"
+msgid "Scroll on _output"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:125
-msgid "Scroll_back:"
+msgid "Scroll on _keystroke"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:126
-msgid "lines"
+msgid "Infinite Scrollback"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:127
-msgid "Scrolling"
+msgid "Scroll_back:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:128
-msgid ""
-"<small><i><b>Note:</b> These options may cause some applications to behave "
-"incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+msgid "lines"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:129
-msgid "_Backspace key generates:"
+msgid "Scrolling"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:130
-msgid "_Delete key generates:"
+msgid ""
+"<small><i><b>Note:</b> These options may cause some applications to behave "
+"incorrectly.  They are only here to allow you to work around certain "
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
+msgid "_Backspace key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:132
-msgid "_Reset Compatibility Options to Defaults"
+msgid "_Delete key generates:"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:133
-msgid "Compatibility"
+msgid "_Reset Compatibility Options to Defaults"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:134
-msgid "Focused"
+msgid "Compatibility"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:135
-msgid "Inactive"
+msgid "Focused"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:136
-msgid "Receiving"
+msgid "Inactive"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:137
-msgid "Hide size from title"
+msgid "Receiving"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:138
-msgid "_Use the system font"
+msgid "Hide size from title"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:139
-msgid "Choose A Titlebar Font"
+msgid "_Use the system font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:140
-msgid "Titlebar"
+msgid "Choose A Titlebar Font"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+msgid "Titlebar"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:161
-msgid "The Manual"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:162
-msgid ""
-"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+msgid "The Manual"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:163
+msgid ""
+"<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
+msgstr ""
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
 msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
@@ -1577,11 +1450,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr ""
 
@@ -1594,185 +1467,169 @@ msgstr ""
 msgid "Close Search bar"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "橫向分隔(_o)"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "垂直分隔(_e)"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "開啟分頁(_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "放大終端機(_Z)"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "顯示捲軸(_s)"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "編碼"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr ""
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "其他編碼"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr ""
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "無法找到 Shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr ""
 
@@ -1880,12 +1737,111 @@ msgstr ""
 msgid "window"
 msgstr ""
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr ""
+
+#~ msgid "Current Locale"
+#~ msgstr "目前的地區語言"
+
+#~ msgid "Western"
+#~ msgstr "西歐地區"
+
+#~ msgid "Central European"
+#~ msgstr "中歐地區"
+
+#~ msgid "South European"
+#~ msgstr "南歐地區"
+
+#~ msgid "Baltic"
+#~ msgstr "波羅的海語系"
+
+#~ msgid "Cyrillic"
+#~ msgstr "斯拉夫語系"
+
+#~ msgid "Arabic"
+#~ msgstr "阿拉伯文"
+
+#~ msgid "Greek"
+#~ msgstr "希臘文"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "希伯來文（左至右）"
+
+#~ msgid "Hebrew"
+#~ msgstr "希伯來文"
+
+#~ msgid "Turkish"
+#~ msgstr "土耳其語"
+
+#~ msgid "Nordic"
+#~ msgstr "北歐語系"
+
+#~ msgid "Celtic"
+#~ msgstr "塞爾特語系"
+
+#~ msgid "Romanian"
+#~ msgstr "羅馬尼亞語"
+
+#~ msgid "Unicode"
+#~ msgstr "萬國碼"
+
+#~ msgid "Armenian"
+#~ msgstr "亞美尼亞文"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "中文（繁體）"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "斯拉夫文字/俄文"
+
+#~ msgid "Japanese"
+#~ msgstr "日文"
+
+#~ msgid "Korean"
+#~ msgstr "韓文"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "中文（簡體）"
+
+#~ msgid "Georgian"
+#~ msgstr "格魯吉亞文"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "斯拉夫文/烏克蘭文"
+
+#~ msgid "Croatian"
+#~ msgstr "克羅地亞文"
+
+#~ msgid "Hindi"
+#~ msgstr "印地語"
+
+#~ msgid "Persian"
+#~ msgstr "波斯語"
+
+#~ msgid "Gujarati"
+#~ msgstr "古吉拉特語"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "古爾穆奇文"
+
+#~ msgid "Icelandic"
+#~ msgstr "冰島語"
+
+#~ msgid "Vietnamese"
+#~ msgstr "越南語"
+
+#~ msgid "Thai"
+#~ msgstr "泰文"
+
+#~ msgid "Encodings"
+#~ msgstr "編碼"
+
+#~ msgid "Other Encodings"
+#~ msgstr "其他編碼"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2,23 +2,24 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Gnome Terminator <terminator@lazyfrosch.de>, 2020
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-14 18:55+0200\n"
+"POT-Creation-Date: 2022-01-22 00:51+0100\n"
 "PO-Revision-Date: 2020-04-22 08:11+0000\n"
 "Last-Translator: Gnome Terminator <terminator@lazyfrosch.de>, 2020\n"
-"Language-Team: Chinese (Taiwan) (https://www.transifex.com/terminator/teams/109338/zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (https://www.transifex.com/terminator/"
+"teams/109338/zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. Command             uuid req.    Description
@@ -128,7 +129,7 @@ msgstr ""
 #: ../data/terminator.desktop.in.h:1 ../data/terminator.appdata.xml.in.h:1
 #: ../terminatorlib/plugins/activitywatch.py:83
 #: ../terminatorlib/plugins/activitywatch.py:162
-#: ../terminatorlib/preferences.glade.h:155
+#: ../terminatorlib/preferences.glade.h:156
 msgid "Terminator"
 msgstr "Terminator"
 
@@ -137,7 +138,7 @@ msgid "Multiple terminals in one window"
 msgstr "單一視窗，多重終端"
 
 #: ../data/terminator.appdata.xml.in.h:3
-#: ../terminatorlib/preferences.glade.h:156
+#: ../terminatorlib/preferences.glade.h:157
 msgid "The robot future of terminals"
 msgstr "終結者(Terminator) - 終端機器人的未來"
 
@@ -145,8 +146,8 @@ msgstr "終結者(Terminator) - 終端機器人的未來"
 msgid ""
 "A power-user tool for arranging terminals. It is inspired by programs such "
 "as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging "
-"terminals in grids (tabs is the most common default method, which Terminator"
-" also supports)."
+"terminals in grids (tabs is the most common default method, which Terminator "
+"also supports)."
 msgstr ""
 
 #: ../data/terminator.appdata.xml.in.h:5
@@ -229,156 +230,12 @@ msgstr "這個分頁已經開啟多個終端。關閉分頁會關閉視窗內的
 msgid "Do not show this message next time"
 msgstr "下次不要再顯示此訊息"
 
-#: ../terminatorlib/encoding.py:34
-msgid "Current Locale"
-msgstr "在地語言"
-
-#: ../terminatorlib/encoding.py:35 ../terminatorlib/encoding.py:48
-#: ../terminatorlib/encoding.py:67 ../terminatorlib/encoding.py:90
-#: ../terminatorlib/encoding.py:101
-msgid "Western"
-msgstr "西歐語系"
-
-#: ../terminatorlib/encoding.py:36 ../terminatorlib/encoding.py:68
-#: ../terminatorlib/encoding.py:80 ../terminatorlib/encoding.py:99
-msgid "Central European"
-msgstr "中歐語系"
-
-#: ../terminatorlib/encoding.py:37
-msgid "South European"
-msgstr "南歐語系"
-
-#: ../terminatorlib/encoding.py:38 ../terminatorlib/encoding.py:46
-#: ../terminatorlib/encoding.py:106
-msgid "Baltic"
-msgstr "波羅的海語"
-
-#. [False, "JOHAB", _("Korean") ],
-#: ../terminatorlib/encoding.py:39 ../terminatorlib/encoding.py:69
-#: ../terminatorlib/encoding.py:75 ../terminatorlib/encoding.py:77
-#: ../terminatorlib/encoding.py:82 ../terminatorlib/encoding.py:100
-msgid "Cyrillic"
-msgstr "斯拉夫語"
-
-#: ../terminatorlib/encoding.py:40 ../terminatorlib/encoding.py:72
-#: ../terminatorlib/encoding.py:79 ../terminatorlib/encoding.py:105
-msgid "Arabic"
-msgstr "阿拉伯語"
-
-#: ../terminatorlib/encoding.py:41 ../terminatorlib/encoding.py:85
-#: ../terminatorlib/encoding.py:102
-msgid "Greek"
-msgstr "希臘語"
-
-#: ../terminatorlib/encoding.py:42
-msgid "Hebrew Visual"
-msgstr "希伯來語（左至右）"
-
-#: ../terminatorlib/encoding.py:43 ../terminatorlib/encoding.py:71
-#: ../terminatorlib/encoding.py:88 ../terminatorlib/encoding.py:104
-msgid "Hebrew"
-msgstr "希伯來語"
-
-#: ../terminatorlib/encoding.py:44 ../terminatorlib/encoding.py:70
-#: ../terminatorlib/encoding.py:92 ../terminatorlib/encoding.py:103
-msgid "Turkish"
-msgstr "土耳其語"
-
-#: ../terminatorlib/encoding.py:45
-msgid "Nordic"
-msgstr "北歐語系"
-
-#: ../terminatorlib/encoding.py:47
-msgid "Celtic"
-msgstr "塞爾特語"
-
-#: ../terminatorlib/encoding.py:49 ../terminatorlib/encoding.py:91
-msgid "Romanian"
-msgstr "羅馬尼亞語"
-
-#. [False, "UTF-7", _("Unicode") ],
-#: ../terminatorlib/encoding.py:51
-msgid "Unicode"
-msgstr "萬國碼 (Unicode)"
-
-#. [False, "UTF-16", _("Unicode") ],
-#. [False, "UCS-2", _("Unicode") ],
-#. [False, "UCS-4", _("Unicode") ],
-#: ../terminatorlib/encoding.py:55
-msgid "Armenian"
-msgstr "亞美尼亞語"
-
-#: ../terminatorlib/encoding.py:56 ../terminatorlib/encoding.py:57
-#: ../terminatorlib/encoding.py:61
-msgid "Chinese Traditional"
-msgstr "正體中文"
-
-#: ../terminatorlib/encoding.py:58
-msgid "Cyrillic/Russian"
-msgstr "斯拉夫語系/俄文"
-
-#: ../terminatorlib/encoding.py:59 ../terminatorlib/encoding.py:73
-#: ../terminatorlib/encoding.py:94
-msgid "Japanese"
-msgstr "日本語"
-
-#: ../terminatorlib/encoding.py:60 ../terminatorlib/encoding.py:74
-#: ../terminatorlib/encoding.py:97
-msgid "Korean"
-msgstr "韓國語"
-
-#: ../terminatorlib/encoding.py:62 ../terminatorlib/encoding.py:63
-#: ../terminatorlib/encoding.py:64 ../terminatorlib/encoding.py:66
-msgid "Chinese Simplified"
-msgstr "簡體中文"
-
-#: ../terminatorlib/encoding.py:65
-msgid "Georgian"
-msgstr "喬治亞語"
-
-#: ../terminatorlib/encoding.py:78 ../terminatorlib/encoding.py:93
-msgid "Cyrillic/Ukrainian"
-msgstr "斯拉夫/烏克蘭語系"
-
-#: ../terminatorlib/encoding.py:81
-msgid "Croatian"
-msgstr "克羅埃西亞語"
-
-#: ../terminatorlib/encoding.py:83
-msgid "Hindi"
-msgstr "北印度語"
-
-#: ../terminatorlib/encoding.py:84
-msgid "Persian"
-msgstr "波斯語"
-
-#: ../terminatorlib/encoding.py:86
-msgid "Gujarati"
-msgstr "古吉拉特語"
-
-#: ../terminatorlib/encoding.py:87
-msgid "Gurmukhi"
-msgstr "古爾穆奇文"
-
-#: ../terminatorlib/encoding.py:89
-msgid "Icelandic"
-msgstr "冰島語"
-
-#: ../terminatorlib/encoding.py:95 ../terminatorlib/encoding.py:98
-#: ../terminatorlib/encoding.py:107
-msgid "Vietnamese"
-msgstr "越南語"
-
-#: ../terminatorlib/encoding.py:96
-msgid "Thai"
-msgstr "泰語"
-
 #: ../terminatorlib/layoutlauncher.glade.h:1
 msgid "Terminator Layout Launcher"
 msgstr "Terminator版面配置啟動器"
 
 #: ../terminatorlib/layoutlauncher.glade.h:2
-#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/preferences.glade.h:143
 msgid "Layout"
 msgstr "版面配置"
 
@@ -386,11 +243,11 @@ msgstr "版面配置"
 msgid "Launch"
 msgstr "啟動"
 
-#: ../terminatorlib/notebook.py:384
+#: ../terminatorlib/notebook.py:383
 msgid "tab"
 msgstr "分頁"
 
-#: ../terminatorlib/notebook.py:656
+#: ../terminatorlib/notebook.py:655
 msgid "Close Tab"
 msgstr "關閉分頁"
 
@@ -520,7 +377,7 @@ msgstr "自訂指令"
 
 #. VERIFY FOR GTK3: is this ever false?
 #: ../terminatorlib/plugins/custom_commands.py:67
-#: ../terminatorlib/terminal_popup_menu.py:198
+#: ../terminatorlib/terminal_popup_menu.py:197
 msgid "_Preferences"
 msgstr "偏好設定(_P)"
 
@@ -545,12 +402,12 @@ msgid "Enabled"
 msgstr "啟用"
 
 #: ../terminatorlib/plugins/custom_commands.py:170
-#: ../terminatorlib/preferences.glade.h:144
+#: ../terminatorlib/preferences.glade.h:145
 msgid "Name"
 msgstr "名稱"
 
 #: ../terminatorlib/plugins/custom_commands.py:174
-#: ../terminatorlib/preferences.glade.h:101
+#: ../terminatorlib/preferences.glade.h:103
 msgid "Command"
 msgstr "指令"
 
@@ -656,7 +513,7 @@ msgid "Escape sequence"
 msgstr "跳脫序列"
 
 #. FIXME: Why isn't this being done by Terminator() ?
-#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:727
+#: ../terminatorlib/preferences.glade.h:5 ../terminatorlib/window.py:754
 msgid "All"
 msgstr "全部"
 
@@ -873,487 +730,508 @@ msgid "Use custom URL handler"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:60
-msgid "Custom URL handler:"
-msgstr ""
-
-#: ../terminatorlib/preferences.glade.h:61
 msgid "PRIMARY"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:62
+#: ../terminatorlib/preferences.glade.h:61
 msgid "Clipboard"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:63
+#: ../terminatorlib/preferences.glade.h:62
 msgid "Clear selection on copy"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:64
+#: ../terminatorlib/preferences.glade.h:63
 msgid "Open links with a single click (instead of Ctrl-left click)"
 msgstr ""
 
+#: ../terminatorlib/preferences.glade.h:64
+msgid "Disable mouse paste"
+msgstr ""
+
 #: ../terminatorlib/preferences.glade.h:65
+msgid "Custom URL handler:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:66
 msgid "<b>Appearance</b>"
 msgstr "<b>外觀</b>"
 
-#: ../terminatorlib/preferences.glade.h:66
+#: ../terminatorlib/preferences.glade.h:67
 msgid "Window borders"
 msgstr "視窗邊界"
 
-#: ../terminatorlib/preferences.glade.h:67
+#: ../terminatorlib/preferences.glade.h:68
 msgid "Unfocused terminal font brightness:"
 msgstr "字型亮度(非當前視窗)"
 
-#: ../terminatorlib/preferences.glade.h:68
+#: ../terminatorlib/preferences.glade.h:69
 msgid "Terminal separator size:"
 msgstr "分隔線寬度"
-
-#: ../terminatorlib/preferences.glade.h:69
-msgid "Line Height:"
-msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:70
 msgid "Extra Styling (Theme dependant)"
 msgstr ""
 
 #: ../terminatorlib/preferences.glade.h:71
+msgid "Cell Height:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:72
+msgid "Cell Width:"
+msgstr ""
+
+#: ../terminatorlib/preferences.glade.h:73
 msgid "Tab position:"
 msgstr "分頁列位置："
 
-#: ../terminatorlib/preferences.glade.h:72
+#: ../terminatorlib/preferences.glade.h:74
 msgid "Tabs homogeneous"
 msgstr "平均分配分頁寬度"
 
-#: ../terminatorlib/preferences.glade.h:73
+#: ../terminatorlib/preferences.glade.h:75
 msgid "Tabs scroll buttons"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:74
+#: ../terminatorlib/preferences.glade.h:76
 msgid "Title bar at bottom (Require restart)"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:75
+#: ../terminatorlib/preferences.glade.h:77
 msgid "Global"
 msgstr "全域"
 
-#: ../terminatorlib/preferences.glade.h:76
+#: ../terminatorlib/preferences.glade.h:78
 msgid "Profile"
 msgstr "設定檔"
 
-#: ../terminatorlib/preferences.glade.h:77
+#: ../terminatorlib/preferences.glade.h:79
 msgid "_Use the system fixed width font"
 msgstr "使用系統的固定寬度字型 (_U)"
 
-#: ../terminatorlib/preferences.glade.h:78
+#: ../terminatorlib/preferences.glade.h:80
 msgid "_Font:"
 msgstr "字型 (_F)："
 
-#: ../terminatorlib/preferences.glade.h:79
+#: ../terminatorlib/preferences.glade.h:81
 msgid "Choose A Terminal Font"
 msgstr "請選取終端機字型"
 
-#: ../terminatorlib/preferences.glade.h:80
+#: ../terminatorlib/preferences.glade.h:82
 msgid "_Allow bold text"
 msgstr "可使用粗體文字 (_A)"
 
-#: ../terminatorlib/preferences.glade.h:81
+#: ../terminatorlib/preferences.glade.h:83
 msgid "Show titlebar"
 msgstr "顯示標題列"
 
-#: ../terminatorlib/preferences.glade.h:82
+#: ../terminatorlib/preferences.glade.h:84
 msgid "Copy on selection"
 msgstr "選擇即複製"
 
-#: ../terminatorlib/preferences.glade.h:83
+#: ../terminatorlib/preferences.glade.h:85
 msgid "Disable Ctrl+mousewheel zoom"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:84
+#: ../terminatorlib/preferences.glade.h:86
 msgid "Select-by-_word characters:"
 msgstr "用滑鼠連按兩下選取字詞時會包括以下字元(_W):"
 
-#: ../terminatorlib/preferences.glade.h:85
+#: ../terminatorlib/preferences.glade.h:87
 msgid "<b>Cursor</b>"
 msgstr "<b>游標</b>"
 
-#: ../terminatorlib/preferences.glade.h:86
+#: ../terminatorlib/preferences.glade.h:88
 msgid "_Shape:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:87
+#: ../terminatorlib/preferences.glade.h:89
 msgid "Blink"
 msgstr "閃爍"
 
-#: ../terminatorlib/preferences.glade.h:88
+#: ../terminatorlib/preferences.glade.h:90
 msgid "Use default colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:89
+#: ../terminatorlib/preferences.glade.h:91
 msgid "Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:90
+#: ../terminatorlib/preferences.glade.h:92
 msgid "Background:"
 msgstr "背景："
 
-#: ../terminatorlib/preferences.glade.h:91
+#: ../terminatorlib/preferences.glade.h:93
 msgid "<b>Terminal bell</b>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:92
+#: ../terminatorlib/preferences.glade.h:94
 msgid "Titlebar icon"
 msgstr "標題列圖示"
 
-#: ../terminatorlib/preferences.glade.h:93
+#: ../terminatorlib/preferences.glade.h:95
 msgid "Visual flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:94
+#: ../terminatorlib/preferences.glade.h:96
 msgid "Audible beep"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:95
+#: ../terminatorlib/preferences.glade.h:97
 msgid "Window list flash"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:96
+#: ../terminatorlib/preferences.glade.h:98
 msgid "General"
 msgstr "一般"
 
-#: ../terminatorlib/preferences.glade.h:97
+#: ../terminatorlib/preferences.glade.h:99
 msgid "_Run command as a login shell"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:98
+#: ../terminatorlib/preferences.glade.h:100
 msgid "Ru_n a custom command instead of my shell"
 msgstr "啟動時執行自訂的指令而不是執行 shell(_N)"
 
-#: ../terminatorlib/preferences.glade.h:99
+#: ../terminatorlib/preferences.glade.h:101
 msgid "Custom co_mmand:"
 msgstr "自訂指令 (_M)："
 
-#: ../terminatorlib/preferences.glade.h:100
+#: ../terminatorlib/preferences.glade.h:102
 msgid "When command _exits:"
 msgstr "當完成執行指令後(_E):"
 
-#: ../terminatorlib/preferences.glade.h:102
+#: ../terminatorlib/preferences.glade.h:104
 msgid "<b>Foreground and Background</b>"
 msgstr "<b>前景與背景</b>"
 
-#: ../terminatorlib/preferences.glade.h:103
+#: ../terminatorlib/preferences.glade.h:105
 msgid "_Use colors from system theme"
 msgstr "使用系統佈景主題指定的色彩(_U)"
 
-#: ../terminatorlib/preferences.glade.h:104
+#: ../terminatorlib/preferences.glade.h:106
 msgid "Built-in sche_mes:"
 msgstr "內建色彩組合(_M)"
 
-#: ../terminatorlib/preferences.glade.h:105
+#: ../terminatorlib/preferences.glade.h:107
 msgid "_Foreground:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:106
+#: ../terminatorlib/preferences.glade.h:108
 msgid "_Background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:107
+#: ../terminatorlib/preferences.glade.h:109
 msgid "<b>Palette</b>"
 msgstr "<b>調色盤</b>"
 
-#: ../terminatorlib/preferences.glade.h:108
+#: ../terminatorlib/preferences.glade.h:110
 msgid "Built-in _schemes:"
 msgstr "內建色彩組合(_S)："
 
-#: ../terminatorlib/preferences.glade.h:109
+#: ../terminatorlib/preferences.glade.h:111
 msgid "Color p_alette:"
 msgstr "調色盤(_A)："
 
-#: ../terminatorlib/preferences.glade.h:110
+#: ../terminatorlib/preferences.glade.h:112
 msgid "Show b_old text in bright colors"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:111
+#: ../terminatorlib/preferences.glade.h:113
 msgid "Colors"
 msgstr "色彩"
 
-#: ../terminatorlib/preferences.glade.h:112
+#: ../terminatorlib/preferences.glade.h:114
 msgid "_Solid color"
 msgstr "固定顏色(_S)"
 
-#: ../terminatorlib/preferences.glade.h:113
+#: ../terminatorlib/preferences.glade.h:115
 msgid "_Transparent background"
 msgstr "透明背景(_T)"
 
-#: ../terminatorlib/preferences.glade.h:114
+#: ../terminatorlib/preferences.glade.h:116
 msgid "Background Image"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:115
+#: ../terminatorlib/preferences.glade.h:117
 msgid "Background Image File:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:116
+#: ../terminatorlib/preferences.glade.h:118
 msgid "Choose file"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:117
+#: ../terminatorlib/preferences.glade.h:119
 msgid "S_hade background:"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:118
+#: ../terminatorlib/preferences.glade.h:120
 msgid "<small><i>None</i></small>"
 msgstr "<small><i>完全透明</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:119
+#: ../terminatorlib/preferences.glade.h:121
 msgid "<small><i>Maximum</i></small>"
 msgstr "<small><i>不透明</i></small>"
 
-#: ../terminatorlib/preferences.glade.h:120
+#: ../terminatorlib/preferences.glade.h:122
 msgid "Background"
 msgstr "背景"
 
-#: ../terminatorlib/preferences.glade.h:121
+#: ../terminatorlib/preferences.glade.h:123
 msgid "_Scrollbar is:"
 msgstr "捲動列(_S)："
 
-#: ../terminatorlib/preferences.glade.h:122
+#: ../terminatorlib/preferences.glade.h:124
 msgid "Scroll on _output"
 msgstr "輸出時捲動(_O)"
 
-#: ../terminatorlib/preferences.glade.h:123
+#: ../terminatorlib/preferences.glade.h:125
 msgid "Scroll on _keystroke"
 msgstr "按鍵時還原至原來位置(_K)"
 
-#: ../terminatorlib/preferences.glade.h:124
+#: ../terminatorlib/preferences.glade.h:126
 msgid "Infinite Scrollback"
 msgstr "無限制"
 
-#: ../terminatorlib/preferences.glade.h:125
+#: ../terminatorlib/preferences.glade.h:127
 msgid "Scroll_back:"
 msgstr "向後捲動(_B):"
 
-#: ../terminatorlib/preferences.glade.h:126
+#: ../terminatorlib/preferences.glade.h:128
 msgid "lines"
 msgstr "行"
 
-#: ../terminatorlib/preferences.glade.h:127
+#: ../terminatorlib/preferences.glade.h:129
 msgid "Scrolling"
 msgstr "捲動列"
 
-#: ../terminatorlib/preferences.glade.h:128
+#: ../terminatorlib/preferences.glade.h:130
 msgid ""
 "<small><i><b>Note:</b> These options may cause some applications to behave "
 "incorrectly.  They are only here to allow you to work around certain "
-"applications and operating systems that expect different terminal "
-"behavior.</i></small>"
+"applications and operating systems that expect different terminal behavior.</"
+"i></small>"
 msgstr ""
-"<small><i><b>注意：</b> "
-"以下的選項可能令某部分應用程式無法正常運作。它們只是在某些應用程式及作業系統需要不同的終端機運作方式時，提供暫時的解決方法。</i></small>"
+"<small><i><b>注意：</b> 以下的選項可能令某部分應用程式無法正常運作。它們只是"
+"在某些應用程式及作業系統需要不同的終端機運作方式時，提供暫時的解決方法。</"
+"i></small>"
 
-#: ../terminatorlib/preferences.glade.h:129
+#: ../terminatorlib/preferences.glade.h:131
 msgid "_Backspace key generates:"
 msgstr "Backspace 鍵產生(_B)"
 
-#: ../terminatorlib/preferences.glade.h:130
+#: ../terminatorlib/preferences.glade.h:132
 msgid "_Delete key generates:"
 msgstr "Detelet 鍵產生(_D):"
 
-#: ../terminatorlib/preferences.glade.h:131
-msgid "Encoding:"
-msgstr "編碼："
-
-#: ../terminatorlib/preferences.glade.h:132
+#: ../terminatorlib/preferences.glade.h:133
 msgid "_Reset Compatibility Options to Defaults"
 msgstr "將有關兼容性的選項重設為預設值(_R)"
 
-#: ../terminatorlib/preferences.glade.h:133
+#: ../terminatorlib/preferences.glade.h:134
 msgid "Compatibility"
 msgstr "相容性"
 
-#: ../terminatorlib/preferences.glade.h:134
+#: ../terminatorlib/preferences.glade.h:135
 msgid "Focused"
 msgstr "當前視窗"
 
-#: ../terminatorlib/preferences.glade.h:135
+#: ../terminatorlib/preferences.glade.h:136
 msgid "Inactive"
 msgstr "非使用中"
 
-#: ../terminatorlib/preferences.glade.h:136
+#: ../terminatorlib/preferences.glade.h:137
 msgid "Receiving"
 msgstr "接收中"
 
-#: ../terminatorlib/preferences.glade.h:137
+#: ../terminatorlib/preferences.glade.h:138
 msgid "Hide size from title"
 msgstr "不在標題列顯示終端機大小(列數X行數)"
 
-#: ../terminatorlib/preferences.glade.h:138
+#: ../terminatorlib/preferences.glade.h:139
 msgid "_Use the system font"
 msgstr "使用系統字型"
 
-#: ../terminatorlib/preferences.glade.h:139
+#: ../terminatorlib/preferences.glade.h:140
 msgid "Choose A Titlebar Font"
 msgstr "選擇標題列字型"
 
-#: ../terminatorlib/preferences.glade.h:140
+#: ../terminatorlib/preferences.glade.h:141
 msgid "Titlebar"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:141
-#: ../terminatorlib/terminal_popup_menu.py:205
+#: ../terminatorlib/preferences.glade.h:142
+#: ../terminatorlib/terminal_popup_menu.py:204
 msgid "Profiles"
 msgstr "設定組合"
 
-#: ../terminatorlib/preferences.glade.h:143
+#: ../terminatorlib/preferences.glade.h:144
 msgid "Type"
 msgstr "類型"
 
-#: ../terminatorlib/preferences.glade.h:145
+#: ../terminatorlib/preferences.glade.h:146
 msgid "Profile:"
 msgstr "設定檔："
 
-#: ../terminatorlib/preferences.glade.h:146
+#: ../terminatorlib/preferences.glade.h:147
 msgid "Custom command:"
 msgstr "客製化命令"
 
-#: ../terminatorlib/preferences.glade.h:147
+#: ../terminatorlib/preferences.glade.h:148
 msgid "Working directory:"
 msgstr "工作目錄："
 
-#: ../terminatorlib/preferences.glade.h:148
+#: ../terminatorlib/preferences.glade.h:149
 msgid "Layouts"
 msgstr "版面設置"
 
-#: ../terminatorlib/preferences.glade.h:149
+#: ../terminatorlib/preferences.glade.h:150
 msgid "Action"
 msgstr "動作"
 
-#: ../terminatorlib/preferences.glade.h:150
+#: ../terminatorlib/preferences.glade.h:151
 msgid "Keybinding"
 msgstr "快速鍵"
 
-#: ../terminatorlib/preferences.glade.h:151
+#: ../terminatorlib/preferences.glade.h:152
 msgid "Keybindings"
 msgstr "快速鍵"
 
-#: ../terminatorlib/preferences.glade.h:152
+#: ../terminatorlib/preferences.glade.h:153
 msgid "Plugin"
 msgstr "外掛程式"
 
-#: ../terminatorlib/preferences.glade.h:153
+#: ../terminatorlib/preferences.glade.h:154
 msgid "This plugin has no configuration options"
 msgstr "當前外掛程式沒有可設定的選項"
 
-#: ../terminatorlib/preferences.glade.h:154
+#: ../terminatorlib/preferences.glade.h:155
 msgid "Plugins"
 msgstr "外掛程式"
 
-#: ../terminatorlib/preferences.glade.h:157
+#: ../terminatorlib/preferences.glade.h:158
 msgid "Version: 2.1.1"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:158
+#: ../terminatorlib/preferences.glade.h:159
 msgid ""
-"The goal of this project is to produce a useful tool for arranging terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, etc. in that the main focus is arranging terminals in grids (tabs is the most common default method, which Terminator also supports).\n"
+"The goal of this project is to produce a useful tool for arranging "
+"terminals. It is inspired by programs such as gnome-multi-term, quadkonsole, "
+"etc. in that the main focus is arranging terminals in grids (tabs is the "
+"most common default method, which Terminator also supports).\n"
 "\n"
-"Much of the behavior of Terminator is based on GNOME Terminal, and we are adding more features from that as time goes by, but we also want to extend out in different directions with useful features for sysadmins and other users. If you have any suggestions, please file wishlist bugs! (see left for the Development link)"
+"Much of the behavior of Terminator is based on GNOME Terminal, and we are "
+"adding more features from that as time goes by, but we also want to extend "
+"out in different directions with useful features for sysadmins and other "
+"users. If you have any suggestions, please file wishlist bugs! (see left for "
+"the Development link)"
 msgstr ""
-"這個項目的目標是製作一個可以排列終端機視窗的有用工具。此項目受到諸如gnome-multi-term、quadkonsole等程序的啟發，其主要功能是聚焦在網格中排列各個終端機視窗（使用分頁是最常用的手法，Terminator也是這樣做的）。\n"
+"這個項目的目標是製作一個可以排列終端機視窗的有用工具。此項目受到諸如gnome-"
+"multi-term、quadkonsole等程序的啟發，其主要功能是聚焦在網格中排列各個終端機視"
+"窗（使用分頁是最常用的手法，Terminator也是這樣做的）。\n"
 "\n"
-"Terminator的許多行為都是以GNOME Terminal為基礎開發的，隨著時間的推移，我們會添加更多的功能，也希望向系統管理員和其他用戶提供更多有用的功能。如果您有任何建議，請提交您期待的功能清單！（請參閱左側的鏈結）"
+"Terminator的許多行為都是以GNOME Terminal為基礎開發的，隨著時間的推移，我們會"
+"添加更多的功能，也希望向系統管理員和其他用戶提供更多有用的功能。如果您有任何"
+"建議，請提交您期待的功能清單！（請參閱左側的鏈結）"
 
-#: ../terminatorlib/preferences.glade.h:161
+#: ../terminatorlib/preferences.glade.h:162
 msgid "The Manual"
 msgstr "手冊"
 
-#: ../terminatorlib/preferences.glade.h:162
+#: ../terminatorlib/preferences.glade.h:163
 msgid ""
 "<a href=\"https://github.com/gnome-terminator/terminator\">Development</a>\n"
-"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / Enhancements</a>"
+"<a href=\"https://github.com/gnome-terminator/terminator/issues\">Bugs / "
+"Enhancements</a>"
 msgstr ""
 
-#: ../terminatorlib/preferences.glade.h:164
+#: ../terminatorlib/preferences.glade.h:165
 msgid "About"
 msgstr "關於"
 
-#: ../terminatorlib/prefseditor.py:105
+#: ../terminatorlib/prefseditor.py:104
 msgid "Increase font size"
 msgstr "字型變大"
 
-#: ../terminatorlib/prefseditor.py:106
+#: ../terminatorlib/prefseditor.py:105
 msgid "Decrease font size"
 msgstr "字型變小"
 
-#: ../terminatorlib/prefseditor.py:107
+#: ../terminatorlib/prefseditor.py:106
 msgid "Restore original font size"
 msgstr "恢復原始字型大小"
 
-#: ../terminatorlib/prefseditor.py:108
+#: ../terminatorlib/prefseditor.py:107
 msgid "Increase font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:109
+#: ../terminatorlib/prefseditor.py:108
 msgid "Decrease font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:110
+#: ../terminatorlib/prefseditor.py:109
 msgid "Restore original font size on all terminals"
 msgstr ""
 
-#: ../terminatorlib/prefseditor.py:111
+#: ../terminatorlib/prefseditor.py:110
 msgid "Create a new tab"
 msgstr "建立新分頁"
 
-#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
+#: ../terminatorlib/prefseditor.py:111 ../terminatorlib/prefseditor.py:113
 msgid "Focus the next terminal"
 msgstr "切換到下一個終端機"
 
-#: ../terminatorlib/prefseditor.py:113 ../terminatorlib/prefseditor.py:115
+#: ../terminatorlib/prefseditor.py:112 ../terminatorlib/prefseditor.py:114
 msgid "Focus the previous terminal"
 msgstr "切換到上一個終端機"
 
-#: ../terminatorlib/prefseditor.py:116
+#: ../terminatorlib/prefseditor.py:115
 msgid "Focus the terminal above"
 msgstr "切換到上方終端機"
 
-#: ../terminatorlib/prefseditor.py:117
+#: ../terminatorlib/prefseditor.py:116
 msgid "Focus the terminal below"
 msgstr "切換到下方終端機"
 
-#: ../terminatorlib/prefseditor.py:118
+#: ../terminatorlib/prefseditor.py:117
 msgid "Focus the terminal left"
 msgstr "切換到左方終端機"
 
-#: ../terminatorlib/prefseditor.py:119
+#: ../terminatorlib/prefseditor.py:118
 msgid "Focus the terminal right"
 msgstr "切換到右方終端機"
 
-#: ../terminatorlib/prefseditor.py:120
+#: ../terminatorlib/prefseditor.py:119
 msgid "Rotate terminals clockwise"
 msgstr "順時針旋轉所有終端機"
 
-#: ../terminatorlib/prefseditor.py:121
+#: ../terminatorlib/prefseditor.py:120
 msgid "Rotate terminals counter-clockwise"
 msgstr "逆時針旋轉所有終端機"
 
-#: ../terminatorlib/prefseditor.py:122
+#: ../terminatorlib/prefseditor.py:121
 msgid "Split horizontally"
 msgstr "垂直分割"
 
-#: ../terminatorlib/prefseditor.py:123
+#: ../terminatorlib/prefseditor.py:122
 msgid "Split vertically"
 msgstr "水平分割"
 
-#: ../terminatorlib/prefseditor.py:124
+#: ../terminatorlib/prefseditor.py:123
 msgid "Close terminal"
 msgstr "關閉終端機"
 
-#: ../terminatorlib/prefseditor.py:125
+#: ../terminatorlib/prefseditor.py:124
 msgid "Copy selected text"
 msgstr "複製所選文字"
 
-#: ../terminatorlib/prefseditor.py:126
+#: ../terminatorlib/prefseditor.py:125
 msgid "Paste clipboard"
 msgstr "貼上剪貼簿的內容"
+
+#: ../terminatorlib/prefseditor.py:126
+msgid "Paste primary selection"
+msgstr ""
 
 #: ../terminatorlib/prefseditor.py:127
 msgid "Show/Hide the scrollbar"
@@ -1587,11 +1465,11 @@ msgstr ""
 msgid "Open the manual"
 msgstr "開啟使用手冊"
 
-#: ../terminatorlib/prefseditor.py:1364
+#: ../terminatorlib/prefseditor.py:1370
 msgid "New Profile"
 msgstr "新增設定組合"
 
-#: ../terminatorlib/prefseditor.py:1407 ../terminatorlib/prefseditor.py:1412
+#: ../terminatorlib/prefseditor.py:1413 ../terminatorlib/prefseditor.py:1418
 msgid "New Layout"
 msgstr "新配置"
 
@@ -1604,185 +1482,169 @@ msgstr "搜尋："
 msgid "Close Search bar"
 msgstr "關閉搜尋列"
 
-#: ../terminatorlib/terminal_popup_menu.py:59
+#: ../terminatorlib/terminal_popup_menu.py:58
 msgid "_Send email to..."
 msgstr "發送電子郵件給...(_S)"
 
-#: ../terminatorlib/terminal_popup_menu.py:60
+#: ../terminatorlib/terminal_popup_menu.py:59
 msgid "_Copy email address"
 msgstr "複製電子郵件地址(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:62
+#: ../terminatorlib/terminal_popup_menu.py:61
 msgid "Ca_ll VoIP address"
 msgstr "呼叫網路電話地址(_l)"
 
-#: ../terminatorlib/terminal_popup_menu.py:63
+#: ../terminatorlib/terminal_popup_menu.py:62
 msgid "_Copy VoIP address"
 msgstr "複製網路電話地址(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:84
+#: ../terminatorlib/terminal_popup_menu.py:83
 msgid "_Open link"
 msgstr "開啟連結(_O)"
 
-#: ../terminatorlib/terminal_popup_menu.py:86
+#: ../terminatorlib/terminal_popup_menu.py:85
 msgid "_Copy address"
 msgstr "複製連結位址"
 
-#: ../terminatorlib/terminal_popup_menu.py:102
+#: ../terminatorlib/terminal_popup_menu.py:101
 msgid "_Copy"
 msgstr "複製(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:107
+#: ../terminatorlib/terminal_popup_menu.py:106
 msgid "_Paste"
 msgstr "貼上(_P)"
 
-#: ../terminatorlib/terminal_popup_menu.py:113
+#: ../terminatorlib/terminal_popup_menu.py:112
 msgid "Set W_indow Title"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:118
+#: ../terminatorlib/terminal_popup_menu.py:117
 msgid "Split H_orizontally"
 msgstr "水平分割"
 
-#: ../terminatorlib/terminal_popup_menu.py:128
+#: ../terminatorlib/terminal_popup_menu.py:127
 msgid "Split V_ertically"
 msgstr "垂直分割"
 
-#: ../terminatorlib/terminal_popup_menu.py:138
+#: ../terminatorlib/terminal_popup_menu.py:137
 msgid "Open _Tab"
 msgstr "開啟分頁(_T)"
 
-#: ../terminatorlib/terminal_popup_menu.py:144
+#: ../terminatorlib/terminal_popup_menu.py:143
 msgid "Open _Debug Tab"
 msgstr "開啟除錯分頁(_D)"
 
-#: ../terminatorlib/terminal_popup_menu.py:151
+#: ../terminatorlib/terminal_popup_menu.py:150
 msgid "_Close"
 msgstr "關閉(_C)"
 
-#: ../terminatorlib/terminal_popup_menu.py:160
+#: ../terminatorlib/terminal_popup_menu.py:159
 msgid "_Zoom terminal"
 msgstr "縮放終端機(_Z)"
 
-#: ../terminatorlib/terminal_popup_menu.py:165
+#: ../terminatorlib/terminal_popup_menu.py:164
 msgid "Ma_ximize terminal"
 msgstr "最大化終端機"
 
-#: ../terminatorlib/terminal_popup_menu.py:172
+#: ../terminatorlib/terminal_popup_menu.py:171
 msgid "_Restore all terminals"
 msgstr "還原所有終端機(_R)"
 
-#: ../terminatorlib/terminal_popup_menu.py:179
+#: ../terminatorlib/terminal_popup_menu.py:178
 msgid "Grouping"
 msgstr "群組"
 
-#: ../terminatorlib/terminal_popup_menu.py:187
+#: ../terminatorlib/terminal_popup_menu.py:186
 msgid "Relaunch Command"
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:192
+#: ../terminatorlib/terminal_popup_menu.py:191
 msgid "Show _scrollbar"
 msgstr "顯示捲動列"
 
-#: ../terminatorlib/terminal_popup_menu.py:250
+#: ../terminatorlib/terminal_popup_menu.py:248
 msgid "_Layouts..."
 msgstr ""
 
-#: ../terminatorlib/terminal_popup_menu.py:264
-msgid "Encodings"
-msgstr "編碼"
-
-#: ../terminatorlib/terminal_popup_menu.py:279
-msgid "Default"
-msgstr "預設"
-
-#: ../terminatorlib/terminal_popup_menu.py:282
-msgid "User defined"
-msgstr "使用者定義"
-
-#: ../terminatorlib/terminal_popup_menu.py:298
-msgid "Other Encodings"
-msgstr "其他編碼"
-
-#: ../terminatorlib/terminal.py:496
+#: ../terminatorlib/terminal.py:481
 msgid "N_ew group..."
 msgstr "新增群組"
 
-#: ../terminatorlib/terminal.py:502
+#: ../terminatorlib/terminal.py:487
 msgid "_None"
 msgstr "無(_N)"
 
-#: ../terminatorlib/terminal.py:522
+#: ../terminatorlib/terminal.py:507
 #, python-format
 msgid "Remove group %s"
 msgstr "移除群組 %s"
 
-#: ../terminatorlib/terminal.py:527
+#: ../terminatorlib/terminal.py:512
 msgid "G_roup all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:532
+#: ../terminatorlib/terminal.py:517
 msgid "Ungro_up all in window"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:537
+#: ../terminatorlib/terminal.py:522
 msgid "G_roup all in tab"
 msgstr "將分頁內容合併為群組(_R)"
 
-#: ../terminatorlib/terminal.py:542
+#: ../terminatorlib/terminal.py:527
 msgid "Ungro_up all in tab"
 msgstr "取消分頁中的群組"
 
-#: ../terminatorlib/terminal.py:547
+#: ../terminatorlib/terminal.py:532
 msgid "Remove all groups"
 msgstr "移除所有群組"
 
-#: ../terminatorlib/terminal.py:554
+#: ../terminatorlib/terminal.py:539
 #, python-format
 msgid "Close group %s"
 msgstr "關閉群組 %s"
 
-#: ../terminatorlib/terminal.py:564
+#: ../terminatorlib/terminal.py:549
 msgid "Broadcast _all"
 msgstr "發送到所有終端機"
 
-#: ../terminatorlib/terminal.py:565
+#: ../terminatorlib/terminal.py:550
 msgid "Broadcast _group"
 msgstr "發送到群組"
 
-#: ../terminatorlib/terminal.py:566
+#: ../terminatorlib/terminal.py:551
 msgid "Broadcast _off"
 msgstr "停用發送功能"
 
-#: ../terminatorlib/terminal.py:582
+#: ../terminatorlib/terminal.py:567
 msgid "_Split to this group"
 msgstr "分割群組"
 
-#: ../terminatorlib/terminal.py:587
+#: ../terminatorlib/terminal.py:572
 msgid "Auto_clean groups"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:594
+#: ../terminatorlib/terminal.py:579
 msgid "_Insert terminal number"
 msgstr "在命令列插入終端機編號"
 
-#: ../terminatorlib/terminal.py:598
+#: ../terminatorlib/terminal.py:583
 msgid "Insert _padded terminal number"
 msgstr ""
 
-#: ../terminatorlib/terminal.py:1524
+#: ../terminatorlib/terminal.py:1490
 msgid "Unable to find a shell"
 msgstr "找不到 shell"
 
-#: ../terminatorlib/terminal.py:1555
+#: ../terminatorlib/terminal.py:1521
 msgid "Unable to start shell:"
 msgstr "無法啟動 shell"
 
-#: ../terminatorlib/terminal.py:2005
+#: ../terminatorlib/terminal.py:1975
 msgid "Rename Window"
 msgstr "修改視窗名稱"
 
-#: ../terminatorlib/terminal.py:2013
+#: ../terminatorlib/terminal.py:1983
 msgid "Enter a new title for the Terminator window..."
 msgstr "輸入終端機視窗新標題"
 
@@ -1890,12 +1752,120 @@ msgstr ""
 msgid "window"
 msgstr "視窗"
 
-#: ../terminatorlib/window.py:746
+#: ../terminatorlib/window.py:773
 #, python-format
 msgid "Window group %s"
 msgstr ""
 
-#: ../terminatorlib/window.py:772
+#: ../terminatorlib/window.py:799
 #, python-format
 msgid "Tab %d"
 msgstr "分頁 %d"
+
+#~ msgid "Current Locale"
+#~ msgstr "在地語言"
+
+#~ msgid "Western"
+#~ msgstr "西歐語系"
+
+#~ msgid "Central European"
+#~ msgstr "中歐語系"
+
+#~ msgid "South European"
+#~ msgstr "南歐語系"
+
+#~ msgid "Baltic"
+#~ msgstr "波羅的海語"
+
+#~ msgid "Cyrillic"
+#~ msgstr "斯拉夫語"
+
+#~ msgid "Arabic"
+#~ msgstr "阿拉伯語"
+
+#~ msgid "Greek"
+#~ msgstr "希臘語"
+
+#~ msgid "Hebrew Visual"
+#~ msgstr "希伯來語（左至右）"
+
+#~ msgid "Hebrew"
+#~ msgstr "希伯來語"
+
+#~ msgid "Turkish"
+#~ msgstr "土耳其語"
+
+#~ msgid "Nordic"
+#~ msgstr "北歐語系"
+
+#~ msgid "Celtic"
+#~ msgstr "塞爾特語"
+
+#~ msgid "Romanian"
+#~ msgstr "羅馬尼亞語"
+
+#~ msgid "Unicode"
+#~ msgstr "萬國碼 (Unicode)"
+
+#~ msgid "Armenian"
+#~ msgstr "亞美尼亞語"
+
+#~ msgid "Chinese Traditional"
+#~ msgstr "正體中文"
+
+#~ msgid "Cyrillic/Russian"
+#~ msgstr "斯拉夫語系/俄文"
+
+#~ msgid "Japanese"
+#~ msgstr "日本語"
+
+#~ msgid "Korean"
+#~ msgstr "韓國語"
+
+#~ msgid "Chinese Simplified"
+#~ msgstr "簡體中文"
+
+#~ msgid "Georgian"
+#~ msgstr "喬治亞語"
+
+#~ msgid "Cyrillic/Ukrainian"
+#~ msgstr "斯拉夫/烏克蘭語系"
+
+#~ msgid "Croatian"
+#~ msgstr "克羅埃西亞語"
+
+#~ msgid "Hindi"
+#~ msgstr "北印度語"
+
+#~ msgid "Persian"
+#~ msgstr "波斯語"
+
+#~ msgid "Gujarati"
+#~ msgstr "古吉拉特語"
+
+#~ msgid "Gurmukhi"
+#~ msgstr "古爾穆奇文"
+
+#~ msgid "Icelandic"
+#~ msgstr "冰島語"
+
+#~ msgid "Vietnamese"
+#~ msgstr "越南語"
+
+#~ msgid "Thai"
+#~ msgstr "泰語"
+
+#~ msgid "Encoding:"
+#~ msgstr "編碼："
+
+#~ msgid "Encodings"
+#~ msgstr "編碼"
+
+#~ msgid "Default"
+#~ msgstr "預設"
+
+#~ msgid "User defined"
+#~ msgstr "使用者定義"
+
+#~ msgid "Other Encodings"
+#~ msgstr "其他編碼"


### PR DESCRIPTION
In PR #536 `encoding.py` was removed, but the translation files were still trying to read that file.
That brings to the errors in #569.

This PR simply removed one line in POTFILES.in and the rest is just output of the two scripts (`genpot.sh` and `update_all_po.sh`)

The translations for `encoding.py` are no longer necessary and the script automatically deleted them. I don't know if there is something to do in transifex.