### PR TITLE
Added hotfix for #78 that deletes GTK_IM_MODULE environment variable

### DIFF
--- a/terminator
+++ b/terminator
@@ -56,12 +56,8 @@ from terminatorlib.configjson import ConfigJson
 
 # Deleting env variable fixes double char problem when broadcasting (#78)
 # Only delete if it exists, or exception occurs
-try:
+if os.environ.get('GTK_IM_MODULE') is not None:
     del os.environ['GTK_IM_MODULE']
-except Exception as e:
-    # Only exception is a key error, which states that env var does not exists
-    # So, it is okay to pass
-    pass
 
 if __name__ == '__main__':
     # Workaround for IBus intefering with broadcast when using dead keys

--- a/terminator
+++ b/terminator
@@ -53,6 +53,16 @@ from terminatorlib.util import dbg, err
 from terminatorlib.layoutlauncher import LayoutLauncher
 from terminatorlib.configjson import ConfigJson
 
+
+# Deleting env variable fixes double char problem when broadcasting (#78)
+# Only delete if it exists, or exception occurs
+try:
+    del os.environ['GTK_IM_MODULE']
+except Exception as e:
+    # Only exception is a key error, which states that env var does not exists
+    # So, it is okay to pass
+    pass
+
 if __name__ == '__main__':
     # Workaround for IBus intefering with broadcast when using dead keys
     # Environment also needs IBUS_DISABLE_SNOOPER=1, or double chars appear


### PR DESCRIPTION
Using this hotfix for a while, did not observe any discrepancy. Creating this PR in order to
permanently(hopefully) fix the issue without any local modification.