### PR TITLE
Do not remove focus from the last_active_window

### DIFF
--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -355,7 +355,6 @@ class Terminator(Borg):
         if self.last_active_window:
             window = self.find_window_by_uuid(self.last_active_window.urn)
             window.present_with_time(t)
-            window.set_focus()
         self.prelayout_windows = None
 
     def on_gtk_theme_name_notify(self, settings, prop):


### PR DESCRIPTION
This caused all the new windows to be unfocused, forcing the user to manually focus one.

From the [docs](https://lazka.github.io/pgi-docs/Gtk-3.0/classes/Window.html#Gtk.Window.set_focus):
> If `focus` is `None`, unsets the focus widget for this window.

On my machine, the last_active_window feature seems to be broken.
I've spent some time trying to figure out why, but found nothing.

Most of the `layout_done` function appears to do nothing useful, but that might be different on other Desktop Environments.

It's an old problem, with commits from 10 years ago trying to fix it. And it's a mess.