### PR TITLE
Better distinguishing of inactive windows from the active one, by changing the background brightness

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -103,7 +103,7 @@ DEFAULTS = {
             'custom_url_handler'    : '',
             'disable_real_transparency' : False,
             'inactive_color_offset': 0.8,
-            'inactive_bg_color_offset': 0.8,
+            'inactive_bg_color_offset': 1.0,
             'enabled_plugins'       : ['LaunchpadBugURLHandler',
                                        'LaunchpadCodeURLHandler',
                                        'APTURLHandler'],

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -103,6 +103,7 @@ DEFAULTS = {
             'custom_url_handler'    : '',
             'disable_real_transparency' : False,
             'inactive_color_offset': 0.8,
+            'inactive_bg_color_offset': 0.8,
             'enabled_plugins'       : ['LaunchpadBugURLHandler',
                                        'LaunchpadCodeURLHandler',
                                        'APTURLHandler'],

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -1121,7 +1121,7 @@
                                   <object class="GtkLabel" id="label35">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Unfocused terminal background color</property>
+                                    <property name="label" translatable="yes">Unfocused terminal background color:</property>
                                     <property name="xalign">0</property>
                                   </object>
                                   <packing>

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -340,6 +340,11 @@
     <property name="step-increment">0.10</property>
     <property name="page-increment">0.20</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment8">
+    <property name="upper">1</property>
+    <property name="step-increment">0.10</property>
+    <property name="page-increment">0.20</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment_cellheight">
     <property name="lower">1</property>
     <property name="upper">2</property>
@@ -887,7 +892,7 @@
                             <property name="spacing">36</property>
                             <property name="homogeneous">True</property>
                             <child>
-                              <!-- n-columns=3 n-rows=6 -->
+                              <!-- n-columns=3 n-rows=7 -->
                               <object class="GtkGrid" id="grid3">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -906,7 +911,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
-                                    <property name="top-attach">3</property>
+                                    <property name="top-attach">4</property>
                                     <property name="width">3</property>
                                   </packing>
                                 </child>
@@ -960,7 +965,7 @@
                                     <property name="can-focus">True</property>
                                     <property name="halign">baseline</property>
                                     <property name="hexpand">True</property>
-                                    <property name="adjustment">adjustment7</property>
+                                    <property name="adjustment">adjustment8</property>
                                     <property name="round-digits">2</property>
                                     <property name="digits">2</property>
                                     <property name="draw-value">False</property>
@@ -1030,7 +1035,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
-                                    <property name="top-attach">5</property>
+                                    <property name="top-attach">6</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -1046,7 +1051,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">1</property>
-                                    <property name="top-attach">5</property>
+                                    <property name="top-attach">6</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -1064,7 +1069,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">2</property>
-                                    <property name="top-attach">5</property>
+                                    <property name="top-attach">6</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -1081,7 +1086,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">2</property>
-                                    <property name="top-attach">4</property>
+                                    <property name="top-attach">5</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -1097,7 +1102,7 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">1</property>
-                                    <property name="top-attach">4</property>
+                                    <property name="top-attach">5</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -1109,7 +1114,52 @@
                                   </object>
                                   <packing>
                                     <property name="left-attach">0</property>
-                                    <property name="top-attach">4</property>
+                                    <property name="top-attach">5</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="label35">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Unfocused terminal background color</property>
+                                    <property name="xalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="inactive_bg_color_offset_value_label">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">100%</property>
+                                    <property name="justify">right</property>
+                                    <property name="width-chars">5</property>
+                                    <property name="max-width-chars">5</property>
+                                    <property name="xalign">1</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkScale" id="inactive_bg_color_offset">
+                                    <property name="width-request">100</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="adjustment">adjustment7</property>
+                                    <property name="round-digits">2</property>
+                                    <property name="digits">2</property>
+                                    <property name="draw-value">False</property>
+                                    <property name="value-pos">bottom</property>
+                                    <signal name="value-changed" handler="on_inactive_bg_color_offset_value_changed" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">3</property>
                                   </packing>
                                 </child>
                               </object>
@@ -3721,12 +3771,12 @@
             </child>
             <child>
               <object class="GtkVBox" id="vbox124">
-               <child>
+                <property name="can-focus">False</property>
+                <child>
                   <object class="GtkEntry" id="keybindingsearchentry">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="has-focus">False</property>
-                    <property name="placeholder_text">filter keybindings</property>
+                    <property name="placeholder-text">filter keybindings</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -3734,67 +3784,72 @@
                     <property name="position">0</property>
                   </packing>
                 </child>
-              <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow1">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="vadjustment">adjustment4</property>
-                <property name="hscrollbar-policy">never</property>
-                <property name="shadow-type">in</property>
                 <child>
-                  <object class="GtkTreeView" id="keybindingtreeview">
+                  <object class="GtkScrolledWindow" id="scrolledwindow1">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="has-focus">True</property>
-                    <property name="model">KeybindingsListStore</property>
-                    <property name="headers-clickable">False</property>
-                    <property name="search-column">0</property>
-                    <child internal-child="selection">
-                      <object class="GtkTreeSelection" id="treeview-selection4"/>
-                    </child>
+                    <property name="vadjustment">adjustment4</property>
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="shadow-type">in</property>
                     <child>
-                      <object class="GtkTreeViewColumn" id="treeviewcolumn1">
-                        <property name="title" translatable="yes">Name</property>
-                        <child>
-                          <object class="GtkCellRendererText" id="cellrenderertext10"/>
-                          <attributes>
-                            <attribute name="text">0</attribute>
-                          </attributes>
+                      <object class="GtkTreeView" id="keybindingtreeview">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="has-focus">True</property>
+                        <property name="model">KeybindingsListStore</property>
+                        <property name="headers-clickable">False</property>
+                        <property name="search-column">0</property>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection" id="treeview-selection4"/>
                         </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkTreeViewColumn" id="treeviewcolumn2">
-                        <property name="title" translatable="yes">Action</property>
                         <child>
-                          <object class="GtkCellRendererText" id="cellrenderertext11"/>
-                          <attributes>
-                            <attribute name="text">1</attribute>
-                          </attributes>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkTreeViewColumn" id="treeviewcolumn3">
-                        <property name="title" translatable="yes">Keybinding</property>
-                        <child>
-                          <object class="GtkCellRendererAccel" id="cellrendereraccel1">
-                            <property name="editable">True</property>
-                            <property name="accel-mode">other</property>
-                            <signal name="accel-cleared" handler="on_cellrenderer_accel_cleared" object="KeybindingsListStore" swapped="yes"/>
-                            <signal name="accel-edited" handler="on_cellrenderer_accel_edited" object="KeybindingsListStore" swapped="yes"/>
+                          <object class="GtkTreeViewColumn" id="treeviewcolumn1">
+                            <property name="title" translatable="yes">Name</property>
+                            <child>
+                              <object class="GtkCellRendererText" id="cellrenderertext10"/>
+                              <attributes>
+                                <attribute name="text">0</attribute>
+                              </attributes>
+                            </child>
                           </object>
-                          <attributes>
-                            <attribute name="accel-key">2</attribute>
-                            <attribute name="accel-mods">3</attribute>
-                          </attributes>
+                        </child>
+                        <child>
+                          <object class="GtkTreeViewColumn" id="treeviewcolumn2">
+                            <property name="title" translatable="yes">Action</property>
+                            <child>
+                              <object class="GtkCellRendererText" id="cellrenderertext11"/>
+                              <attributes>
+                                <attribute name="text">1</attribute>
+                              </attributes>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkTreeViewColumn" id="treeviewcolumn3">
+                            <property name="title" translatable="yes">Keybinding</property>
+                            <child>
+                              <object class="GtkCellRendererAccel" id="cellrendereraccel1">
+                                <property name="editable">True</property>
+                                <property name="accel-mode">other</property>
+                                <signal name="accel-cleared" handler="on_cellrenderer_accel_cleared" object="KeybindingsListStore" swapped="yes"/>
+                                <signal name="accel-edited" handler="on_cellrenderer_accel_edited" object="KeybindingsListStore" swapped="yes"/>
+                              </object>
+                              <attributes>
+                                <attribute name="accel-key">2</attribute>
+                                <attribute name="accel-mods">3</attribute>
+                              </attributes>
+                            </child>
+                          </object>
                         </child>
                       </object>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
-              </object>
-              </child>
               </object>
               <packing>
                 <property name="position">3</property>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -674,6 +674,10 @@ class PrefsEditor:
         widget.set_value(float(self.config['inactive_color_offset']))
         widget = guiget('inactive_color_offset_value_label')
         widget.set_text('%d%%' % (int(float(self.config['inactive_color_offset'])*100)))
+        widget = guiget('inactive_bg_color_offset')
+        widget.set_value(float(self.config['inactive_bg_color_offset']))
+        widget = guiget('inactive_bg_color_offset_value_label')
+        widget.set_text('%d%%' % (int(float(self.config['inactive_bg_color_offset'])*100)))
         # Open links with a single click (instead of a Ctrl-left click)
         widget = guiget('link_single_click')
         widget.set_active(self.config['link_single_click'])
@@ -1292,6 +1296,17 @@ class PrefsEditor:
         self.config.save()
         guiget = self.builder.get_object
         label_widget = guiget('inactive_color_offset_value_label')
+        label_widget.set_text('%d%%' % (int(value * 100)))
+
+    def on_inactive_bg_color_offset_value_changed(self, widget):
+        """Inactive background color offset setting changed"""
+        value = widget.get_value()  # This one is rounded according to the UI.
+        if value > 1.0:
+          value = 1.0
+        self.config['inactive_bg_color_offset'] = value
+        self.config.save()
+        guiget = self.builder.get_object
+        label_widget = guiget('inactive_bg_color_offset_value_label')
         label_widget.set_text('%d%%' % (int(value * 100)))
 
     def on_handlesize_value_changed(self, widget):

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -756,7 +756,9 @@ class Terminal(Gtk.VBox):
                                                       getattr(self.fgcolor_inactive, "green"),
                                                       getattr(self.fgcolor_inactive, "blue")))
 
