### PR TITLE
Fix missing icons when started with Ctrl-Alt-T

### DIFF
--- a/terminator
+++ b/terminator
@@ -33,7 +33,7 @@ try:
     import gi
     gi.require_version('Gtk','3.0')
     # pylint: disable-msg=W0611
-    from gi.repository import Gtk, Gdk
+    from gi.repository import Gtk, Gdk, GLib
 
     if Gdk.Display.get_default() == None:
         print('You need to run terminator in an X environment. ' \
@@ -80,6 +80,8 @@ if __name__ == '__main__':
 
     dbg ("%s starting up, version %s" % (APP_NAME, APP_VERSION))
   
+    GLib.set_prgname(APP_NAME)
+
     OPTIONS,dbus_options = terminatorlib.optionparse.parse_options()
     if OPTIONS.configjson:
         configjson = ConfigJson()


### PR DESCRIPTION
By default, GTK sets the prgname to argv[0], which is then used to choose the correct .desktop file. If the program is run through a symlink, such as through `/etc/alternatives/x-terminal-emulator`, argv[0] is not `terminator` so under Wayland the desktop file is not detected, leading to a missing icon.

Possibly fixes these issues:
https://askubuntu.com/questions/1218884/terminator-does-not-add-to-dock-icon-when-opened-via-ctrlaltt
https://bugs.launchpad.net/terminator/+bug/1726525