### PR TITLE
Add "scroll caching" functionality, similar to mark jumping in iTerm2

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -146,6 +146,8 @@ DEFAULTS = {
             'paste_selection'  : '',
             'toggle_scrollbar' : '<Shift><Control>s',
             'search'           : '<Shift><Control>f',
+            'prev_scroll'      : '<Control>Up',
+            'next_scroll'      : '<Control>Down',
             'page_up'          : '',
             'page_down'        : '',
             'page_up_half'     : '',

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -126,6 +126,8 @@ class PrefsEditor:
                         'paste_selection'  : _('Paste primary selection'),
                         'toggle_scrollbar' : _('Show/Hide the scrollbar'),
                         'search'           : _('Search terminal scrollback'),
+                        'prev_scroll'      : _('Scroll backwards in the cache'),
+                        'next_scroll'      : _('Scroll forwards in the cache'),
                         'page_up'          : _('Scroll upwards one page'),
                         'page_down'        : _('Scroll downwards one page'),
                         'page_up_half'     : _('Scroll upwards half a page'),

--- a/terminatorlib/scrollcache.py
+++ b/terminatorlib/scrollcache.py
@@ -1,0 +1,157 @@
+from bisect import bisect_left, bisect_right
+from .util import dbg
+from collections import deque
+
+
+class ScrollCache:
+    """Class implementing scroll cache functionality"""
+
+
+    def __init__(self, terminal):
+        """Class initialiser"""
+        self.vte_offset = terminal.vte.get_cursor_position()[1]
+        self.scroll_cache = []
+        self.reset(terminal)
+
+
+    def reset(self, terminal):
+        self.scrolling = False
+        self.can_restore = False
+
+        # The scrollbar and vte desync after 'clear/reset', so need to store the offset.
+        self.prev_vte_offset = self.vte_offset
+        self.prev_scroll_cache = self.scroll_cache
+
+        self.vte_offset = terminal.vte.get_cursor_position()[1]
+        self.scroll_cache = []
+
+        # Fullscreen programs like vim restore the terminal after exiting, try detect that.
+        self.prev_scrollbar_value = deque(maxlen=2)
+        self.prev_scrollbar_upper = deque(maxlen=2)
+        self.prev_scrollbar_value.append(terminal.scrollbar.get_adjustment().get_value())
+        self.prev_scrollbar_upper.append(terminal.scrollbar.get_adjustment().get_upper())
+
+
+    def scroll_restored(self, terminal):
+        dbg(f"{terminal.scrollbar.get_adjustment().get_value()}/{self.prev_scrollbar_value}, "
+            f"{terminal.scrollbar.get_adjustment().get_upper()}/{self.prev_scrollbar_upper}")
+        # Detecting the special case where a full screen application like vim has just returned control.
+        return (len(self.prev_scrollbar_upper) == 2 and len(self.prev_scrollbar_value) == 2 and
+            self.prev_scrollbar_value[0] == 0.0 and
+            self.prev_scrollbar_upper[0] == terminal.scrollbar.get_adjustment().get_page_size() and
+            terminal.scrollbar.get_adjustment().get_value() != 0.0 and
+            terminal.scrollbar.get_adjustment().get_upper() != terminal.scrollbar.get_adjustment().get_page_size() and
+            terminal.scrollbar.get_adjustment().get_value() - self.prev_scrollbar_value[1] <= 2 and
+            terminal.scrollbar.get_adjustment().get_upper() - self.prev_scrollbar_upper[1] <= 2)
+
+
+    # Calculates the scroll value accounting for any scrollback limiting
+    def calculate_scroll_value(self, terminal, raw_value):
+        return (terminal.scrollbar.get_adjustment().get_upper() -
+                (self.get_cursor_pos(terminal) - raw_value) - 1)
+
+
+    # Invert a scroll value to no longer account for scrollback limiting (such as those stored in the cache)
+    def calculate_inv_scroll_value(self, terminal, value):
+        return (value - terminal.scrollbar.get_adjustment().get_upper() + self.get_cursor_pos(terminal) + 1)
+
+
+    def scroll_handler(self, terminal):
+        # Don't try handle the scrolling we perform internally
+        if self.scrolling:
+            return
+
+        if self.can_restore and self.scroll_restored(terminal):
+            self.print_cache(terminal, "Scrolling restored after reset")
+            self.vte_offset = self.prev_vte_offset
+            self.scroll_cache = self.prev_scroll_cache
+        elif (terminal.scrollbar.get_adjustment().get_value() == 0.0 and
+            terminal.scrollbar.get_adjustment().get_lower() == 0.0 and
+            terminal.scrollbar.get_adjustment().get_upper() == terminal.scrollbar.get_adjustment().get_page_size()):
+            # Try to detect if the terminal was cleared with 'clear'
+            dbg(f"Clear/reset detected, clearing cache")
+            self.reset(terminal)
+            self.can_restore = True
+        else:
+            self.prev_scrollbar_value.append(terminal.scrollbar.get_adjustment().get_value())
+            self.prev_scrollbar_upper.append(terminal.scrollbar.get_adjustment().get_upper())
+
+
+    # Convenience for getting 'clear/reset' safe cursor pos
+    def get_cursor_pos(self, terminal):
+        return terminal.vte.get_cursor_position()[1] - self.vte_offset
+
+
+    def clean_cache(self, terminal):
+        # Need to remove cached points that have been scrolled out
+        if terminal.config['scrollback_infinite'] != True:
+            while (len(self.scroll_cache) and
+                (self.get_cursor_pos(terminal) - terminal.vte.get_scrollback_lines()) > self.scroll_cache[0]):
+                dbg(f"Removing {self.scroll_cache[0]} from cache as it's after "
+                    f"{(self.get_cursor_pos(terminal) - terminal.vte.get_scrollback_lines())}")
+                self.scroll_cache.pop(0)
+
+
+    def print_cache(self, terminal, when):
+        scrollback = "inf" if terminal.vte.get_scrollback_lines() == 9223372036854775807 else str(terminal.vte.get_scrollback_lines())
+        dbg(f"{when}: scrollback: {scrollback}, "
+            f"current: {self.get_cursor_pos(terminal)}, "
+            f"raw: {terminal.vte.get_cursor_position()[1]}, "
+            f"offset: {self.vte_offset}, "
+            f"scrollbar: {terminal.scrollbar.get_adjustment().get_value():.2f}, "
+            f"cache: {self.scroll_cache}, "
+            f"can restore: {self.can_restore}")
+
+
+    def key_cache_scroll(self, terminal, offset):
+        self.clean_cache(terminal)
+        self.print_cache(terminal, "append before")
+
+        self.can_restore = False
+
+        scroll_pos = self.get_cursor_pos(terminal) - offset
+
+        if len(self.scroll_cache) == 0:
+            self.scroll_cache.append(scroll_pos)
+        else:
+            # Find where to insert (may be out of order with fullscreen apps)
+            idx = bisect_left(self.scroll_cache, scroll_pos)
+            if idx == len(self.scroll_cache) or self.scroll_cache[idx] != scroll_pos:
+                self.scroll_cache.insert(idx, scroll_pos)
+
+        self.print_cache(terminal, "append after")
+
+
+    def key_prev_scroll(self, terminal):
+        self.clean_cache(terminal)
+        self.print_cache(terminal, "up before")
+
+        if len(self.scroll_cache) > 0:
+            scroll_cache_idx = bisect_left(self.scroll_cache,
+                self.calculate_inv_scroll_value(terminal,
+                    terminal.scrollbar.get_adjustment().get_value())) - 1
+
+            if scroll_cache_idx >= 0:
+                self.scrolling = True
+                terminal.scrollbar.set_value(self.calculate_scroll_value(terminal, self.scroll_cache[scroll_cache_idx]))
+                self.scrolling = False
+
+        self.print_cache(terminal, "up after")
+
+
+    def key_next_scroll(self, terminal):
+        self.clean_cache(terminal)
+        self.print_cache(terminal, "down before")
+
+        scroll_cache_idx = bisect_right(self.scroll_cache,
+            self.calculate_inv_scroll_value(terminal,
+                terminal.scrollbar.get_adjustment().get_value()))
+
+        self.scrolling = True
+        if scroll_cache_idx >= len(self.scroll_cache):
+            terminal.scrollbar.set_value(terminal.scrollbar.get_adjustment().get_upper())
+        else:
+            terminal.scrollbar.set_value(self.calculate_scroll_value(terminal, self.scroll_cache[scroll_cache_idx]))
+        self.scrolling = False
+
+        self.print_cache(terminal, "down after")


### PR DESCRIPTION
Ok I think this is ready for review again. It's more complicated but a lot more robust. I suspect you'll want to put this behind a checkbox setting? 

So, from the top: Adds two new keyboard shortcuts (`ctrl-up/down`) for jumping up/down between previous command executions on the shell. 

I had to hook into a terminal's scrollbar value-changed signal to handle tracking of the current "location" when the user scrolls. 

To detect "command execution", I had to do some relatively hacky stuff. Firstly, like in iTerm2 (AFAIK the only other terminal emulator that supports this?), I had to add a special hidden char to my shell's `PS1` prompt. I opted for the whitespace rendered Soft Hyphen (\u00AD), like this in my .bashrc:

```
PROMPT=$(echo -e '$\u00AD')
PS1=${PROMPT}
```
Now, I capture the `\r` character with the VTE terminal's on-commit signal. In order to function in the scenario where a command spans multiple lines, I search backwards in the terminal text until I hit the top of the window or find the prompt string (`$\xad`). I guess making this string a customiseable option would be a good idea? 

All of these signals go into the ScrollCache class that handles all of the logic. It stores a cache of cursor positions, populated every time a command is executed from the shell prompt via `\r`. 

Special consideration is required for a number of cases:
1) When infinite scrollback is disabled, book keeping needs to be done between the scroll bar's position and the VTE terminal's position. 
2) When `clear/reset` is called, more book keeping is required between the scroll bar and VTE terminal position. 
3) Full screen applications like vim mess with the cursor position once again and the cache has to be cleverly managed to avoid weirdness when the application is exited. 

Overall from testing I think it's working as expected now. I tested with/without infinite scroll, with mouse wheel scrolling, with clear/reset, with vim, with nvim, with another fullscreen terminal application, with fzf. Some fullscreen terminal applications end up erasing the cache history, but I think that's unavoidable. 

Looking forward to feedback, I'll continue dogfooding this myself. 