### PR TITLE
Remove duplicated info in some debug messages

### DIFF
--- a/terminatorlib/borg.py
+++ b/terminatorlib/borg.py
@@ -42,11 +42,10 @@ class Borg:
         if borgtype is None:
             raise TypeError('Borg::__init__: You must pass a borgtype')
         if borgtype not in self.__shared_state:
-            dbg('Borg::__init__: Preparing borg state for %s' % borgtype)
+            dbg('Preparing borg state for %s' % borgtype)
             self.__shared_state[borgtype] = {}
         self.__dict__ = self.__shared_state[borgtype]
 
     def prepare_attributes(self):
         """This should be used to prepare any attributes of the borg class."""
         raise NotImplementedError('prepare_attributes')
-

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -321,10 +321,10 @@ class Config(object):
         if not force and options and options.profile and profile == 'default':
             dbg('overriding default profile to %s' % options.profile)
             profile = options.profile
-        dbg('Config::set_profile: Changing profile to %s' % profile)
+        dbg('Changing profile to %s' % profile)
         self.profile = profile
         if profile not in self.base.profiles:
-            dbg('Config::set_profile: %s does not exist, creating' % profile)
+            dbg('%s does not exist, creating' % profile)
             self.base.profiles[profile] = copy(DEFAULTS['profiles']['default'])
 
     def add_profile(self, profile, toclone):
@@ -617,7 +617,7 @@ class ConfigBase(Borg):
     def load(self):
         """Load configuration data from our various sources"""
         if self.loaded is True:
-            dbg('ConfigBase::load: config already loaded')
+            dbg('config already loaded')
             return
 
         if self.command_line_options and self.command_line_options.config:
@@ -665,11 +665,11 @@ class ConfigBase(Borg):
             dbg('config validated successfully')
 
         for section_name in self.sections:
-            dbg('ConfigBase::load: Processing section: %s' % section_name)
+            dbg('Processing section: %s' % section_name)
             section = getattr(self, section_name)
             if section_name == 'profiles':
                 for profile in parser[section_name]:
-                    dbg('ConfigBase::load: Processing profile: %s' % profile)
+                    dbg('Processing profile: %s' % profile)
                     if section_name not in section:
                         # FIXME: Should this be outside the loop?
                         section[profile] = copy(DEFAULTS['profiles']['default'])
@@ -678,13 +678,11 @@ class ConfigBase(Borg):
                 if section_name not in parser:
                     continue
                 for part in parser[section_name]:
-                    dbg('ConfigBase::load: Processing %s: %s' % (section_name,
-                                                                 part))
+                    dbg('Processing %s: %s' % (section_name, part))
                     section[part] = parser[section_name][part]
             elif section_name == 'layouts':
                 for layout in parser[section_name]:
-                    dbg('ConfigBase::load: Processing %s: %s' % (section_name,
-                                                                 layout))
+                    dbg('Processing %s: %s' % (section_name, layout))
                     if layout == 'default' and \
                        parser[section_name][layout] == {}:
                            continue
@@ -693,8 +691,7 @@ class ConfigBase(Borg):
                 if section_name not in parser:
                     continue
                 for part in parser[section_name]:
-                    dbg('ConfigBase::load: Processing %s: %s' % (section_name,
-                                                                 part))
+                    dbg('Processing %s: %s' % (section_name, part))
                     if parser[section_name][part] == 'None':
                         section[part] = None
                     else:
@@ -703,8 +700,7 @@ class ConfigBase(Borg):
                 try:
                     section.update(parser[section_name])
                 except KeyError as ex:
-                    dbg('ConfigBase::load: skipping missing section %s' %
-                            section_name)
+                    dbg('skipping missing section %s' % section_name)
 
         self.loaded = True
 
@@ -715,12 +711,12 @@ class ConfigBase(Borg):
 
     def save(self):
         """Save the config to a file"""
