### PR TITLE
More fixes to the Color pickers in the Preferences Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Terminator
 ==========
 
-by Chris Jones <cmsj@tenshu.net> and others.
+Started by Chris Jones <cmsj@tenshu.net> in 2007, maintained from 2014 to 2020 by Stephen Boddy, currently maintained by Matt Rose. Terminator has had contributions from countless others listed in the [AUTHORS](AUTHORS) file
 
 ## Description
 
@@ -81,6 +81,9 @@ useful at figuring out vte's API).
 vte-demo.py was not my code and is copyright its original author. While it 
 does not contain any specific licensing information in it, the VTE package 
 appears to be licenced under LGPL v2.
+
+The original version 0.1 release of Terminator was on Saturday, 28 July 2007.
+ [Here is the archived Terminator 0.1 release announcement](http://cmsj.net/2007/07/28/terminator-01-released.html)
 
 ## Licensing
 

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1697,12 +1697,8 @@ class PrefsEditor:
 
         fore = guiget('foreground_colorbutton')
         back = guiget('background_colorbutton')
-        if value == 'custom':
-            fore.set_sensitive(True)
-            back.set_sensitive(True)
-        else:
-            fore.set_sensitive(False)
-            back.set_sensitive(False)
+        fore.set_sensitive(True)
+        back.set_sensitive(True)
 
         forecol = None
         backcol = None


### PR DESCRIPTION
in #590 @amaan211 fixed it so that you could edit the palette colors for the themes without selecting "custom" first.  This allows the same change for the foreground and background colors.


