### PR TITLE
Fix context menu keybinding reading.

### DIFF
--- a/terminatorlib/terminal_popup_menu.py
+++ b/terminatorlib/terminal_popup_menu.py
@@ -30,6 +30,8 @@ class TerminalPopupMenu(object):
 
     def get_menu_item_mask(self, maskstr):
         mask = 0
+        if maskstr is None:
+            return mask
         maskstr = maskstr.lower()
         if maskstr.find('<Shift>'.lower()) >= 0:
             mask = mask | Gdk.ModifierType.SHIFT_MASK


### PR DESCRIPTION
When the keybinding for an action that also appears in the context menu is None, python can't do it's usual string tricks and throws a backtrace, and doesn't display the menu.

Fixes #724