### PR TITLE
Background image drawing modes and alignment

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -217,6 +217,8 @@ DEFAULTS = {
                 'background_type'       : 'solid',
                 'background_image'      : '',
                 'background_image_mode' : 'stretch_and_fill',
+                'background_image_align_horiz': 'center',
+                'background_image_align_vert' : 'middle',
                 'backspace_binding'     : 'ascii-del',
                 'delete_binding'        : 'escape-sequence',
                 'color_scheme'          : 'grey_on_black',

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -216,6 +216,7 @@ DEFAULTS = {
                 'background_darkness'   : 0.5,
                 'background_type'       : 'solid',
                 'background_image'      : '',
+                'background_image_mode' : 'stretch_and_fill',
                 'backspace_binding'     : 'ascii-del',
                 'delete_binding'        : 'escape-sequence',
                 'color_scheme'          : 'grey_on_black',

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkListStore" id="BackspaceKeyListStore">
@@ -151,6 +151,60 @@
       </row>
       <row>
         <col id="0" translatable="yes">Follow mouse pointer</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="ImageAlignHorizListStore">
+    <columns>
+      <!-- column-name Alignment -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Left</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Center</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Right</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="ImageAlignVertListStore">
+    <columns>
+      <!-- column-name Alignment -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Top</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Middle</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Bottom</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="ImageDrawingModeListStore">
+    <columns>
+      <!-- column-name DrawingMode -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Stretch and Fill</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Scale and Fit</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Scale and Crop</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Tiling</col>
       </row>
     </data>
   </object>
@@ -2660,41 +2714,208 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox">
+                          <object class="GtkAlignment">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
+                            <property name="left-padding">12</property>
                             <child>
-                              <object class="GtkLabel">
+                              <object class="GtkBox">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Background Image File:</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Image File:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkFileChooserButton" id="background_image_file">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="title" translatable="yes">Choose file</property>
+                                        <signal name="file-set" handler="on_background_image_file_set" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="pack-type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkAccelLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Drawing mode:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="background_image_mode_combobox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="model">ImageDrawingModeListStore</property>
+                                        <property name="active">0</property>
+                                        <signal name="changed" handler="on_background_image_mode_changed" swapped="no"/>
+                                        <child>
+                                          <object class="GtkCellRendererText"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="pack-type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <property name="homogeneous">True</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Horizontal alignment:</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="padding">5</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkComboBox" id="background_image_align_horiz_combobox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="model">ImageAlignHorizListStore</property>
+                                            <property name="active">1</property>
+                                            <signal name="changed" handler="on_background_image_align_horiz_changed" swapped="no"/>
+                                            <child>
+                                              <object class="GtkCellRendererText"/>
+                                              <attributes>
+                                                <attribute name="text">0</attribute>
+                                              </attributes>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack-type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Vertical alignment:</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="padding">5</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkComboBox" id="background_image_align_vert_combobox">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="model">ImageAlignVertListStore</property>
+                                            <property name="active">1</property>
+                                            <signal name="changed" handler="on_background_image_align_vert_changed" swapped="no"/>
+                                            <child>
+                                              <object class="GtkCellRendererText"/>
+                                              <attributes>
+                                                <attribute name="text">0</attribute>
+                                              </attributes>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack-type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkFileChooserButton" id="background_image_file">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="title" translatable="yes">Choose file</property>
-                                <signal name="file-set" handler="on_background_image_file_set" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="pack-type">end</property>
-                                <property name="position">1</property>
-                              </packing>
                             </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">4</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                         <child>
@@ -2783,7 +3004,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">4</property>
+                            <property name="position">6</property>
                           </packing>
                         </child>
                       </object>
@@ -3721,12 +3942,12 @@
             </child>
             <child>
               <object class="GtkVBox" id="vbox124">
-               <child>
+                <property name="can-focus">False</property>
+                <child>
                   <object class="GtkEntry" id="keybindingsearchentry">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="has-focus">False</property>
-                    <property name="placeholder_text">filter keybindings</property>
+                    <property name="placeholder-text">filter keybindings</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -3734,67 +3955,72 @@
                     <property name="position">0</property>
                   </packing>
                 </child>
-              <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow1">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="vadjustment">adjustment4</property>
-                <property name="hscrollbar-policy">never</property>
-                <property name="shadow-type">in</property>
                 <child>
-                  <object class="GtkTreeView" id="keybindingtreeview">
+                  <object class="GtkScrolledWindow" id="scrolledwindow1">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="has-focus">True</property>
-                    <property name="model">KeybindingsListStore</property>
-                    <property name="headers-clickable">False</property>
-                    <property name="search-column">0</property>
-                    <child internal-child="selection">
-                      <object class="GtkTreeSelection" id="treeview-selection4"/>
-                    </child>
+                    <property name="vadjustment">adjustment4</property>
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="shadow-type">in</property>
                     <child>
-                      <object class="GtkTreeViewColumn" id="treeviewcolumn1">
-                        <property name="title" translatable="yes">Name</property>
-                        <child>
-                          <object class="GtkCellRendererText" id="cellrenderertext10"/>
-                          <attributes>
-                            <attribute name="text">0</attribute>
-                          </attributes>
+                      <object class="GtkTreeView" id="keybindingtreeview">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="has-focus">True</property>
+                        <property name="model">KeybindingsListStore</property>
+                        <property name="headers-clickable">False</property>
+                        <property name="search-column">0</property>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection" id="treeview-selection4"/>
                         </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkTreeViewColumn" id="treeviewcolumn2">
-                        <property name="title" translatable="yes">Action</property>
                         <child>
-                          <object class="GtkCellRendererText" id="cellrenderertext11"/>
-                          <attributes>
-                            <attribute name="text">1</attribute>
-                          </attributes>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkTreeViewColumn" id="treeviewcolumn3">
-                        <property name="title" translatable="yes">Keybinding</property>
-                        <child>
-                          <object class="GtkCellRendererAccel" id="cellrendereraccel1">
-                            <property name="editable">True</property>
-                            <property name="accel-mode">other</property>
-                            <signal name="accel-cleared" handler="on_cellrenderer_accel_cleared" object="KeybindingsListStore" swapped="yes"/>
-                            <signal name="accel-edited" handler="on_cellrenderer_accel_edited" object="KeybindingsListStore" swapped="yes"/>
+                          <object class="GtkTreeViewColumn" id="treeviewcolumn1">
+                            <property name="title" translatable="yes">Name</property>
+                            <child>
+                              <object class="GtkCellRendererText" id="cellrenderertext10"/>
+                              <attributes>
+                                <attribute name="text">0</attribute>
+                              </attributes>
+                            </child>
                           </object>
-                          <attributes>
-                            <attribute name="accel-key">2</attribute>
-                            <attribute name="accel-mods">3</attribute>
-                          </attributes>
+                        </child>
+                        <child>
+                          <object class="GtkTreeViewColumn" id="treeviewcolumn2">
+                            <property name="title" translatable="yes">Action</property>
+                            <child>
+                              <object class="GtkCellRendererText" id="cellrenderertext11"/>
+                              <attributes>
+                                <attribute name="text">1</attribute>
+                              </attributes>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkTreeViewColumn" id="treeviewcolumn3">
+                            <property name="title" translatable="yes">Keybinding</property>
+                            <child>
+                              <object class="GtkCellRendererAccel" id="cellrendereraccel1">
+                                <property name="editable">True</property>
+                                <property name="accel-mode">other</property>
+                                <signal name="accel-cleared" handler="on_cellrenderer_accel_cleared" object="KeybindingsListStore" swapped="yes"/>
+                                <signal name="accel-edited" handler="on_cellrenderer_accel_edited" object="KeybindingsListStore" swapped="yes"/>
+                              </object>
+                              <attributes>
+                                <attribute name="accel-key">2</attribute>
+                                <attribute name="accel-mods">3</attribute>
+                              </attributes>
+                            </child>
+                          </object>
                         </child>
                       </object>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
-              </object>
-              </child>
               </object>
               <packing>
                 <property name="position">3</property>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -694,11 +694,42 @@ class PrefsEditor:
         elif self.config['background_type'] == 'image':
             guiget('image_radiobutton').set_active(True)
         self.update_background_tab()
+        # Background image
+        widget = guiget('background_image_file')
+        widget.set_filename(self.config['background_image'])
+
+        widget = guiget('background_image_mode_combobox')
+        if self.config['background_image_mode'] == 'scale_and_fit':
+            widget.set_active(1)
+        elif self.config['background_image_mode'] == 'scale_and_crop':
+            widget.set_active(2)
+        elif self.config['background_image_mode'] == 'tiling':
+            widget.set_active(3)
+        else:
+            # default to stretch_and_fill
+            widget.set_active(0)
+
+        widget = guiget('background_image_align_horiz_combobox')
+        if self.config['background_image_align_horiz'] == 'center':
+            widget.set_active(1)
+        elif self.config['background_image_align_horiz'] == 'right':
+            widget.set_active(2)
+        else:
+            # default to left
+            widget.set_active(0)
+
+        widget = guiget('background_image_align_vert_combobox')
+        if self.config['background_image_align_vert'] == 'middle':
+            widget.set_active(1)
+        elif self.config['background_image_align_vert'] == 'bottom':
+            widget.set_active(2)
+        else:
+            # default to top
+            widget.set_active(0)
+
         # Background shading
         widget = guiget('background_darkness_scale')
         widget.set_value(float(self.config['background_darkness']))
-        widget = guiget('background_image_file')
-        widget.set_filename(self.config['background_image'])
    
         ## Scrolling tab
         # Scrollbar position
@@ -997,6 +1028,41 @@ class PrefsEditor:
 
     def on_background_image_file_set(self,widget):
         self.config['background_image'] = widget.get_filename()
+        self.config.save()
+
+    def on_background_image_mode_changed(self, widget):
+        selected = widget.get_active()
+        if selected == 1:
+            value = 'scale_and_fit'
+        elif selected == 2:
+            value = 'scale_and_crop'
+        elif selected == 3:
+            value = 'tiling'
+        else:
+            value = 'stretch_and_fill'
+        self.config['background_image_mode'] = value
+        self.config.save()
+
+    def on_background_image_align_horiz_changed(self, widget):
+        selected = widget.get_active()
+        if selected == 1:
+            value = 'center'
+        elif selected == 2:
+            value = 'right'
+        else:
+            value = 'left'
+        self.config['background_image_align_horiz'] = value
+        self.config.save()
+
+    def on_background_image_align_vert_changed(self, widget):
+        selected = widget.get_active()
+        if selected == 1:
+            value = 'middle'
+        elif selected == 2:
+            value = 'bottom'
+        else:
+            value = 'top'
+        self.config['background_image_align_vert'] = value
         self.config.save()
 
     def on_darken_background_scale_value_changed(self, widget):
@@ -1603,10 +1669,12 @@ class PrefsEditor:
         self.config['background_type'] = backtype
         self.config.save()
 
-        if backtype == 'image':
-                guiget('background_image_file').set_sensitive(True)
-        else:
-                guiget('background_image_file').set_sensitive(False)
+        # toggle sensitivity of widgets related to background image
+        for element in ('background_image_file',
+                        'background_image_align_horiz_combobox',
+                        'background_image_align_vert_combobox',
+                        'background_image_mode_combobox'):
+            guiget(element).set_sensitive(backtype == 'image')
 
         if backtype in ('transparent', 'image'):
             guiget('darken_background_scale').set_sensitive(True)

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1135,17 +1135,35 @@ class Terminal(Gtk.VBox):
 
         # save cairo context
         cr.save()
+
         # draw background image
+        image_mode = self.config['background_image_mode']
+
         rect = self.vte.get_allocation()
         xratio = float(rect.width) / float(self.background_image.get_width())
         yratio = float(rect.height) / float(self.background_image.get_height())
-        cr.scale(xratio, yratio)
+        if image_mode == 'stretch_and_fill':
+            cr.scale(xratio, yratio)
+        elif image_mode == 'scale_and_fit':
+            ratio = min(xratio, yratio)
+            cr.scale(ratio, ratio)
+        elif image_mode == 'scale_and_crop':
+            ratio = max(xratio, yratio)
+            cr.scale(ratio, ratio)
+
+        # TODO add image alignment
+
         cr.set_source_surface(self.background_image)
         cr.get_source().set_filter(cairo.Filter.FAST)
+        if image_mode == 'tiling':
+            cr.get_source().set_extend(cairo.Extend.REPEAT)
+
         cr.paint()
+
         # draw transparent monochrome layer
         Gdk.cairo_set_source_rgba(cr, self.bgcolor)
         cr.paint()
+
         # restore cairo context
         cr.restore()
 

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1138,22 +1138,39 @@ class Terminal(Gtk.VBox):
 
         # draw background image
         image_mode = self.config['background_image_mode']
+        image_align_horiz = self.config['background_image_align_horiz']
+        image_align_vert = self.config['background_image_align_vert']
 
         rect = self.vte.get_allocation()
         xratio = float(rect.width) / float(self.background_image.get_width())
         yratio = float(rect.height) / float(self.background_image.get_height())
         if image_mode == 'stretch_and_fill':
-            cr.scale(xratio, yratio)
+            # keep stretched ratios
+            xratio = xratio
+            yratio = yratio
         elif image_mode == 'scale_and_fit':
             ratio = min(xratio, yratio)
-            cr.scale(ratio, ratio)
+            xratio = yratio = ratio
         elif image_mode == 'scale_and_crop':
             ratio = max(xratio, yratio)
-            cr.scale(ratio, ratio)
+            xratio = yratio = ratio
+        else:
+            xratio = yratio = 1
+        cr.scale(xratio, yratio)
 
-        # TODO add image alignment
+        xoffset = 0
+        yoffset = 0
+        if image_align_horiz == 'center':
+            xoffset = (rect.width / xratio - self.background_image.get_width()) / 2
+        elif image_align_horiz == 'right':
+            xoffset = rect.width / xratio - self.background_image.get_width()
 
-        cr.set_source_surface(self.background_image)
+        if image_align_vert == 'middle':
+            yoffset = (rect.height / yratio - self.background_image.get_height()) / 2
+        elif image_align_vert == 'bottom':
+            yoffset = rect.height / yratio - self.background_image.get_height()
+
+        cr.set_source_surface(self.background_image, xoffset, yoffset)
         cr.get_source().set_filter(cairo.Filter.FAST)
         if image_mode == 'tiling':
             cr.get_source().set_extend(cairo.Extend.REPEAT)


### PR DESCRIPTION
Closes #644.

After quite some time, I made the GUI changes that were necessary. This PR adds different drawing modes and alignment for the background image.

![terminator-gui-changes](https://user-images.githubusercontent.com/47713809/218793887-919dbd13-187f-47af-a8c9-5908cfbbc9a2.png)

***

New config options: `background_image_mode`, `background_image_align_horiz` and `background_image_align_vert`.

1. `background_image_mode`:
    - stretch_and_fill
    - scale_and_fit
    - scale_and_crop
    - tiling
2. `background_image_align_horiz`:
    - left
    - center
    - right
3. `background_image_align_vert`:
    - top
    - middle
    - bottom

The defaults are `stretch_and_fill`, `center` and `center`. This is the behavior that terminator has right now with images.