-        dbg('ConfigBase::save: saving config')
+        dbg('saving config')
         parser = ConfigObj(encoding='utf-8')
         parser.indent_type = '  '
 
         for section_name in ['global_config', 'keybindings']:
-            dbg('ConfigBase::save: Processing section: %s' % section_name)
+            dbg('Processing section: %s' % section_name)
             section = getattr(self, section_name)
             parser[section_name] = dict_diff(DEFAULTS[section_name], section)
 
@@ -730,7 +726,7 @@ class ConfigBase(Borg):
         for profile in self.profiles:
             if profile == JSON_PROFILE_NAME:
                 continue
-            dbg('ConfigBase::save: Processing profile: %s' % profile)
+            dbg('Processing profile: %s' % profile)
             parser['profiles'][profile] = dict_diff(
                     DEFAULTS['profiles']['default'], self.profiles[profile])
 
@@ -738,12 +734,12 @@ class ConfigBase(Borg):
         for layout in self.layouts:
             if layout == JSON_LAYOUT_NAME:
                 continue
-            dbg('ConfigBase::save: Processing layout: %s' % layout)
+            dbg('Processing layout: %s' % layout)
             parser['layouts'][layout] = self.layouts[layout]
 
         parser['plugins'] = {}
         for plugin in self.plugins:
-            dbg('ConfigBase::save: Processing plugin: %s' % plugin)
+            dbg('Processing plugin: %s' % plugin)
             parser['plugins'][plugin] = self.plugins[plugin]
 
         config_dir = get_config_dir()
@@ -776,17 +772,17 @@ class ConfigBase(Borg):
             profile = 'default'
 
         if key in self.global_config:
