### PR TITLE
Zoom on notebook even if there is only one terminal in the tab + keep tab position and label in notebook rotation

### DIFF
--- a/terminatorlib/container.py
+++ b/terminatorlib/container.py
@@ -134,17 +134,6 @@ class Container(object):
         """Handle a keyboard event requesting a terminal resize"""
         raise NotImplementedError('resizeterm')
 
-    def toggle_zoom(self, widget, fontscale = False):
-        """Toggle the existing zoom state"""
-        try:
-            if self.get_property('term_zoomed'):
-                self.unzoom(widget)
-            else:
-                self.zoom(widget, fontscale)
-        except TypeError:
-            err('Container::toggle_zoom: %s is unable to handle zooming, for \
-            %s' % (self, widget))
-
     def zoom(self, widget, fontscale = False):
         """Zoom a terminal"""
         raise NotImplementedError('zoom')

--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -290,7 +290,9 @@ class Notebook(Container, Gtk.Notebook):
                    'ungroup-tab': top_window.ungroup_tab,
                    'move-tab': top_window.move_tab,
                    'tab-new': [top_window.tab_new, widget],
-                   'navigate': top_window.navigate_terminal}
+                   'navigate': top_window.navigate_terminal,
+                   'zoom': top_window.zoom,
+                   'maximise': [top_window.zoom, False]}
 
         if maker.isinstance(widget, 'Terminal'):
             for signal in signals:

--- a/terminatorlib/paned.py
+++ b/terminatorlib/paned.py
@@ -424,7 +424,7 @@ class Paned(Container):
         """We don't want focus, we want a Terminal to have it"""
         self.get_child1().grab_focus()
 
-    def rotate_recursive(self, parent, w, h, clockwise):
+    def rotate_recursive(self, parent, w, h, clockwise, metadata=None):
         """
         Recursively rotate "self" into a new paned that'll have "w" x "h" size. Attach it to "parent".
 
@@ -458,7 +458,7 @@ class Paned(Container):
             w2 = max(w - w1 - handle_size, 0)
 
         container.set_pos(pos)
-        parent.add(container)
+        parent.add(container, metadata=metadata)
 
         if maker.isinstance(children[0], 'Terminal'):
             children[0].get_parent().remove(children[0])

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -597,8 +597,17 @@ class Window(Container, Gtk.Window):
 
         # If our child is a Notebook, reset to work from its visible child
         if maker.isinstance(child, 'Notebook'):
-            pagenum = child.get_current_page()
-            child = child.get_nth_page(pagenum)
+            notebook = child
+
+            pagenum = notebook.get_current_page()
+            child = notebook.get_nth_page(pagenum)
+
+            metadata = {
+                'tabnum': pagenum,
+                'label': notebook.get_tab_label(child).get_label()
+            }
+        else:
+            metadata = None
 
         if maker.isinstance(child, 'Paned'):
             parent = child.get_parent()
@@ -606,7 +615,7 @@ class Window(Container, Gtk.Window):
             # otherwise _sometimes_ we get incorrect values.
             alloc = child.get_allocation()
             parent.remove(child)
-            child.rotate_recursive(parent, alloc.width, alloc.height, clockwise)
+            child.rotate_recursive(parent, alloc.width, alloc.height, clockwise, metadata)
 
             self.show_all()
             while Gtk.events_pending():


### PR DESCRIPTION
## The problem
When there are multiple tabs, the notebook top bar is visible.
Now, it is possible to split the terminal and then zoom/maximize, so that the top bar is hidden.
But when there is only one terminal in the notebook tab, it's not possible to do it.

## Solution
I added the signals for the notebook, so that it does zoom/maximize now.

## Current bug
When unzooming a tab **with a single terminal** in it, the tab is moved to the end of the notebook.
I currently have no idea why it does that, but since it can be annoying I think it's best to fix it before merging.

## Second commit
The function I deleted in the second commit (container.py) seems to be unused. Nowhere it's called and other functions do the same thing.