### PR TITLE
data: Remove GNOME branding

### DIFF
--- a/data/terminator.appdata.xml.in
+++ b/data/terminator.appdata.xml.in
@@ -47,4 +47,5 @@
  </screenshots>
  <url type="homepage">https://github.com/gnome-terminator/terminator</url>
  <updatecontact>terminator@lazyfrosch.de</updatecontact>
+ <developer_name>The Terminator Team</developer_name>
 </component>


### PR DESCRIPTION
This MR is part of an [initiative](https://gitlab.gnome.org/GNOME/Initiatives/-/issues/35) to fade out legacy app branding. Following the [Software Policy](https://wiki.gnome.org/Foundation/SoftwarePolicy), GNOME branding is reserved for official GNOME software (Core apps and Development tools.) You can find a summary in [this blog post](https://blogs.gnome.org/sophieh/2022/06/08/apps-attempt-of-a-status-report/).

If you think that your app is a special case that needs an exception from the software policy, we would ask you to leave a comment about your app's case in GNOME/Initiatives#35.

/label ~"9. Initiative: Legacy app branding"