### PR TITLE
Modification in the /terminatorlib/prefseditor.py file

### DIFF
--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -966,10 +966,6 @@ class PrefsEditor:
             if self.palettevalues[key] == active:
                 value = key
 
-        sensitive = value == 'custom'
-        for palette_id in range(0, NUM_PALETTE_COLORS):
-            self.get_palette_widget(palette_id).set_sensitive(sensitive)
-
         if value in self.palettes:
             palette = self.palettes[value]
             palettebits = palette.split(':')
@@ -1726,8 +1722,8 @@ class PrefsEditor:
             for widget in [scheme, fore, back]:
                 widget.set_sensitive(False)
         else:
-            scheme.set_sensitive(True)
-            self.on_color_scheme_combobox_changed(scheme)
+        	scheme.set_sensitive(True)
+        	self.on_color_scheme_combobox_changed(scheme)
 
         self.config['use_theme_colors'] = active
         self.config.save()

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1722,8 +1722,8 @@ class PrefsEditor:
             for widget in [scheme, fore, back]:
                 widget.set_sensitive(False)
         else:
-        	scheme.set_sensitive(True)
-        	self.on_color_scheme_combobox_changed(scheme)
+            scheme.set_sensitive(True)
+            self.on_color_scheme_combobox_changed(scheme)
 
         self.config['use_theme_colors'] = active
         self.config.save()


### PR DESCRIPTION
While editing the preferences in terminator, If you select a particular palette, all of the palette widgets get locked which prevent you to make small changes according to your taste in that particular palette. To do that, you need to select "custom" palette where the widgets get unlocked and you can change the palette. I have changed it so that you can make slight changes then and there and don't have to select "custom" and change it from there. This is more convenient and easier to understand (I was stuck trying to make slight change to the "solarized" palette for a very long time).