### PR TITLE
[bug 680] Open up keybindings page on keypress #680

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -202,6 +202,7 @@ DEFAULTS = {
             'next_profile'     : '',
             'previous_profile' : '', 
             'preferences'      : '',
+            'preferences_keybindings' : '<Control><Shift>k',
             'help'             : 'F1'
         },
         'profiles': {

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -181,11 +181,12 @@ class PrefsEditor:
                         'layout_launcher'  : _('Open layout launcher window'),
                         'next_profile'     : _('Switch to next profile'),
                         'previous_profile' : _('Switch to previous profile'), 
-			'preferences'	   : _('Open the Preferences window'),
+                        'preferences'	   : _('Open the Preferences window'),
+                        'preferences_keybindings' : _('Open the Preferences-Keybindings window'),
                         'help'             : _('Open the manual')
             }
 
-    def __init__ (self, term):
+    def __init__ (self, term, cur_page=0):
         self.config = config.Config()
         self.config.base.reload()
         self.term = term
@@ -227,6 +228,10 @@ class PrefsEditor:
         except Exception as e:
             err('Unable to set values: %s' % e)
         self.config.uninhibit_save()
+
+        guiget = self.builder.get_object
+        nb = guiget('notebook1')
+        nb.set_current_page(cur_page)
 
     def on_closebutton_clicked(self, _button):
         """Close the window"""

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -2080,6 +2080,11 @@ class Terminal(Gtk.VBox):
     def key_preferences(self):
         PrefsEditor(self)
 
+    def key_preferences_keybindings(self):
+        #need to have this as a config may be preferences_default
+        #have a mapping rather than hardcoded page
+        PrefsEditor(self, cur_page = 3)
+
     def key_help(self):
         manual_index_page = manual_lookup()
         if manual_index_page:


### PR DESCRIPTION
- implemented the short-cut
- seems the key combo is already taken 'go_prev' : 'p'
- How about : 'k', I will make the change for now.
- But adding key seq to a long list of keypress function breaks my heart, If the plugin util keybind makes it to the main branch, I will take this out and may be have a shortcut plugin to handle these.
- Also selecting of Keybindings page is being done for this specific case Page = 3
- A notebook tab number and title map would remove this. Which can be configurable, later.