-        bg_factor = 0.8
+        bg_factor = self.config['inactive_bg_color_offset']
+        if bg_factor > 1.0:
+            bg_factor = 1.0
         self.bgcolor_inactive = self.bgcolor.copy()
         for bit in ['red', 'green', 'blue']:
             setattr(self.bgcolor_inactive, bit,

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -760,9 +760,16 @@ class Terminal(Gtk.VBox):
         if bg_factor > 1.0:
             bg_factor = 1.0
         self.bgcolor_inactive = self.bgcolor.copy()
+        dbg(("bgcolor_inactive set to: RGB(%s,%s,%s)", getattr(self.bgcolor_inactive, "red"),
+                                                      getattr(self.bgcolor_inactive, "green"),
+                                                      getattr(self.bgcolor_inactive, "blue")))
+
         for bit in ['red', 'green', 'blue']:
             setattr(self.bgcolor_inactive, bit,
                     getattr(self.bgcolor_inactive, bit) * bg_factor)
+        dbg(("bgcolor_inactive set to: RGB(%s,%s,%s)", getattr(self.bgcolor_inactive, "red"),
+                                                      getattr(self.bgcolor_inactive, "green"),
+                                                      getattr(self.bgcolor_inactive, "blue")))
 
         colors = self.config['palette'].split(':')
         self.palette_active = []

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -112,6 +112,7 @@ class Terminal(Gtk.VBox):
     fgcolor_active = None
     fgcolor_inactive = None
     bgcolor = None
+    bgcolor_inactive = None
     palette_active = None
     palette_inactive = None
 
@@ -754,6 +755,13 @@ class Terminal(Gtk.VBox):
         dbg(("fgcolor_inactive set to: RGB(%s,%s,%s)", getattr(self.fgcolor_inactive, "red"),
                                                       getattr(self.fgcolor_inactive, "green"),
                                                       getattr(self.fgcolor_inactive, "blue")))
+
+        bg_factor = 0.8
+        self.bgcolor_inactive = self.bgcolor.copy()
+        for bit in ['red', 'green', 'blue']:
+            setattr(self.bgcolor_inactive, bit,
+                    getattr(self.bgcolor_inactive, bit) * bg_factor)
+
         colors = self.config['palette'].split(':')
         self.palette_active = []
         for color in colors:
@@ -789,7 +797,7 @@ class Terminal(Gtk.VBox):
             self.vte.set_colors(self.fgcolor_active, self.bgcolor,
                                 self.palette_active)
         else:
-            self.vte.set_colors(self.fgcolor_inactive, self.bgcolor,
+            self.vte.set_colors(self.fgcolor_inactive, self.bgcolor_inactive,
                                 self.palette_inactive)
         profiles = self.config.base.profiles
         terminal_box_style_context = self.terminalbox.get_style_context()
@@ -1314,7 +1322,7 @@ class Terminal(Gtk.VBox):
 
     def on_vte_focus_out(self, _widget, _event):
         """Inform other parts of the application when focus is lost"""
-        self.vte.set_colors(self.fgcolor_inactive, self.bgcolor,
+        self.vte.set_colors(self.fgcolor_inactive, self.bgcolor_inactive,
                             self.palette_inactive)
         self.set_cursor_color()
         self.emit('focus-out')


### PR DESCRIPTION
Hello!

I normally don't use title bar, thus differentiation between active and inactive windows, when there is not much in the foreground, is hard for me.

To better explain this, check out this GIF - the problem:
<img src="https://user-images.githubusercontent.com/17928698/216665594-778c3aa7-e2ab-47a3-ba6c-696f6ece405e.gif" width="512"/>
When there is not much data on the terminals, then it's hard to distinguish in which terminal I'm currently writing.

With this PR, one can change the background brightness of the Inactive window:
<img src="https://user-images.githubusercontent.com/17928698/216666745-a1ef36e9-36df-4e19-b6ee-00408c439e58.gif" width="512"/>


I have introduced a setting which allows changing the background brightness of the inactive window:
<img src="https://user-images.githubusercontent.com/17928698/216667590-f251739f-539d-40d2-9429-ebcac344d6d7.png" width="512">

This PR introduces changes to the background color, and the implementation is a simple copy-pasted solution, scrapped from the `inactive_color_offset`, which controls the brightness of the font for an inactive window.

At this stage, it is a draft, because I have few questions:
1. Do you find it good?
2. Should I update the translations as well, since a new text within the "Preferences" window is introduced? Even, when I generate the translation script from the upstream/master, I get a non-null git diff. Therefore, I am "afraid" of putting the updated to the PR.