### PR TITLE
Ctrl+Click on group button automatically creates groups whenever needed

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -879,7 +879,13 @@ class Terminal(Gtk.VBox):
                 focused=self.get_toplevel().get_focussed_terminal()
                 if focused in targets: targets.remove(focused)
                 if self != focused:
-                    if self.group == focused.group:
+                    if focused.group is None and self.group is None:
+                        # Create a new group and assign currently focused
+                        # terminal to this group
+                        new_group = self.terminator.new_random_group()
+                        focused.set_group(None, new_group)
+                        focused.titlebar.update()
+                    elif self.group == focused.group:
                         new_group = None
                     else:
                         new_group = focused.group

--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -8,6 +8,8 @@ import gi
 gi.require_version('Vte', '2.91')
 from gi.repository import Gtk, Gdk, Vte
 from gi.repository.GLib import GError
+import itertools
+import random
 
 from . import borg
 from .borg import Borg
@@ -16,6 +18,7 @@ from .keybindings import Keybindings
 from .util import dbg, err, enumerate_descendants
 from .factory import Factory
 from .version import APP_NAME, APP_VERSION
+from .translation import _
 
 try:
     from gi.repository import GdkX11
@@ -638,4 +641,18 @@ class Terminator(Borg):
     def zoom_orig_all(self):
         for term in self.terminals:
             term.zoom_orig()
+
+    def new_random_group(self):
+        defaultmembers=[_('Alpha'),_('Beta'),_('Gamma'),_('Delta'),_('Epsilon'),_('Zeta'),_('Eta'),
+                        _('Theta'),_('Iota'),_('Kappa'),_('Lambda'),_('Mu'),_('Nu'),_('Xi'),
+                        _('Omicron'),_('Pi'),_('Rho'),_('Sigma'),_('Tau'),_('Upsilon'),_('Phi'),
+                        _('Chi'),_('Psi'),_('Omega')]
+        currentgroups=set(self.groups)
+        for i in range(1,4):
+            defaultgroups=set(map(''.join, list(itertools.product(defaultmembers,repeat=i))))
+            freegroups = list(defaultgroups-currentgroups)
+            if freegroups:
+                return random.choice(freegroups)
+        return ''
+
 # vim: set expandtab ts=4 sw=4:

--- a/terminatorlib/titlebar.py
+++ b/terminatorlib/titlebar.py
@@ -5,8 +5,6 @@
 from gi.repository import Gtk, Gdk
 from gi.repository import GObject
 from gi.repository import Pango
-import random
-import itertools
 
 from .version import APP_NAME
 from .util import dbg
@@ -255,19 +253,7 @@ class Titlebar(Gtk.EventBox):
         if self.terminal.group:
             self.groupentry.set_text(self.terminal.group)
         else:
-            defaultmembers=[_('Alpha'),_('Beta'),_('Gamma'),_('Delta'),_('Epsilon'),_('Zeta'),_('Eta'),
-                            _('Theta'),_('Iota'),_('Kappa'),_('Lambda'),_('Mu'),_('Nu'),_('Xi'),
-                            _('Omicron'),_('Pi'),_('Rho'),_('Sigma'),_('Tau'),_('Upsilon'),_('Phi'),
-                            _('Chi'),_('Psi'),_('Omega')]
-            currentgroups=set(self.terminator.groups)
-            for i in range(1,4):
-                defaultgroups=set(map(''.join, list(itertools.product(defaultmembers,repeat=i))))
-                freegroups = list(defaultgroups-currentgroups)
-                if freegroups:
-                    self.groupentry.set_text(random.choice(freegroups))
-                    break
-            else:
-                self.groupentry.set_text('')
+            self.groupentry.set_text(self.terminator.new_random_group())
         self.groupentry.show()
         self.grouplabel.hide()
         self.groupentry.grab_focus()


### PR DESCRIPTION
When pressing Ctrl+Click on the group button at the top of a terminal, if both the current terminal and the target terminal are not assigned a group:

- Before this change, nothing would happen.
- After this change, a new group with a randomized name will be created, without prompting the user for the group name.

Suggestion made at issue #685, with the goal of improving ergonomics.

Demonstration:

![001](https://user-images.githubusercontent.com/20824501/206023063-48e044b8-7459-4010-acbf-c2998e0504c1.gif)
