### PR TITLE
[bug 662] [Feature Request] - In the Context Menu(Right-Click) show k…

### DIFF
--- a/terminatorlib/terminal_popup_menu.py
+++ b/terminatorlib/terminal_popup_menu.py
@@ -35,7 +35,9 @@ class TerminalPopupMenu(object):
             mask = mask | Gdk.ModifierType.SHIFT_MASK
             dbg("adding mask <Shift> %s" % mask)
 
-        if maskstr.find('<Control>'.lower()) >= 0:
+        ctrl = (maskstr.find('<Control>'.lower()) >= 0 or
+                maskstr.find('<Primary>'.lower()) >= 0)
+        if ctrl:
             mask = mask | Gdk.ModifierType.CONTROL_MASK
             dbg("adding mask <Control> %s" % mask)
 
@@ -56,6 +58,18 @@ class TerminalPopupMenu(object):
         pos = menustr.lower().find("_")
         if (pos >= 0 and pos+1 < len(menustr)):
             accelchar = menustr.lower()[pos+1]
+
+        #this may require tweak. what about shortcut function keys ?
+        if maskstr:
+            mpos = maskstr.rfind(">")
+            #can't have a char at 0 position as <> is len 2
+            if mpos >= 0 and mpos+1 < len(maskstr):
+                configaccelchar = maskstr[mpos+1:]
+                #ensure to take only 1 char else ignore
+                if len(configaccelchar) == 1:
+                    dbg("found accelchar in config:%s  override:%s"
+                                    %  (configaccelchar, accelchar))
+                    accelchar = configaccelchar
 
         dbg("action from config:%s for item:%s with shortcut accelchar:(%s)"
                                     % (maskstr, menustr, accelchar))


### PR DESCRIPTION
…eyboard shortcuts / accelarators #662

-fixed: The problem in displaying is happening as the the config the key for eg Control is being saved as <Primary> and the short cut alphabetic character is being picked when creating the menu item and not being overwritten from config
-Note: the short cut for function keys are not being displayed in context-menu