-            dbg('ConfigBase::get_item: %s found in globals: %s' %
+            dbg('%s found in globals: %s' %
                     (key, self.global_config[key]))
             return(self.global_config[key])
         elif key in self.profiles[profile]:
-            dbg('ConfigBase::get_item: %s found in profile %s: %s' % (
+            dbg('%s found in profile %s: %s' % (
                     key, profile, self.profiles[profile][key]))
             return(self.profiles[profile][key])
         elif key == 'keybindings':
             return(self.keybindings)
         elif plugin and plugin in self.plugins and key in self.plugins[plugin]:
-            dbg('ConfigBase::get_item: %s found in plugin %s: %s' % (
+            dbg('%s found in plugin %s: %s' % (
                     key, plugin, self.plugins[plugin][key]))
             return(self.plugins[plugin][key])
         elif default:
@@ -796,7 +792,7 @@ class ConfigBase(Borg):
 
     def set_item(self, key, value, profile='default', plugin=None):
         """Set a configuration item"""
-        dbg('ConfigBase::set_item: Setting %s=%s (profile=%s, plugin=%s)' %
+        dbg('Setting %s=%s (profile=%s, plugin=%s)' %
                 (key, value, profile, plugin))
 
         if key in self.global_config:

--- a/terminatorlib/container.py
+++ b/terminatorlib/container.py
@@ -114,7 +114,7 @@ class Container(object):
         try:
             if self.get_property('term_zoomed'):
                 # We're zoomed, so unzoom and then start closing again
-                dbg('Container::closeterm: terminal zoomed, unzooming')
+                dbg('terminal zoomed, unzooming')
                 self.unzoom(widget)
                 widget.close()
                 return(True)
@@ -122,7 +122,7 @@ class Container(object):
             pass
 
         if not self.remove(widget):
-            dbg('Container::closeterm: self.remove() failed for %s' % widget)
+            dbg('self.remove() failed for %s' % widget)
             return(False)
 
         self.terminator.deregister_terminal(widget)

--- a/terminatorlib/factory.py
+++ b/terminatorlib/factory.py
@@ -89,7 +89,7 @@ class Factory(Borg):
             err('Factory::make: requested object does not exist: %s' % product)
             return(None)
 
-        dbg('Factory::make: created a %s' % product)
+        dbg('created a %s' % product)
         output = func(**kwargs)
         inject_uuid(output)
         return(output)
@@ -118,4 +118,3 @@ class Factory(Borg):
         """Make a Notebook"""
         from . import notebook
         return(notebook.Notebook(kwargs['window']))
-

--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -342,12 +342,12 @@ class Notebook(Container, Gtk.Notebook):
 
     def wrapcloseterm(self, widget):
         """A child terminal has closed"""
-        dbg('Notebook::wrapcloseterm: called on %s' % widget)
+        dbg('called on %s' % widget)
         if self.closeterm(widget):
-            dbg('Notebook::wrapcloseterm: closeterm succeeded')
+            dbg('closeterm succeeded')
             self.hoover()
         else:
-            dbg('Notebook::wrapcloseterm: closeterm failed')
+            dbg('closeterm failed')
 
     def closetab(self, widget, label):
         """Close a tab"""
@@ -371,7 +371,7 @@ class Notebook(Container, Gtk.Notebook):
         child = nb.get_nth_page(tabnum)
 
         if maker.isinstance(child, 'Terminal'):
-            dbg('Notebook::closetab: child is a single Terminal')
+            dbg('child is a single Terminal')
             del nb.last_active_term[child]
             child.close()
             # FIXME: We only do this del and return here to avoid removing the
@@ -379,7 +379,7 @@ class Notebook(Container, Gtk.Notebook):
             del(label)
             return
         elif maker.isinstance(child, 'Container'):
-            dbg('Notebook::closetab: child is a Container')
+            dbg('child is a Container')
             result = self.construct_confirm_close(self.window, _('tab'))
 
             if result == Gtk.ResponseType.ACCEPT:
@@ -394,7 +394,7 @@ class Notebook(Container, Gtk.Notebook):
                         Gtk.main_iteration()
                 return
             else:
-                dbg('Notebook::closetab: user cancelled request')
+                dbg('user cancelled request')
                 return
         else:
             err('Notebook::closetab: child is unknown type %s' % child)

--- a/terminatorlib/optionparse.py
+++ b/terminatorlib/optionparse.py
@@ -166,6 +166,6 @@ icon for the window (by file or name)'))
         optionslist[opt] = val and '%s'%val or ''
     # optionslist = dbus.Dictionary(optionslist, signature='ss')
     if util.DEBUG == True:
-        dbg('OptionParse::parse_options: command line options: %s' % options)
+        dbg('command line options: %s' % options)
 
     return(options,optionslist)

--- a/terminatorlib/paned.py
+++ b/terminatorlib/paned.py
@@ -272,7 +272,7 @@ class Paned(Container):
 
     def wrapcloseterm(self, widget):
         """A child terminal has closed, so this container must die"""
-        dbg('Paned::wrapcloseterm: Called on %s' % widget)
+        dbg('Called on %s' % widget)
 
         if self.closeterm(widget):
             # At this point we only have one child, which is the surviving term
@@ -316,12 +316,12 @@ class Paned(Container):
                 except AttributeError:
                     dbg('cannot find terminal with uuid: %s' % sibling.get_toplevel().last_active_term.urn)
         else:
-            dbg("Paned::wrapcloseterm: self.closeterm failed")
+            dbg("self.closeterm failed")
 
     def hoover(self):
         """Check that we still have a reason to exist"""
         if len(self.children) == 1:
-            dbg('Paned::hoover: We only have one child, die')
+            dbg('We only have one child, die')
             parent = self.get_parent()
             child = self.children[0]
             self.remove(child)

--- a/terminatorlib/plugin.py
+++ b/terminatorlib/plugin.py
@@ -63,8 +63,7 @@ class PluginRegistry(borg.Borg):
             (head, _tail) = os.path.split(borg.__file__)
             self.path.append(os.path.join(head, 'plugins'))
             self.path.append(os.path.join(get_config_dir(), 'plugins'))
-            dbg('PluginRegistry::prepare_attributes: Plugin path: %s' % 
-                self.path)
+            dbg('Plugin path: %s' % self.path)
         if not self.done:
             self.done = False
         if not self.available_plugins:
@@ -73,7 +72,7 @@ class PluginRegistry(borg.Borg):
     def load_plugins(self):
         """Load all plugins present in the plugins/ directory in our module"""
         if self.done:
-            dbg('PluginRegistry::load_plugins: Already loaded')
+            dbg('Already loaded')
             return
 
         config = Config()
@@ -90,8 +89,7 @@ class PluginRegistry(borg.Borg):
                     continue
                 pluginpath = os.path.join(plugindir, plugin)
                 if os.path.isfile(pluginpath) and plugin[-3:] == '.py':
-                    dbg('PluginRegistry::load_plugins: Importing plugin %s' % 
-                        plugin)
+                    dbg('Importing plugin %s' % plugin)
                     try:
                         module = __import__(plugin[:-3], None, None, [''])
                         for item in getattr(module, 'AVAILABLE'):
@@ -113,7 +111,7 @@ failed: %s' % (plugin, ex))
     def get_plugins_by_capability(self, capability):
         """Return a list of plugins with a particular capability"""
         result = []
-        dbg('PluginRegistry::get_plugins_by_capability: searching %d plugins \
+        dbg('searching %d plugins \
 for %s' % (len(self.instances), capability))
         for plugin in self.instances:
             if capability in self.instances[plugin].capabilities:
@@ -189,4 +187,3 @@ class MenuItem(Plugin):
     def callback(self, menuitems, menu, terminal):
         """Callback to transform the enclosed URL"""
         raise NotImplementedError
-

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -456,7 +456,7 @@ class PrefsEditor:
         self.config.set_profile(profile)
         guiget = self.builder.get_object
 
-        dbg('PrefsEditor::set_profile_values: Setting profile %s' % profile)
+        dbg('Setting profile %s' % profile)
 
         ## General tab
         # Use system font
@@ -1633,8 +1633,7 @@ class PrefsEditor:
         oldname = cell.get_property('text')
         if oldname == newtext or oldname == 'default':
             return
-        dbg('PrefsEditor::on_profile_name_edited: Changing %s to %s' %
-        (oldname, newtext))
+        dbg('Changing %s to %s' % (oldname, newtext))
         self.config.rename_profile(oldname, newtext)
         self.config.save()
 

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -551,7 +551,7 @@ class Terminal(Gtk.VBox):
                           _('Broadcast _off'):'off'}.items()):
             item = Gtk.RadioMenuItem.new_with_mnemonic(groupitems, key)
             groupitems = item.get_group()
-            dbg('Terminal::populate_group_menu: %s active: %s' %
+            dbg('%s active: %s' %
                     (key, self.terminator.groupsend ==
                         self.terminator.groupsend_type[value]))
             item.set_active(self.terminator.groupsend ==
@@ -618,7 +618,7 @@ class Terminal(Gtk.VBox):
         """Set the groupsend mode"""
         # FIXME: Can we think of a smarter way of doing this than poking?
         if value in list(self.terminator.groupsend_type.values()):
-            dbg('Terminal::set_groupsend: setting groupsend to %s' % value)
+            dbg('setting groupsend to %s' % value)
             self.terminator.groupsend = value
 
     def do_splittogroup_toggle(self):
@@ -904,7 +904,7 @@ class Terminal(Gtk.VBox):
     def on_keypress(self, widget, event):
         """Handler for keyboard events"""
         if not event:
-            dbg('Terminal::on_keypress: Called on %s with no event' % widget)
+            dbg('Called on %s with no event' % widget)
             return False
 
         # FIXME: Does keybindings really want to live in Terminator()?
@@ -915,7 +915,7 @@ class Terminal(Gtk.VBox):
 
         if mapping and mapping not in ['close_window',
                                        'full_screen']:
-            dbg('Terminal::on_keypress: lookup found: %r' % mapping)
+            dbg('lookup found: %r' % mapping)
             # handle the case where user has re-bound copy to ctrl+<key>
             # we only copy if there is a selection otherwise let it fall through
             # to ^<key>
@@ -1379,7 +1379,7 @@ class Terminal(Gtk.VBox):
         new_rows = self.vte.get_row_count()
         new_font = self.vte.get_font()
 
-        dbg('Terminal::zoom_scale: Resized from %dx%d to %dx%d' % (
+        dbg('Resized from %dx%d to %dx%d' % (
              old_data['old_columns'],
              old_data['old_rows'],
              new_columns,
@@ -1387,7 +1387,7 @@ class Terminal(Gtk.VBox):
 
         if new_rows == old_data['old_rows'] or \
            new_columns == old_data['old_columns']:
-            dbg('Terminal::zoom_scale: One axis unchanged, not scaling')
+            dbg('One axis unchanged, not scaling')
             return
 
         scale_factor = min ( (new_columns / old_data['old_columns'] * 0.97),
@@ -1629,7 +1629,7 @@ class Terminal(Gtk.VBox):
             font = self.config.get_system_mono_font()
         else:
             font = self.config['font']
-        dbg("Terminal::zoom_orig: restoring font to: %s" % font)
+        dbg("restoring font to: %s" % font)
         self.set_font(Pango.FontDescription(font))
         self.custom_font_size = None
 

--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -123,14 +123,12 @@ class Terminator(Borg):
     def register_window(self, window):
         """Register a new window widget"""
         if window not in self.windows:
-            dbg('Terminator::register_window: registering %s:%s' % (id(window),
-                type(window)))
+            dbg('registering %s:%s' % (id(window), type(window)))
             self.windows.append(window)
 
     def deregister_window(self, window):
         """de-register a window widget"""
-        dbg('Terminator::deregister_window: de-registering %s:%s' %
-                (id(window), type(window)))
+        dbg('de-registering %s:%s' % (id(window), type(window)))
         if window in self.windows:
             self.windows.remove(window)
         else:
@@ -144,14 +142,12 @@ class Terminator(Borg):
     def register_launcher_window(self, window):
         """Register a new launcher window widget"""
         if window not in self.launcher_windows:
-            dbg('Terminator::register_launcher_window: registering %s:%s' % (id(window),
-                type(window)))
+            dbg('registering %s:%s' % (id(window), type(window)))
             self.launcher_windows.append(window)
 
     def deregister_launcher_window(self, window):
         """de-register a launcher window widget"""
-        dbg('Terminator::deregister_launcher_window: de-registering %s:%s' %
-                (id(window), type(window)))
+        dbg('de-registering %s:%s' % (id(window), type(window)))
         if window in self.launcher_windows:
             self.launcher_windows.remove(window)
         else:
@@ -165,13 +161,13 @@ class Terminator(Borg):
     def register_terminal(self, terminal):
         """Register a new terminal widget"""
         if terminal not in self.terminals:
-            dbg('Terminator::register_terminal: registering %s:%s' %
+            dbg('registering %s:%s' %
                     (id(terminal), type(terminal)))
             self.terminals.append(terminal)
 
     def deregister_terminal(self, terminal):
         """De-register a terminal widget"""
-        dbg('Terminator::deregister_terminal: de-registering %s:%s' %
+        dbg('de-registering %s:%s' %
                 (id(terminal), type(terminal)))
         self.terminals.remove(terminal)
 
@@ -180,8 +176,7 @@ class Terminator(Borg):
             for window in self.windows:
                 window.destroy()
         else:
-            dbg('Terminator::deregister_terminal: %d terminals remain' %
-                    len(self.terminals))
+            dbg('%d terminals remain' % len(self.terminals))
 
     def find_terminal_by_uuid(self, uuid):
         """Search our terminals for one matching the supplied UUID"""
@@ -531,7 +526,7 @@ class Terminator(Borg):
     def create_group(self, name):
         """Create a new group"""
         if name not in self.groups:
-            dbg('Terminator::create_group: registering group %s' % name)
+            dbg('registering group %s' % name)
             self.groups.append(name)
 
     def closegroupedterms(self, group):
@@ -556,15 +551,14 @@ class Terminator(Borg):
                 if not group in inuse:
                     todestroy.append(group)
 
-            dbg('Terminator::group_hoover: %d groups, hoovering %d' %
+            dbg('%d groups, hoovering %d' %
                     (len(self.groups), len(todestroy)))
             for group in todestroy:
                 self.groups.remove(group)
 
     def group_emit(self, terminal, group, type, event):
         """Emit to each terminal in a group"""
-        dbg('Terminator::group_emit: emitting a keystroke for group %s' %
-                group)
+        dbg('emitting a keystroke for group %s' % group)
         for term in self.terminals:
             if term != terminal and term.group == group:
                 term.vte.emit(type, eventkey2gdkevent(event))

--- a/terminatorlib/titlebar.py
+++ b/terminatorlib/titlebar.py
@@ -283,7 +283,7 @@ class Titlebar(Gtk.EventBox):
     def groupentry_activate(self, widget):
         """Actually cause a group to be created"""
         groupname = self.groupentry.get_text() or None
-        dbg('Titlebar::groupentry_activate: creating group: %s' % groupname)
+        dbg('creating group: %s' % groupname)
         self.groupentry_cancel(None, None)
         last_focused_term=self.terminator.last_focused_term
         if self.terminal.targets_for_new_group:

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -212,7 +212,7 @@ class Window(Container, Gtk.Window):
         mapping = self.terminator.keybindings.lookup(event)
 
         if mapping:
-            dbg('Window::on_key_press: looked up %r' % mapping)
+            dbg('looked up %r' % mapping)
             if mapping == 'full_screen':
                 self.set_fullscreen(not self.isfullscreen)
             elif mapping == 'close_window':
@@ -283,7 +283,7 @@ class Window(Container, Gtk.Window):
             if self.is_zoomed():
                 return(self.confirm_close(window, _('window')))
             else:
-                dbg('Window::on_delete_event: Only one child, closing is fine')
+                dbg('Only one child, closing is fine')
                 return(False)
         elif maker.isinstance(self.get_child(), 'Container'):
             return(self.confirm_close(window, _('window')))
@@ -337,7 +337,7 @@ class Window(Container, Gtk.Window):
                                  Gdk.WindowState.FULLSCREEN)
         self.ismaximised = bool(event.new_window_state &
                                  Gdk.WindowState.MAXIMIZED)
-        dbg('Window::on_window_state_changed: fullscreen=%s, maximised=%s' \
+        dbg('fullscreen=%s, maximised=%s' \
                 % (self.isfullscreen, self.ismaximised))
 
         return(False)
@@ -556,7 +556,7 @@ class Window(Container, Gtk.Window):
         """Restore normal terminal layout"""
         if not self.is_zoomed():
             # We're not zoomed anyway
-            dbg('Window::unzoom: not zoomed, no-op')
+            dbg('not zoomed, no-op')
             return
 
         widget = self.zoom_data['widget']


### PR DESCRIPTION
In the code, we can find code like this:
```python
dbg('ConfigBase::get_item: %s found in globals: %s' %
                    (key, self.global_config[key]))
```

But this gets printed:
```
ConfigBase::get_item: ConfigBase::get_item: focus found in globals: click
```

There is a repetition, because the `dbg` function already adds the name of the function at the beginning (4d216633fca8ca46fc3b51fdf2b382db93e3ade1).
The same should probably have been done to the `err` function.

This change should make the debug logs easier to read.