### PR TITLE
Plugin Submission : SaveLastSessionLayout Uses Layout to Auto-Save Last session and CWD

### DIFF
--- a/terminatorlib/container.py
+++ b/terminatorlib/container.py
@@ -245,7 +245,7 @@ the tab will also close all terminals within it.')
 
         return(terminals)
 
-    def describe_layout(self, count, parent, global_layout, child_order):
+    def describe_layout(self, count, parent, global_layout, child_order, save_cwd = False):
         """Describe our current layout"""
         layout = {}
         maker = Factory()
@@ -308,7 +308,7 @@ the tab will also close all terminals within it.')
         child_order = 0
         for child in self.get_children():
             if hasattr(child, 'describe_layout'):
-                count = child.describe_layout(count, name, global_layout, child_order)
+                count = child.describe_layout(count, name, global_layout, child_order, save_cwd)
             child_order = child_order + 1
 
         return(count)

--- a/terminatorlib/plugins/save_last_session_layout.py
+++ b/terminatorlib/plugins/save_last_session_layout.py
@@ -1,0 +1,69 @@
+import os
+import sys 
+
+# Fix imports when testing this file directly
+if __name__ == '__main__':
+  sys.path.append( os.path.join(os.path.dirname(__file__), "../.."))
+
+from terminatorlib.config import Config
+import terminatorlib.plugin as plugin
+from terminatorlib.util import get_config_dir, err, dbg, gerr
+from terminatorlib.terminator import Terminator
+from terminatorlib import util
+
+
+# AVAILABLE must contain a list of all the classes that you want exposed
+AVAILABLE = ['SaveLastSessionLayout']
+
+class SaveLastSessionLayout(plugin.Plugin):
+    capabilities = ['session']
+
+    config = None
+    conf_file = os.path.join(get_config_dir(),"save_last_session_cwd")
+    conf_sessions = []
+    emit_close_count = 0
+
+    def __init__(self):
+      dbg("SaveLastSessionLayout Init")
+      self.connect_signals()
+
+    #not used, but capability
+    def load_session_layout(self, debugtab=False, widget=None, cwd=None, metadata=None, profile=None):
+      dbg("SaveLastSessionLayout load layout")
+      terminator = Terminator()
+      util.spawn_new_terminator(terminator.origcwd, ['-u', '-l', 'SaveLastSessionLayout'])
+
+    def save_session_layout(self, debugtab=False, widget=None, cwd=None, metadata=None, profile=None):
+
+      config = Config()
+      terminator = Terminator()
+      current_layout = terminator.describe_layout(save_cwd = True)
+      dbg("SaveLastSessionLayout: save layout(%s)" % str(current_layout))
+      res = config.replace_layout("SaveLastSessionLayout", current_layout)
+      if (not res):
+        r = config.add_layout("SaveLastSessionLayout", current_layout)
+      config.save()
+      return True
+    
+    def connect_signals(self):
+        dbg("SaveLastSessionLayout connect_signals")
+        n = 0
+        for term in Terminator().terminals:
+            dbg("SaveLastSessionLayout connect_signals to term num:(%d)" % n)
+            n = n + 1
+            term.connect('close-term', self.close, None)
+            #Can connect signal from terminal
+            #term.connect('load-layout', self.load_session_layout, None)
+
+    def close(self, term, event, arg1 = None):
+        if (self.emit_close_count == 0):
+            self.emit_close_count = self.emit_close_count + 1
+            self.save_session_layout("", "")
+
+    def connect_signals_delayed(self, term, event, arg1 = None):
+        def add_watch(self):
+            self.connect_signals()
+            return False
+        GObject.idle_add(add_watch, self)
+        return True
+

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1717,7 +1717,7 @@ class Terminal(Gtk.VBox):
         widget.get_window().process_updates(True)
         return False
 
-    def describe_layout(self, count, parent, global_layout, child_order):
+    def describe_layout(self, count, parent, global_layout, child_order, save_cwd = False):
         """Describe our layout"""
         layout = {'type': 'Terminal', 'parent': parent, 'order': child_order}
         if self.group:
@@ -1730,6 +1730,8 @@ class Terminal(Gtk.VBox):
         if title:
             layout['title'] = title
         layout['uuid'] = self.uuid
+        if save_cwd:
+            layout['directory'] = self.get_cwd()
         name = 'terminal%d' % count
         count = count + 1
         global_layout[name] = layout

--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -617,13 +617,13 @@ class Terminator(Borg):
     def focus_left(self, widget):
         self.last_focused_term=widget
 
-    def describe_layout(self):
+    def describe_layout(self, save_cwd = False):
         """Describe our current layout"""
         layout = {}
         count = 0
         for window in self.windows:
             parent = ''
-            count = window.describe_layout(count, parent, layout, 0)
+            count = window.describe_layout(count, parent, layout, 0, save_cwd)
 
         return(layout)
 


### PR DESCRIPTION
- added plugin save_last_session_layout.py
- saves the working directory and layout of last session (last window) closed
- layout is saved under name of SaveLastSessionLayout
- can be loaded from context menu (right click) -> layouts -> "SaveLastSessionLayout"
- last working directory is also saved