### PR TITLE
Rewrite terminator_config.5 man page in AsciiDoc format

### DIFF
--- a/doc/gen_manpages.sh
+++ b/doc/gen_manpages.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+asciidoctor -b manpage terminator.adoc
+asciidoctor -b manpage terminator_config.adoc

--- a/doc/terminator_config.5
+++ b/doc/terminator_config.5
@@ -1,528 +1,1360 @@
-.TH "TERMINATOR_CONFIG" "5" "Feb 22, 2008" "Nicolas Valcarcel <nvalcarcel@ubuntu.com>" ""
+'\" t
+.\"     Title: terminator_config
+.\"    Author: [see the "AUTHOR(S)" section]
+.\" Generator: Asciidoctor 2.0.18
+.\"      Date: 2023-04-22
+.\"    Manual: Manual for Terminator
+.\"    Source: Terminator
+.\"  Language: English
+.\"
+.TH "TERMINATOR_CONFIG" "5" "2023-04-22" "Terminator" "Manual for Terminator"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\fI\\$2\fP <\\$1>\\$3
+..
+.als MTO URL
+.if \n[.g] \{\
+.  mso www.tmac
+.  am URL
+.    ad l
+.  .
+.  am MTO
+.    ad l
+.  .
+.  LINKSTYLE blue R < >
+.\}
 .SH "NAME"
-~/.config/terminator/config \- the config file for Terminator terminal emulator.
+terminator_config \- the config file for Terminator terminal emulator
 .SH "DESCRIPTION"
-This manual page documents briefly the
-.B Terminator
-config file. Terminator manages its configuration file via the ConfigObj library to combine flexibility with clear, human editable files. As of version 0.90, Terminator offers a full GUI preferences editor which automatically saves its config file so you don't need to write a config file by hand.
-.PP
+.sp
+This file contains the configuration for \fBterminator\fP(1).
+Terminator manages its configuration file via the ConfigObj library to
+combine flexibility with clear, human editable files.
+.br
+Terminator offers a full GUI preferences editor which automatically
+saves its config file so you don\(cqt need to write a config file by hand.
 .SH "FILE LOCATION"
-Normally the config file will be ~/.config/terminator/config, but it may be overridden with $XDG_CONFIG_HOME (in which case it will be $XDG_CONFIG_HOME/terminator/config)
+.sp
+Normally the config file will be \fB~/.config/terminator/config\fP, but it
+may be overridden with \fB$XDG_CONFIG_HOME\fP (in which case it will be
+\fB$XDG_CONFIG_HOME/terminator/config\fP).
 .SH "FILE FORMAT"
+.sp
 This is what a Terminator config file should look like:
+.sp
+.if n .RS 4
+.nf
+.fam C
+# This is a comment
+[global_config]
+  focus = system
 
-  # This is a comment
-  [global_config]
-    focus = system
+[keybindings]
+  full_screen = <Ctrl><Shift>F11
 
-  [keybindings]
-    full_screen = <Ctrl><Shift>F11
-
-  [profiles]
-    [[default]]
-      font = Fixed 10
-      background_color = "#000000" # A comment
-      foreground_color = "#FFFFFF" # Note that hex colour values must be quoted
-      scrollback_lines = '500' #More comment. Single quotes are valid too
-      cursor_blink = True
-      custom_command = "echo \\"foo#bar\\"" #Final comment - this will work as expected.
-
-Below are the individual sections that can exist in the config file:
-
-.SH "global_config"
-These are the options Terminator currently supports in the global_config section:
-.TP
-.B dbus
-Control whether or not Terminator will load its DBus server. When this server is loaded, running Terminator multiple times will cause the first Terminator process to open additional windows. If this configuration item is set to False, or the python dbus module is unavailable, running Terminator multiple times will run a separate Terminator process for each invocation.
-Default value: \fBTrue\fR
-.TP
-.B focus
-Control how focus is given to terminals. 'click' means the focus only moves to a terminal after you click in it. 'sloppy' means the focus will follow the mouse pointer. 'system' means the focus will match that used by a GNOME window manager.
-Default value: \fBclick\fR
-.TP
-.B handle_size
-Controls the width of the separator between terminals. Anything outside the range 0-20 (inclusive) will be ignored and use your default theme value.
-Default value: \fB-1\fR
-.TP
-.B geometry_hinting
-If True the window will resize in step with font sizes, if False it will follow pixels
-Default value: \fBFalse\fR
-.TP
-.B window_state
-When set to 'normal' the Terminator window opens normally. 'maximise' opens the window in a maximised state, 'fullscreen' in a fullscreen state and 'hidden' will make it not shown by default.
-Default value: \fBnormal\fR
-.TP
-.B borderless \fR(boolean)
-Controls whether the Terminator window will be started without window borders
-Default value: \fBFalse\fR
-.TP
-.B tab_position
-Defines where tabs are placed.  Can be any of: top, left, right, bottom.
-If this is set to "hidden", the tab bar will not be shown. Note that hiding the tab bar is very confusing and not recommended.
-Default value: \fBtop\fR
-.TP
-.B broadcast_default
-Defines default broadcast behavior.  Can be any of: all, group, off.
-Default value: \fBgroup\fR
-.TP
-.B close_button_on_tab \fR(boolean)
-If set to True, tabs will have a close button on them.
-Default value: \fBTrue\fR
-.TP
-.B hide_tabbar \fR(boolean)
-If set to True, the tab bar will be hidden. This means there will be no visual indication of either how many tabs there are, or which one you are on. Be warned that this can be very confusing and hard to use.
-.B NOTE: THIS OPTION IS DEPRECATED, USE tab_position INSTEAD
-Default value: \fBFalse\fR
-.TP
-.B scroll_tabbar \fR(boolean)
-If set to True, the tab bar will not fill the width of the window. The titlebars of the tabs will only take as much space as is necessary for the text they contain. Except, that is, if the tabs no longer fit the width of the window - in that case scroll buttons will appear to move through the tabs.
-Default value: \fBFalse\fR
-.TP
-.B try_posix_regexp \fR(boolean)
-If set to True, URL matching regexps will try to use POSIX style first, and fall back on GNU style on failure.  If you are on Linux but URL matches don't work, try setting this to True.  If you are not on Linux, but you get VTE warnings on startup saying "Error compiling regular expression", set this to False to silence them (they are otherwise harmless).
-Default value: \fBFalse\fR on Linux, \fBTrue\fR otherwise.
-.TP
-.B use_custom_url_handler \fR(boolean)
-If set to True, URL handling will be given over entirely to the program specified by 'custom_url_handler'.
-Default value: \fBFalse\fR
-.TP
-.B custom_url_handler \fR(string)
-Path to a program which accepts a URI as an argument and does something relevant with it. This option is ignored unless 'use_custom_url_handler' is set to True.
-Default value: unset
-.TP
-.B disable_real_transparency \fR(string)
-If this is set to True, Terminator will never try to use 'real' transparency if your windowing environment supports it. Instead it will use 'fake' transparency where a background image is shown, but other windows are not.
-Default value: False
-.TP
-.B title_transmit_fg_color
-Sets the colour of the text shown in the titlebar of the active terminal.
-Default value: \fB'#FFFFFF'\fR
-.TP
-.B title_transmit_bg_color
-Sets the colour of the background of the titlebar in the active terminal.
-Default value: \fB'#C80003'\fR
-.TP
-.B title_receive_fg_color
-Sets the colour of the text shown in the titlebar of any terminal that \fBwill\fR receive input from the active terminal.
-Default value: \fB'#FFFFFF'\fR
-.TP
-.B title_receive_bg_color
-Sets the colour of the background of the titlebar of any terminal that \fBwill\fR receive input from the active terminal.
-Default value: \fB'#0076C9'\fR
-.TP
-.B title_inactive_fg_color
-Sets the colour of the text shown in the titlebar of any terminal that will \fBnot\fR receive input from the active terminal.
-Default value: \fB'#000000'\fR
-.TP
-.B title_inactive_bg_color
-Sets the colour of the background of the titlebar of any terminal that will \fBnot\fR receive input from the active terminal.
-Default value: \fB'#C0BEBF'\fR
-.TP
-.B title_use_system_font \fR(boolean)
-Whether or not to use the GNOME default proportional font for titlebars.
-Default value: \fBTrue\fR
-.TP
-.B title_font \fR(string)
-An Pango font name. Examples are "Sans 12" or "Monospace Bold 14".
-Default value: \fB"Sans 9"\fR
-.TP
-.B inactive_color_offset
-Controls how much to reduce the colour values of fonts in terminals that do not have focus. It is a simple multiplication
-factor. A font colour that was RGB(200,200,200) with an inactive_color_offset of 0.5 would set inactive terminals to
-RGB(100,100,100).
-.TP
-.B always_split_with_profile
-Controls whether splits/tabs will continue to use the profile of their peer terminal. If set to False, they will always use
-the default profile.
-Default value: \fBFalse\fR
-.TP
-.B putty_paste_style \fR(boolean)
-If set to True, right-click will paste the Primary selection, middle-click will popup the context menu.
-Default value: \fBFalse\fR
-.TP
-.B smart_copy \fR(boolean)
-If set to True, and there is no selection, the shortcut is allowed to pass through. This is useful for overloading Ctrl-C to copy a selection, or send the SIGINT to the current process if there is no selection. If False the shortcut does not pass through at all, and the SIGINT does not get sent.
-Default value: \fBTrue\fR
-.TP
-.B enabled_plugins
-A list of plugins which should be loaded by default. All other plugin classes will be ignored. The default value includes two
-plugins related to Launchpad, which are enabled by default to provide continuity with earlier releases where these were the
-only substantial plugins available, and all plugins were loaded by default.
-Default value: \fB"LaunchpadBugURLHandler, LaunchpadCodeURLHandler"\fR
-
-.SH keybindings
-These are the options Terminator currently supports in the keybindings section:
-.TP
-.B zoom_in
-Make font one unit larger.
-Default value: \fB<Ctrl>plus\fR
-.TP
-.B zoom_out
-Make font one unit smaller.
-Default value: \fB<Ctrl>minus\fR
-.TP
-.B zoom_normal
-Return font to pre-configured size.
-Default value: \fB<Ctrl>0\fR
-.TP
-.B new_tab
-Open a new tab.
-Default value: \fB<Ctrl><Shift>T\fR
-.TP
-.B cycle_next
-Cycle forwards through the tabs.
-Default value: \fB<Ctrl>Tab\fR
-.TP
-.B cycle_prev
-Cycle backwards through the tabs.
-Default value: \fB<Ctrl><Shift>Tab\fR
-.B go_next
-Move cursor focus to the next tab.
-Default value: \fB<Ctrl><Shift>N\fR
-.TP
-.B go_prev
-Move cursor focus to the previous tab.
-Default value: \fB<Ctrl><Shift>P\fR
-.TP
-.B go_up
-Move cursor focus to the terminal above.
-Default value: \fB<Alt>Up\fR
-.TP
-.B go_down
-Move cursor focus to the terminal below.
-Default value: \fB<Alt>Down\fR
-.TP
-.B go_left
-Move cursor focus to the terminal to the left.
-Default value: \fB<Alt>Left\fR
-.TP
-.B go_right
-Move cursor focus to the terminal to the right.
-Default value: \fB<Alt>Right\fR
-.TP
-.B rotate_cw
-Rotate terminals clockwise.
-Default value: \fB<Super>R\fR
-.TP
-.B rotate_ccw
-Rotate terminals counter-clockwise.
-Default value: \fB<Super><Shift>R\fR
-.TP
-.B split_horiz
-Split the current terminal horizontally.
-Default value: \fB<Ctrl><Shift>O\fR
-.TP
-.B split_vert
-Split the current terminal vertically.
-Default value: \fB<Ctrl><Shift>E\fR
-.TP
-.B close_term
-Close the current terminal.
-Default value: \fB<Ctrl><Shift>W\fR
-.TP
-.B copy
-Copy the currently selected text to the clipboard.
-Default value: \fB<Ctrl><Shift>C\fR
-.TP
-.B paste
-Paste the current contents of the clipboard.
-Default value: \fB<Ctrl><Shift>V\fR
-.TP
-.B paste_selection
-Paste the current contents of the primary selection.
-Default value: \fBUnbound\fR
-.TP
-.B toggle_scrollbar
-Show/Hide the scrollbar.
-Default value: \fB<Ctrl><Shift>S\fR
-.TP
-.B search
-Search for text in the terminal scrollback history.
-Default value: \fB<Ctrl><Shift>F\fR
-.TP
-.B close_window
-Quit Terminator.
-Default value: \fB<Ctrl><Shift>Q\fR
-.TP
-.B resize_up
-Move the parent dragbar upwards.
-Default value: \fB<Ctrl><Shift>Up\fR
-.TP
-.B resize_down
-Move the parent dragbar downwards.
-Default value: \fB<Ctrl><Shift>Down\fR
-.TP
-.B resize_left
-Move the parent dragbar left.
-Default value: \fB<Ctrl><Shift>Left\fR
-.TP
-.B resize_right
-Move the parent dragbar right.
-Default value: \fB<Ctrl><Shift>Right\fR
-.TP
-.B move_tab_right
-Swap the current tab with the one to its right.
-Default value: \fB<Ctrl><Shift>Page_Down\fR
-.TP
-.B move_tab_left
-Swap the current tab with the one to its left.
-Default value: \fB<Ctrl><Shift>Page_Up\fR
-.TP
-.B toggle_zoom
-Zoom/Unzoom the current terminal to fill the window.
-Default value: \fB<Ctrl><Shift>X\fR
-.TP
-.B scaled_zoom
-Zoom/Unzoom the current terminal to fill the window, and scale its font.
-Default value: \fB<Ctrl><Shift>Z\fR
-.TP
-.B next_tab
-Move to the next tab.
-Default value: \fB<Ctrl>Page_Down\fR
-.TP
-.B prev_tab
-Move to the previous tab.
-Default value: \fB<Ctrl>Page_Up\fR
-.TP
-.B switch_to_tab_1 - switch_to_tab_10
-Keys to switch directly to the numbered tab.
-Note that <Alt><Shift>1 may need to be provided as <Alt>! or similar,
-depending on your keyboard layout.
-Default value: \fBUnbound\fR
-.TP
-.B edit_window_title
-Edit the current active window's title
-Default value: \fB<Ctrl><Alt>W\fR
-.TP
-.B edit_tab_title
-Edit the currently active tab's title
-Default value: \fB<Ctrl><Alt>A\fR
-.TP
-.B edit_terminal_title
-Edit the currently active terminal's title
-Default value: \fB<Ctrl><Alt>X\fR
-.TP
-.B full_screen
-Toggle the window to a fullscreen window.
-Default value: \fBF11\fR
-.TP
-.B reset
-Reset the terminal state.
-Default value: \fB<Ctrl><Shift>R\fR
-.TP
-.B reset_clear
-Reset the terminal state and clear the terminal window.
-Default value: \fB<Ctrl><Shift>G\fR
-.TP
-.B hide_window
-Toggle visibility of the Terminator window.
-Default value: \fB<Ctrl><Shift><Alt>a\fR
-.TP
-.B group_all
-Group all terminals together so input sent to one goes to all of them.
-Default value: \fB<Super>g\fR
-.TP
-.B ungroup_all
-Remove grouping from all terminals.
-Default value: \fB<Super><Shift>G\fR
-.TP
-.B group_tab
-Group all terminals in the current tab together so input sent to one goes to all of them.
-Default value: \fB<Super>t\fR
-.TP
-.B ungroup_tab
-Remove grouping from all terminals in the current tab.
-Default value: \fB<Super><Shift>T\fR
-.TP
-.B new_window
-Open a new Terminator window as part of the existing process.
-Default value: \fB<Ctrl><Shift>I\fR
-.TP
-.B new_terminator
-Spawn a new instance of Terminator.
-Default value: \fB<Super>i\fR
-
-.SH profiles
-These are the options Terminator currently supports in the profiles section.
-Each profile should be its own subsection with a header in the format \fB[[name]]\fR
-
-.B allow_bold\fR (boolean)
-If true, allow applications in the terminal to make text boldface.
-Default value: \fBTrue\fR
-.TP
-.B audible_bell\fR (boolean)
-If true, make a noise when applications send the escape sequence for the terminal bell.
-Default value: \fBFalse\fR
-.TP
-.B visible_bell\fR (boolean)
-If true, flash the terminal when applications send the escape sequence for the terminal bell.
-Default value: \fBFalse\fR
-.TP
-.B urgent_bell\fR (boolean)
-If true, set the window manager "urgent" hint when applications send the escale sequence for the terminal bell. Any keypress will cancel the urgent status.
-Default value: \fBFalse\fR
-.TP
-.B icon_bell\fR (boolean)
-If true, briefly show a small icon on the terminal title bar for the terminal bell.
-Default value: \fBTrue\fR
-.TP
-.B force_no_bell\fR (boolean)
-If true, don't make a noise or flash. All terminal bells will be ignored.
-Default value: \fBFalse\fR
-.TP
-.B use_theme_colors
-If true, ignore the configured colours and use values from the theme instead.
-Default value: \fBFalse\fR
-.TP
-.B bold_is_bright
-If true, show bold text with increased brightness. If false, then text boldness can be controlled by applications independently from the text brightness.
-Default value: \fBFalse\fR
-.TP
-.B background_color
-Default colour of terminal background, as a colour specification (can be HTML-style hex digits, or a colour name such as "red"). \fBNote:\fR You may need to set \fBuse_theme_colors=False\fR to force this setting to take effect.
-Default value: \fB'#000000'\fR
-.TP
-.B background_darkness
-A value between 0.0 and 1.0 indicating how much to darken the background image. 0.0 means no darkness, 1.0 means fully dark. If the terminal is set to transparent, this setting controls how transparent it is. 0.0 means fully transparent, 1.0 means fully opaque.
-Default value: \fB0.5\fR
-.TP
-.B background_type
-Type of terminal background. May be "solid" for a solid colour or "transparent" for full transparency in compositing window managers.
-Default value: \fBsolid\fR
-.TP
-.B backspace_binding
-Sets what code the backspace key generates. Possible values are "ascii-del" for the ASCII DEL character, "control-h" for Control-H (AKA the ASCII BS character), "escape-sequence" for the escape sequence typically bound to backspace or delete. "ascii-del" is normally considered the correct setting for the Backspace key.
-Default value: \fBascii\-del\fR
-.TP
-.B delete_binding
-Sets what code the delete key generates. Possible values are "ascii-del" for the ASCII DEL character, "control-h" for Control-H (AKA the ASCII BS character), "escape-sequence" for the escape sequence typically bound to backspace or delete. "escape-sequence" is normally considered the correct setting for the Delete key.
-Default value: \fBescape\-sequence\fR
-.TP
-.B color_scheme \fR(boolean)
-If specified this sets foreground_color and background_color to pre-set values. Possible options are 'grey_on_black', 'black_on_yellow', 'black_on_white', 'white_on_black', 'green_on_black', 'orange_on_black', 'ambience', 'solarized_dark', 'solarized_light'.
-Default value: \fRgrey_on_black\fR
-.TP
-.B cursor_blink \fR(boolean)
-Controls if the cursor blinks.
-Default value: \fBTrue\fR
-.TP
-.B cursor_color
-Default colour of cursor, as a colour specification (can be HTML-style hex digits, or a colour name such as "red").
-Default value: Current value of \fBforeground_color\fR
-.TP
-.B cursor_shape
-Default shape of cursor. Possibilities are "block", "ibeam", and "underline".
-Default value: \fBblock\fR
-.TP
-.B term
-This translates into the value that will be set for TERM in the environment of your terminals.
-Default value: \fBxterm-256color\fR
-.TP
-.B colorterm
-This translates into the value that will be set for COLORTERM in the environment of your terminals.
-Default value: \fBtruecolor\fR
-.TP
-.B use_system_font
-Whether or not to use the GNOME default monospace font for terminals.
-Default value: \fBTrue\fR
-.TP
-.B font
-An Pango font name. Examples are "Sans 12" or "Monospace Bold 14".
-Default value: \fBMono 10\fR
-.TP
-.B foreground_color
-Default colour of text in the terminal, as a colour specification (can be HTML-style hex digits, or a colour name such as "red"). \fBNote:\fR You may need to set \fBuse_theme_colors=False\fR to force this setting to take effect.
-Default value: \fB'#AAAAAA'\fR
-.TP
-.B scrollbar_position
-Where to put the terminal scrollbar. Possibilities are "left", "right", and "disabled".
-Default value: \fBright\fR
-.TP
-.B show_titlebar
-If true, a titlebar will be drawn for each terminal which shows the current title of that terminal.
-Default value: \fBTrue\fR
-.TP
-.B scroll_background \fR(boolean)
-If true, scroll the background image with the foreground text; if false, keep the image in a fixed position and scroll the text above it.
-Default value: \fBTrue\fR
-.TP
-.B scroll_on_keystroke \fR(boolean)
-If true, pressing a key jumps the scrollbar to the bottom.
-Default value: \fBTrue\fR
-.TP
-.B scroll_on_output \fR(boolean)
-If true, whenever there's new output the terminal will scroll to the bottom.
-Default value: \fBFalse\fR
-.TP
-.B scrollback_lines
-Number of scrollback lines to keep around. You can scroll back in the terminal by this number of lines; lines that don't fit in the scrollback are discarded. Warning: with large values, rewrapping on resize might be slow.
-Default value: \fB500\fR
-.TP
-.B scrollback_infinite
-If this is set to True, scrollback_lines will be ignored and VTE will keep the entire scrollback history.
-Default value: \fBFalse\fR
-.TP
-.B focus_on_close
-Sets which terminal should get the focus when another terminal is closed. Values can be "prev", "next" or "auto".
-Using "auto", if the closed terminal is within a split window, the focus will be on the sibling terminal rather than another tab.
-Default value: \fBauto\fR
-.TP
-.B exit_action
-Possible values are "close" to close the terminal, and "restart" to restart the command.
-Default value: \fBclose\fR
-.TP
-.B palette
-Terminals have a 16-colour palette that applications inside the terminal can use. This is that palette, in the form of a colon-separated list of colour names. Colour names should be in hex format e.g. "#FF00FF".
-.TP
-.B word_chars
-When selecting text by word, sequences of these characters are also considered members of single words. The hyphen and alphanumerics do not need to be specified. Ranges can be given as "A-Z".
-Default value: \fB',./?%&#:_'\fR
-.TP
-.B mouse_autohide \fR(boolean)
-Controls whether the mouse cursor should be hidden while typing.
-Default value: \fBTrue\fR
-.TP
-.B use_custom_command \fR(boolean)
-If True, the value of \fBcustom_command\fR will be used instead of the default shell.
-Default value: \fBFalse\fR
-.TP
-.B custom_command
-Command to execute instead of the default shell, if \fBuse_custom_command\fR is set to True.
-Default value: Nothing
-.TP
-.B http_proxy
-URL of an HTTP proxy to use, e.g. http://proxy.lan:3128/
-Default value: Nothing
-.TP
-.B encoding
-Character set to use for the terminal.
-Default value: \fBUTF-8\fR
-.TP
-.B copy_on_selection \fR(boolean)
-If set to True, text selections will be automatically copied to the clipboard, in addition to being made the Primary selection.
-Default value: \fBFalse\fR
-.TP
-
-.SH layouts
-
-This describes the layouts section of the config file. Like with the profiles, each layout should be defined as a sub-section with a name formatted like: \fB[[name]]\fR.
-
-Each object in a layout is a named sub-sub-section with various properties:
+[profiles]
+  [[default]]
+    font = Fixed 10
+    background_color = "#000000" # A comment
+    foreground_color = "#FFFFFF" # Note that hex colour values must be quoted
+    scrollback_lines = \*(Aq500\*(Aq #More comment. Single quotes are valid too
+    cursor_blink = True
+    custom_command = "echo \(rs"foo#bar\(rs"" #Final comment \- this will work as expected.
 
 [layouts]
   [[default]]
-    [[window0]]
+    [[[window0]]]
       type = Window
-    [[child1]]
+      parent = ""
+    [[[child1]]]
       type = Terminal
       parent = window0
 
-Window objects may not have a parent attribute. \fBEvery\fR other object must specify a parent. This is how the structure of the window is determined.
-
-.SH plugins
-
-Terminator plugins can add their own configuration to the config file, and will appear as a sub-section. Please refer to the documentation of individual plugins for more information.
-
+[plugins]
+.fam
+.fi
+.if n .RE
+.SH "GLOBAL_CONFIG"
+.sp
+These are the options Terminator currently supports in the
+\fBglobal_config\fP section.
+.SS "Window Behavior & Appearance"
+.sp
+\fBwindow_state\fP = \fIstring\fP
+.RS 4
+Control how the Terminator window opens.
+\*(Aqnormal\*(Aq to open normally.
+\*(Aqmaximise\*(Aq to open in a maximised state.
+\*(Aqfullscreen\*(Aq to open in a fullscreen state.
+\*(Aqhidden\*(Aq to stay hidden.
+.br
+Default value: \fBnormal\fP
+.RE
+.sp
+\fBalways_on_top\fP = \fIboolean\fP
+.RS 4
+If set to True, the window will always stay on top of other windows.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBsticky\fP = \fIboolean\fP
+.RS 4
+If set to True, the window will be visible on all workspaces.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBhide_on_lose_focus\fP = \fIboolean\fP
+.RS 4
+If set to True, the window will be hidden when focus is lost.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBhide_from_taskbar\fP = \fIboolean\fP
+.RS 4
+If set to True, the window will be hidden from the taskbar.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBgeometry_hinting\fP = \fIboolean\fP
+.RS 4
+If set to True, the window will resize in step with font sizes.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBsuppress_multiple_term_dialog\fP = \fIboolean\fP
+.RS 4
+If set to True, Terminator will ask for confirmation when closing
+multiple terminals.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBborderless\fP = \fIboolean\fP
+.RS 4
+If set to True, the window will be started without window borders.
+.br
+Default value: \fBFalse\fP
+.RE
+.SS "Tab Behavior & Appearance"
+.sp
+\fBtab_position\fP = \fIstring\fP
+.RS 4
+Specify where tabs are placed.
+Can be any of: \*(Aqtop\*(Aq, \*(Aqleft\*(Aq, \*(Aqright\*(Aq, \*(Aqbottom\*(Aq, \*(Aqhidden\*(Aq.
+If set to \*(Aqhidden\*(Aq, the tab bar will not be shown. Hiding the tab is not
+recommended, as it can be very confusing.
+.br
+Default value: \fBtop\fP
+.RE
+.sp
+\fBclose_button_on_tab\fP = \fIboolean\fP
+.RS 4
+If set to True, tabs will have a close button on them.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBscroll_tabbar\fP = \fIboolean\fP
+.RS 4
+If set to True, the tab bar will not fill the width of the window.
+The titlebars of the tabs will only take as much space as is necessary
+for the text they contain. Except, that is, if the tabs no longer fit
+the width of the window \- in that case scroll buttons will appear to
+move through the tabs.
+.br
+Default value: \fBFalse\fP
+.RE
+.SS "Terminal Behavior & Appearance"
+.sp
+\fBfocus\fP = \fIstring\fP
+.RS 4
+Specify how focus is given to terminals.
+\*(Aqclick\*(Aq means the focus only moves to a terminal after you click in it.
+\*(Aqsloppy\*(Aq means the focus will follow the mouse pointer.
+\*(Aqsystem\*(Aq means the focus will match that used by a GNOME window manager.
+.br
+Default value: \fBclick\fP
+.RE
+.sp
+\fBalways_split_with_profile\fP = \fIboolean\fP
+.RS 4
+Specify whether splits/tabs will continue to use the profile of their
+peer terminal. If set to False, they will always use the default profile.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBlink_single_click\fP = \fIboolean\fP
+.RS 4
+If set to True, clicking a link will open it even if \fBCtrl\fP is not
+pressed.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBputty_paste_style\fP = \fIboolean\fP
+.RS 4
+If set to True, right\-click will paste text, while middle\-click will
+popup the context menu. The source for the pasted text depends on the
+value of \fBputty_paste_style_source_clipboard\fP.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBputty_paste_style_source_clipboard\fP = \fIboolean\fP
+.RS 4
+If set to True, the Clipboard will be used as source for pasting in
+PuTTY style. Otherwise, the Primary Selection will be used.
+.br
+This option is ignored unless \fBputty_paste_style\fP is set to True.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBdisable_mouse_paste\fP = \fIboolean\fP
+.RS 4
+If set to True, mouse pasting will be disabled.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBsmart_copy\fP = \fIboolean\fP
+.RS 4
+If set to True, and there is no selection, the shortcut is allowed to
+pass through. This is useful for overloading Ctrl\-C to copy a selection,
+or send the SIGINT to the current process if there is no selection.
+If False, the shortcut does not pass through at all, and the SIGINT does
+not get sent.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBclear_select_on_copy\fP = \fIboolean\fP
+.RS 4
+If set to True, text selection will be cleared after copying using the
+\fBcopy\fP keybinding.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBhandle_size\fP = \fIinteger\fP
+.RS 4
+Specify the width of the separator between terminals.
+Anything outside the range 0\-20 (inclusive) will be ignored and the
+default theme value will be used instead.
+.br
+Default value: \fB1\fP
+.RE
+.sp
+\fBinactive_color_offset\fP = \fIfloat\fP
+.RS 4
+Specify how much to reduce the color values of fonts in terminals that
+do not have focus.
+.br
+Default value: \fB0.8\fP
+.RE
+.sp
+\fBinactive_bg_color_offset\fP = \fIfloat\fP
+.RS 4
+Specify how much to reduce the color values of the background in
+terminals that do not have focus.
+.br
+Default value: \fB1.0\fP
+.RE
+.sp
+\fBcell_width\fP = \fIfloat\fP
+.RS 4
+Specify the horizontal scale of character cells in the terminal.
+.br
+Default value: \fB1.0\fP
+.RE
+.sp
+\fBcell_height\fP = \fIfloat\fP
+.RS 4
+Specify the vertical scale of character cells in the terminal.
+.br
+Default value: \fB1.0\fP
+.RE
+.sp
+\fBtitle_at_bottom\fP = \fIboolean\fP
+.RS 4
+If set to True, the terminal\(cqs titlebar will be drawn at the bottom
+instead of the top.
+.br
+Default value: \fBFalse\fP
+.RE
+.SS "Miscellaneous"
+.sp
+\fBdbus\fP = \fIboolean\fP
+.RS 4
+Specify whether Terminator will load its DBus server.
+When this server is loaded, running Terminator multiple times will cause
+the first Terminator process to open additional windows.
+If this configuration item is set to False, or the python dbus module is
+unavailable, running Terminator multiple times will run a separate
+Terminator process for each invocation.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBextra_styling\fP = \fIboolean\fP
+.RS 4
+If set to True, Terminator may load an additional CSS styling file,
+depending on the theme.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBbroadcast_default\fP = \fIstring\fP
+.RS 4
+Specify the default broadcast behavior.
+Can be any of: \*(Aqall\*(Aq, \*(Aqgroup\*(Aq, \*(Aqoff\*(Aq.
+.br
+Default value: \fBgroup\fP
+.RE
+.sp
+\fBuse_custom_url_handler\fP = \fIboolean\fP
+.RS 4
+If set to True, URL handling will be given over entirely to the program
+specified by \*(Aqcustom_url_handler\*(Aq.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBcustom_url_handler\fP = \fIstring\fP
+.RS 4
+Specify the path to a program which accepts a URI as an argument and
+does something relevant with it.
+This option is ignored unless \fBuse_custom_url_handler\fP is set to True.
+.RE
+.sp
+\fBcase_sensitive\fP = \fIboolean\fP
+.RS 4
+If set to True, uppercase and lowercase characters will be considered
+different when searching text in the terminal.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBinvert_search\fP = \fIboolean\fP
+.RS 4
+If set to True, the search direction will be inverted (bottom to top)
+when searching text in the terminal.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBenabled_plugins\fP = \fIlist of strings\fP
+.RS 4
+Specify which plugins will be loaded by default. All other plugin
+classes will be ignored.
+.br
+Default value: \fB[\*(AqLaunchpadBugURLHandler\*(Aq, \*(AqLaunchpadCodeURLHandler\*(Aq, \*(AqAPTURLHandler\*(Aq]\fP
+.RE
+.SH "KEYBINDINGS"
+.sp
+These are the options Terminator currently supports in the \fBkeybindings\fP
+section.
+.SS "Creation & Destruction"
+.sp
+\fBsplit_horiz\fP
+.RS 4
+Split the current terminal horizontally.
+.br
+Default value: \fB<Ctrl><Shift>O\fP
+.RE
+.sp
+\fBsplit_vert\fP
+.RS 4
+Split the current terminal vertically.
+.br
+Default value: \fB<Ctrl><Shift>E\fP
+.RE
+.sp
+\fBsplit_auto\fP
+.RS 4
+Split the current terminal automatically, along the longer side.
+.br
+Default value: \fB<Ctrl><Shift>A\fP
+.RE
+.sp
+\fBnew_tab\fP
+.RS 4
+Open a new tab.
+.br
+Default value: \fB<Ctrl><Shift>T\fP
+.RE
+.sp
+\fBnew_window\fP
+.RS 4
+Open a new window as part of the existing process.
+.br
+Default value: \fB<Ctrl><Shift>I\fP
+.RE
+.sp
+\fBnew_terminator\fP
+.RS 4
+Spawn a new Terminator process.
+.br
+Default value: \fB<Super>I\fP
+.RE
+.sp
+\fBlayout_launcher\fP
+.RS 4
+Open the layout launcher.
+.br
+Default value: \fB<Alt>L\fP
+.RE
+.sp
+\fBclose_term\fP
+.RS 4
+Close the current terminal.
+.br
+Default value: \fB<Ctrl><Shift>W\fP
+.RE
+.sp
+\fBclose_window\fP
+.RS 4
+Close the current window.
+.br
+Default value: \fB<Ctrl><Shift>Q\fP
+.RE
+.SS "Navigation"
+.sp
+\fBcycle_next\fP
+.RS 4
+Focus the next terminal. This is an alias for \fBgo_next\fP.
+.br
+Default value: \fB<Ctrl>Tab\fP
+.RE
+.sp
+\fBcycle_prev\fP
+.RS 4
+Focus the previous terminal. This is an alias for \fBgo_prev\fP.
+.br
+Default value: \fB<Ctrl><Shift>Tab\fP
+.RE
+.sp
+\fBgo_next\fP
+.RS 4
+Focus the next terminal.
+.br
+Default value: \fB<Ctrl><Shift>N\fP
+.RE
+.sp
+\fBgo_prev\fP
+.RS 4
+Focus the previous terminal.
+.br
+Default value: \fB<Ctrl><Shift>P\fP
+.RE
+.sp
+\fBgo_up\fP
+.RS 4
+Focus the terminal above the current one.
+.br
+Default value: \fB<Alt>Up\fP
+.RE
+.sp
+\fBgo_down\fP
+.RS 4
+Focus the terminal below the current one.
+.br
+Default value: \fB<Alt>Down\fP
+.RE
+.sp
+\fBgo_left\fP
+.RS 4
+Focus the terminal to the left of the current one.
+.br
+Default value: \fB<Alt>Left\fP
+.RE
+.sp
+\fBgo_right\fP
+.RS 4
+Focus the terminal to the right of the current one.
+.br
+Default value: \fB<Alt>Right\fP
+.RE
+.sp
+\fBpage_up\fP
+.RS 4
+Scroll the terminal up one page.
+.RE
+.sp
+\fBpage_down\fP
+.RS 4
+Scroll the terminal down one page.
+.RE
+.sp
+\fBpage_up_half\fP
+.RS 4
+Scroll the terminal up half a page.
+.RE
+.sp
+\fBpage_down_half\fP
+.RS 4
+Scroll the terminal down half a page.
+.RE
+.sp
+\fBline_up\fP
+.RS 4
+Scroll the terminal up one line.
+.RE
+.sp
+\fBline_down\fP
+.RS 4
+Scroll the terminal down one line.
+.RE
+.sp
+\fBnext_tab\fP
+.RS 4
+Move to the next tab.
+.br
+Default value: \fB<Ctrl>Page_Down\fP
+.RE
+.sp
+\fBprev_tab\fP
+.RS 4
+Move to the previous tab.
+.br
+Default value: \fB<Ctrl>Page_Up\fP
+.RE
+.sp
+\fBswitch_to_tab_1\fP, \fBswitch_to_tab_2\fP, ... \fBswitch_to_tab_10\fP
+.RS 4
+Move to the \fBN\fPth tab.
+Note that \fB<Alt><Shift>1\fP may be provided as \fB<Alt>!\fP or similar,
+depending on the keyboard layout.
+.RE
+.SS "Organisation"
+.sp
+\fBresize_up\fP
+.RS 4
+Move the parent dragbar up.
+.br
+Default value: \fB<Ctrl><Shift>Up\fP
+.RE
+.sp
+\fBresize_down\fP
+.RS 4
+Move the parent dragbar down.
+.br
+Default value: \fB<Ctrl><Shift>Down\fP
+.RE
+.sp
+\fBresize_left\fP
+.RS 4
+Move the parent dragbar left.
+.br
+Default value: \fB<Ctrl><Shift>Left\fP
+.RE
+.sp
+\fBresize_right\fP
+.RS 4
+Move the parent dragbar right.
+.br
+Default value: \fB<Ctrl><Shift>Right\fP
+.RE
+.sp
+\fBrotate_cw\fP
+.RS 4
+Rotate terminals clockwise.
+.br
+Default value: \fB<Super>R\fP
+.RE
+.sp
+\fBrotate_ccw\fP
+.RS 4
+Rotate terminals counter+clockwise.
+.br
+Default value: \fB<Super><Shift>R\fP
+.RE
+.sp
+\fBmove_tab_right\fP
+.RS 4
+Move the current tab to the right by swapping position with the next
+tab.
+.br
+Default value: \fB<Ctrl><Shift>Page_Down\fP
+.RE
+.sp
+\fBmove_tab_left\fP
+.RS 4
+Move the current tab to the left by swapping position with the previous
+tab.
+.br
+Default value: \fB<Ctrl><Shift>Page_Up\fP
+.RE
+.SS "Focus"
+.sp
+\fBfull_screen\fP
+.RS 4
+Toggle window to fullscreen.
+.br
+Default value: \fBF11\fP
+.RE
+.sp
+\fBtoggle_zoom\fP
+.RS 4
+Toggle maximisation of the current terminal.
+.br
+Default value: \fB<Ctrl><Shift>X\fP
+.RE
+.sp
+\fBscaled_zoom\fP
+.RS 4
+Toggle maximisation of the current terminal and scale the font when
+maximised.
+.br
+Default value: \fB<Ctrl><Shift>Z\fP
+.RE
+.sp
+\fBhide_window\fP
+.RS 4
+Hide/Show all Terminator windows.
+.br
+Default value: \fB<Ctrl><Shift><Alt>A\fP
+.RE
+.SS "Grouping & Broadcasting"
+.sp
+\fBcreate_group\fP
+.RS 4
+Create a new group.
+.RE
+.sp
+\fBgroup_all\fP
+.RS 4
+Group all terminals together.
+.br
+Default value: \fB<Super>G\fP
+.RE
+.sp
+\fBungroup_all\fP
+.RS 4
+Ungroup all terminals.
+.RE
+.sp
+\fBgroup_all_toggle\fP
+.RS 4
+Toggle grouping of all terminals.
+.RE
+.sp
+\fBgroup_win\fP
+.RS 4
+Group all terminals in the current window together.
+.RE
+.sp
+\fBungroup_win\fP
+.RS 4
+Ungroup all terminals in the current window.
+.br
+Default value: \fB<Super><Shift>W\fP
+.RE
+.sp
+\fBgroup_win_toggle\fP
+.RS 4
+Toggle grouping of all terminals in the current window.
+.RE
+.sp
+\fBgroup_tab\fP
+.RS 4
+Group all terminals in the current tab together.
+.br
+Default value: \fB<Super>T\fP
+.RE
+.sp
+\fBungroup_tab\fP
+.RS 4
+Ungroup all terminals in the current tab.
+.br
+Default value: \fB<Super><Shift>T\fP
+.RE
+.sp
+\fBgroup_tab_toggle\fP
+.RS 4
+Toggle grouping of all terminals in the current tab.
+.RE
+.sp
+\fBbroadcast_off\fP
+.RS 4
+Turn broadcasting off.
+.RE
+.sp
+\fBbroadcast_group\fP
+.RS 4
+Broadcast to all terminals in the same group as the current terminal.
+.RE
+.sp
+\fBbroadcast_all\fP
+.RS 4
+Broadcast to all terminals.
+.RE
+.SS "Miscellaneous"
+.sp
+\fBhelp\fP
+.RS 4
+Open the full HTML manual in the browser.
+.br
+Default value: \fBF1\fP
+.RE
+.sp
+\fBpreferences\fP
+.RS 4
+Open the Preferences window.
+.RE
+.sp
+\fBpreferences_keybindings\fP
+.RS 4
+Open the Preferences window and show the Keybindings tab.
+.br
+Default value: \fB<Ctrl><Shift>K\fP
+.RE
+.sp
+\fBcopy\fP
+.RS 4
+Copy the selected text to the Clipboard.
+.br
+Default value: \fB<Ctrl><Shift>C\fP
+.RE
+.sp
+\fBpaste\fP
+.RS 4
+Paste the current contents of the Clipboard.
+.br
+Default value: \fB<Ctrl><Shift>V\fP
+.RE
+.sp
+\fBpaste_selection\fP
+.RS 4
+Paste the current contents of the Primary Selection.
+.RE
+.sp
+\fBtoggle_scrollbar\fP
+.RS 4
+Toggle the scrollbar.
+.br
+Default value: \fB<Ctrl><Shift>S\fP
+.RE
+.sp
+\fBsearch\fP
+.RS 4
+Search for text in the terminal scrollback history.
+.br
+Default value: \fB<Ctrl><Shift>F\fP
+.RE
+.sp
+\fBreset\fP
+.RS 4
+Reset the terminal state.
+.br
+Default value: \fB<Ctrl><Shift>R\fP
+.RE
+.sp
+\fBreset_clear\fP
+.RS 4
+Reset the terminal state and clear the terminal window.
+.br
+Default value: \fB<Ctrl><Shift>G\fP
+.RE
+.sp
+\fBzoom_in\fP
+.RS 4
+Increase the font size by one unit.
+.br
+Default value: \fB<Ctrl>plus\fP
+.RE
+.sp
+\fBzoom_out\fP
+.RS 4
+Decrease the font size by one unit.
+.br
+Default value: \fB<Ctrl>minus\fP
+.RE
+.sp
+\fBzoom_normal\fP
+.RS 4
+Restore the original font size.
+.br
+Default value: \fB<Ctrl>0\fP
+.RE
+.sp
+\fBzoom_in_all\fP
+.RS 4
+Increase the font size by one unit for all terminals.
+.RE
+.sp
+\fBzoom_out_all\fP
+.RS 4
+Decrease the font size by one unit for all terminals.
+.RE
+.sp
+\fBzoom_normal_all\fP
+.RS 4
+Restore the original font size for all terminals.
+.RE
+.sp
+\fBedit_window_title\fP
+.RS 4
+Rename the current window.
+.br
+Default value: \fB<Ctrl><Alt>W\fP
+.RE
+.sp
+\fBedit_tab_title\fP
+.RS 4
+Rename the current tab.
+.br
+Default value: \fB<Ctrl><Alt>A\fP
+.RE
+.sp
+\fBedit_terminal_title\fP
+.RS 4
+Rename the current terminal.
+.br
+Default value: \fB<Ctrl><Alt>X\fP
+.RE
+.sp
+\fBinsert_number\fP
+.RS 4
+Insert the current terminal\(cqs number, i.e. 1 to 12.
+.br
+Default value: \fB<Super>1\fP
+.RE
+.sp
+\fBinsert_padded\fP
+.RS 4
+Insert the current terminal\(cqs number, but zero padded, i.e. 01 to 12.
+.br
+Default value: \fB<Super>0\fP
+.RE
+.sp
+\fBnext_profile\fP
+.RS 4
+Switch to the next profile.
+.RE
+.sp
+\fBprevious_profile\fP
+.RS 4
+Switch to the previous profile.
+.RE
+.SH "PROFILES"
+.sp
+These are the options Terminator currently supports in the \fBprofiles\fP
+section. Each profile should be its own subsection with a header in the
+format \fB[[name]]\fP.
+.SS "General"
+.sp
+\fBallow_bold\fP = \fIboolean\fP
+.RS 4
+If set to True, text in the terminal can displayed in bold.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBcopy_on_selection\fP = \fIboolean\fP
+.RS 4
+If set to True, text selections will be automatically copied to the
+Clipboard, in addition to being copied to the Primary Selection.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBdisable_mousewheel_zoom\fP = \fIboolean\fP
+.RS 4
+If set to True, Ctrl+mouse_wheel will not zoom or unzoom the terminal.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBword_chars\fP = \fIstring\fP
+.RS 4
+Specify the characters that will be considered part of a single word
+when selecting text by word.
+Hyphen and alphanumerics do not need to be specified.
+Ranges can be given, e.g. "A\-Z".
+.br
+For example, if \fBword_chars\fP = "," then "foo,bar" is considered a single
+word.
+.br
+Default value: \fB\-,./?%&#:_\fP
+.RE
+.sp
+\fBmouse_autohide\fP = \fIboolean\fP
+.RS 4
+If set to True, the mouse pointer will be hidden when typing.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBterm\fP = \fIstring\fP
+.RS 4
+Specify the value Terminator will assign to the \*(AqTERM\*(Aq environment
+variable.
+.br
+Default value: \fBxterm\-256color\fP
+.RE
+.sp
+\fBcolorterm\fP = \fIstring\fP
+.RS 4
+Specify the value Terminator will assign to the \*(AqCOLORTERM\*(Aq environment
+variable.
+.br
+Default value: \fBtruecolor\fP
+.RE
+.sp
+\fBsplit_to_group\fP = \fIboolean\fP
+.RS 4
+If set to True, the terminal created by splitting will be inserted in
+the current terminal\(cqs group.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBautoclean_groups\fP = \fIboolean\fP
+.RS 4
+If set to True, empty groups will be removed.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBuse_system_font\fP = \fIboolean\fP
+.RS 4
+If set to True, the system default font will be used for text in the
+terminal. Otherwise, the value of \fBfont\fP will be used.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBfont\fP = \fIstring\fP
+.RS 4
+Specify which font to use for text in the terminal.
+This option is ignored unless \fBuse_system_font\fP is set to False.
+.br
+Default value: \fBMono 10\fP
+.RE
+.sp
+\fBcursor_blink\fP = \fIboolean\fP
+.RS 4
+If set to True, the cursor will blink when not typing.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBcursor_shape\fP = \fIstring\fP
+.RS 4
+Specify the shape of the cursor.
+Can be any of: \*(Aqblock\*(Aq, \*(Aqunderline\*(Aq, \*(Aqibeam\*(Aq.
+.br
+Default value: \fBblock\fP
+.RE
+.sp
+\fBcursor_color_default\fP = \fIboolean\fP
+.RS 4
+If set to True, the background and foreground colors of the terminal
+will be used as foreground and background colors for the cursor,
+respectively.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBcursor_fg_color\fP = \fIcolor string\fP
+.RS 4
+Specify the foreground color to use for the cursor.
+This option is ignored unless \fBcursor_color_default\fP is set to False.
+.RE
+.sp
+\fBcursor_bg_color\fP = \fIcolor string\fP
+.RS 4
+Specify the background color to use for the cursor.
+This option is ignored unless \fBcursor_color_default\fP is set to False.
+.RE
+.sp
+\fBaudible_bell\fP = \fIboolean\fP
+.RS 4
+If set to True, a sound will be played when an application writes the
+escape sequence for the terminal bell.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBvisible_bell\fP = \fIboolean\fP
+.RS 4
+If set to True, the terminal will flash when an application writes the
+escape sequence for the terminal bell.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBurgent_bell\fP = \fIboolean\fP
+.RS 4
+If set to True, the window\(cqs urgency hint will be set when an
+application writes the escape sequence for the terminal bell.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBicon_bell\fP = \fIboolean\fP
+.RS 4
+If set to True, a small icon will be shown on the terminal titlebar when
+an application writes the escape sequence for the terminal bell.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBforce_no_bell\fP = \fIboolean\fP
+.RS 4
+If set to True, the terminal bell will be completely disabled.
+.br
+Default value: \fBFalse\fP
+.RE
+.SS "Command"
+.sp
+\fBlogin_shell\fP = \fIboolean\fP
+.RS 4
+If set to True, the terminal will run the default shell (or the command
+specified by \fBcustom_command\fP) as a login shell.
+This means the first argument passed to the shell/command will be \*(Aq\-l\*(Aq.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBuse_custom_command\fP = \fIboolean\fP
+.RS 4
+If set to True, the value of \fBcustom_command\fP will be used instead of
+the default shell.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBcustom_command\fP = \fIstring\fP
+.RS 4
+Specify the command to execute instead of the default shell.
+This option is ignored unless \fBuse_custom_command\fP is set to True.
+.RE
+.sp
+\fBexit_action\fP = \fIstring\fP
+.RS 4
+Specify the action to perform when the terminal is closed.
+\*(Aqclose\*(Aq to remove the terminal.
+\*(Aqrestart\*(Aq to restart the shell (or the command specified by
+\fBcustom_command\fP).
+\*(Aqhold\*(Aq to keep the terminal open, even if the process in it has
+terminated.
+.br
+Default value: \fBclose\fP
+.RE
+.SS "Colors"
+.sp
+\fBuse_theme_colors\fP = \fIboolean\fP
+.RS 4
+If set to True, the theme\(cqs foreground and background colors will be
+used for the terminal. Otherwise, the values of \fBforeground_color\fP and
+\fBbackground_color\fP will be used.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBforeground_color\fP = \fIcolor string\fP
+.RS 4
+Specify the foreground color to use for the terminal.
+This option is ignored unless \fBuse_theme_colors\fP is set to False.
+.br
+Default value: \fB#AAAAAA\fP
+.RE
+.sp
+\fBbackground_color\fP = \fIcolor string\fP
+.RS 4
+Specify the background color to use for the terminal.
+This option is ignored unless \fBuse_theme_colors\fP is set to False.
+.br
+Default value: \fB#000000\fP
+.RE
+.sp
+\fBpalette\fP = \fIstring list of colors\fP
+.RS 4
+Specify the 16\-color palette to use for the terminal.
+The value must be a string containing a colon\-separated list of colors
+in hex format.
+.br
+For example, "#000000:#cd0000:#00cd00: ... ".
+.RE
+.sp
+\fBbold_is_bright\fP = \fIboolean\fP
+.RS 4
+If set to True, bold text will have brighter colors.
+.br
+Default value: \fBFalse\fP
+.RE
+.SS "Background"
+.sp
+\fBbackground_darkness\fP = \fIfloat\fP
+.RS 4
+Specify the transparency of the background color.
+The value must be between 0.0 and 1.0.
+This option is ignored unless \fBbackground_type\fP is set to \*(Aqtransparent\*(Aq
+or \*(Aqimage\*(Aq.
+.br
+Default value: \fB0.5\fP
+.RE
+.sp
+\fBbackground_type\fP = \fIstring\fP
+.RS 4
+Specify what type of background the terminal will have.
+\*(Aqsolid\*(Aq for a solid (opaque) background.
+\*(Aqtransparent\*(Aq for a transparent background.
+\*(Aqimage\*(Aq for a background image.
+.br
+If this is set to \*(Aqtransparent\*(Aq, the transparency of the background will
+be the value of \fBbackground_darkness\fP.
+If this is set to \*(Aqimage\*(Aq, the image specified by \fBbackground_image\fP
+will be the background; the background color will then be drawn on top
+of it, with a transparency specified by \fBbackground_darkness\fP.
+.br
+Default value: \fBsolid\fP
+.RE
+.sp
+\fBbackground_image\fP = \fIpath string\fP
+.RS 4
+Specify the path to an image that will be used as background.
+This option is ignored unless \fBbackground_type\fP is set to \*(Aqimage\*(Aq.
+.RE
+.sp
+\fBbackground_image_mode\fP = \fIstring\fP
+.RS 4
+Specify how the background image will be drawn.
+\*(Aqstretch_and_fill\*(Aq to fill the terminal entirely, without necessarily
+maintaining aspect ratio.
+\*(Aqscale_and_fit\*(Aq to fit the image inside the terminal, eventually leaving
+blank bars, while maintaining aspect ratio.
+\*(Aqscale_and_crop\*(Aq to fill the terminal entirely, eventually cropping the
+image, while maintaining aspect ratio.
+\*(Aqtiling\*(Aq to repeat the image as to fill the terminal.
+This option is ignored unless \fBbackground_type\fP is set to \*(Aqimage\*(Aq.
+.br
+Default value: \fBstretch_and_fill\fP
+.RE
+.sp
+\fBbackground_image_align_horiz\fP = \fIstring\fP
+.RS 4
+Specify the horizontal alignment of the background image.
+Can be any of: \*(Aqleft\*(Aq, \*(Aqcenter\*(Aq, \*(Aqright\*(Aq.
+This option is ignored unless \fBbackground_type\fP is set to \*(Aqimage\*(Aq.
+.br
+Default value: \fBcenter\fP
+.RE
+.sp
+\fBbackground_image_align_vert\fP = \fIstring\fP
+.RS 4
+Specify the vertical alignment of the background image.
+Can be any of: \*(Aqtop\*(Aq, \*(Aqmiddle\*(Aq, \*(Aqbottom\*(Aq.
+This option is ignored unless \fBbackground_type\fP is set to \*(Aqimage\*(Aq.
+.br
+Default value: \fBmiddle\fP
+.RE
+.SS "Scrolling"
+.sp
+\fBscrollbar_position\fP = \fIstring\fP
+.RS 4
+Specify where the terminal scrollbar is put.
+Can be any of: \*(Aqleft\*(Aq, \*(Aqright\*(Aq, \*(Aqhidden\*(Aq.
+.br
+Default value: \fBright\fP
+.RE
+.sp
+\fBscroll_on_output\fP = \fIboolean\fP
+.RS 4
+If set to True, the terminall will scroll to the bottom when an
+application writes text to it.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBscroll_on_keystroke\fP = \fIboolean\fP
+.RS 4
+If set to True, the terminal will scroll to the bottom when typing.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBscrollback_infinite\fP = \fIboolean\fP
+.RS 4
+If set to True, the terminal will keep the entire scrollback history.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBscrollback_lines\fP = \fIinteger\fP
+.RS 4
+Specify how many lines of scrollback history will be kept by the
+terminal. Lines that don\(cqt fit in the scrollback history will be
+discarted. Note that setting large values can slow down rewrapping and
+resizing.
+This option is ignored unless \fBscrollback_infinite\fP is set to False.
+.br
+Default value: \fB500\fP
+.RE
+.SS "Compatibility"
+.sp
+\fBbackspace_binding\fP = \fIstring\fP
+.RS 4
+Specify what code will be generated by the backspace key.
+The value can be:
+\*(Aqascii\-del\*(Aq for the ASCII DEL character;
+\*(Aqcontrol\-h\*(Aq for the ASCII BS character (Ctrl+H);
+\*(Aqescape\-sequence\*(Aq for the escape sequence typically bound to backspace
+or delete;
+\*(Aqautomatic\*(Aq for letting the terminal automatically decide the character
+sequence to use.
+.br
+Default value: \fBascii\-del\fP
+.RE
+.sp
+\fBdelete_binding\fP = \fIstring\fP
+.RS 4
+Specify what code will be generated by the delete key.
+The value can be:
+\*(Aqascii\-del\*(Aq for the ASCII DEL character;
+\*(Aqcontrol\-h\*(Aq for the ASCII BS character (Ctrl+H);
+\*(Aqescape\-sequence\*(Aq for the escape sequence typically bound to backspace
+or delete;
+\*(Aqautomatic\*(Aq for letting the terminal automatically decide the character
+sequence to use.
+.br
+Default value: \fBescape\-sequence\fP
+.RE
+.SS "Titlebar"
+.sp
+\fBshow_titlebar\fP = \fIboolean\fP
+.RS 4
+If set to True, the terminal will have a titlebar showing the current
+title of that terminal.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBtitle_hide_sizetext\fP = \fIboolean\fP
+.RS 4
+If set to True, the size of the terminal will not be written on its
+titlebar.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
+\fBtitle_use_system_font\fP = \fIboolean\fP
+.RS 4
+If set to True, the system default font will be used for text in the
+terminal\(cqs titlebar. Otherwise, the value of \fBtitle_font\fP will be used.
+.br
+Default value: \fBTrue\fP
+.RE
+.sp
+\fBtitle_font\fP = \fIstring\fP
+.RS 4
+Specify which font to use for text in the terminal\(cqs titlebar.
+This option is ignored unless \fBtitle_use_system_font\fP is set to False.
+.br
+Default value: \fBSans 9\fP
+.RE
+.sp
+\fBtitle_transmit_fg_color\fP = \fIcolor string\fP
+.RS 4
+Specify the foreground color to use for the terminal\(cqs titlebar in case
+the terminal is focused.
+.br
+Default value: \fB#ffffff\fP
+.RE
+.sp
+\fBtitle_transmit_bg_color\fP = \fIcolor string\fP
+.RS 4
+Specify the background color to use for the terminal\(cqs titlebar in case
+the terminal is focused.
+.br
+Default value: \fB#c80003\fP
+.RE
+.sp
+\fBtitle_inactive_fg_color\fP = \fIcolor string\fP
+.RS 4
+Specify the foreground color to use for the terminal\(cqs titlebar in case
+the terminal is unfocused.
+.br
+Default value: \fB#000000\fP
+.RE
+.sp
+\fBtitle_inactive_bg_color\fP = \fIcolor string\fP
+.RS 4
+Specify the background color to use for the terminal\(cqs titlebar in case
+the terminal is unfocused.
+.br
+Default value: \fB#c0bebf\fP
+.RE
+.sp
+\fBtitle_receive_fg_color\fP = \fIcolor string\fP
+.RS 4
+Specify the foreground color to use for the terminal\(cqs titlebar in case
+the terminal is in a group and is receiving input while unfocused.
+.br
+Default value: \fB#ffffff\fP
+.RE
+.sp
+\fBtitle_receive_bg_color\fP = \fIcolor string\fP
+.RS 4
+Specify the background color to use for the terminal\(cqs titlebar in case
+the terminal is in a group and is receiving input while unfocused.
+.br
+Default value: \fB#0076c9\fP
+.RE
+.SH "LAYOUTS"
+.sp
+The \fBlayouts\fP section contains all the saved layouts. Each layout should
+be its own subsection with a header in the format \fB[[name]]\fP.
+.sp
+Each object in a layout is a named sub\-sub\-section with various
+properties.
+.sp
+\fBtype\fP = \fIstring\fP
+.RS 4
+Can be any of: \*(AqWindow\*(Aq, \*(AqNotebook\*(Aq, \*(AqHPaned\*(Aq, \*(AqVPaned\*(Aq, \*(AqTerminal\*(Aq.
+.RE
+.sp
+\fBparent\fP = \fIstring\fP
+.RS 4
+Specify which object is the parent of the component being defined.
+All objects, except those of type Window, must specify a parent.
+.RE
+.sp
+This is an example of a \fBlayouts\fP section containing only the layout
+named "default".
+.sp
+.if n .RS 4
+.nf
+.fam C
+[layouts]
+  [[default]]
+    [[[window0]]]
+      type = Window
+      parent = ""
+    [[[child1]]]
+      type = Terminal
+      parent = window0
+.fam
+.fi
+.if n .RE
+.SH "PLUGINS"
+.sp
+Terminator plugins can add their own configuration to the config file,
+and it will appear as a subsection. Please refer to the documentation of
+individual plugins for more information.
 .SH "SEE ALSO"
-.TP
-\fBterminator\fP(1), http://www.voidspace.org.uk/python/configobj.html
+.sp
+\fBterminator\fP(1), \c
+.URL "https://configobj.readthedocs.io/" "" ""

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -1,0 +1,228 @@
+= Terminator_config(5)
+:doctype: manpage
+:manmanual: Manual for Terminator
+:mansource: Terminator
+:revdate: 2023-03-31
+:docdate: {revdate}
+
+== NAME
+// ~/.config/terminator/config - the config file for Terminator terminal emulator
+config - TODO
+
+== DESCRIPTION
+This file contains the configuration for *terminator*(1).
+Terminator manages its configuration file via the ConfigObj library to
+combine flexibility with clear, human editable files. +
+Terminator offers a full GUI preferences editor which automatically
+saves its config file so you don't need to write a config file by hand.
+
+== FILE LOCATION
+Normally the config file will be *~/.config/terminator/config*, but it
+may be overridden with *$XDG_CONFIG_HOME* (in which case it will be
+*$XDG_CONFIG_HOME/terminator/config*).
+
+== FILE FORMAT
+This is what a Terminator config file should look like:
+
+TODO
+
+== global_config
+These are the options Terminator currently supports in the
+*global_config* section:
+
+=== Window Behavior & Appearance
+
+// --- Window behavior ---
+
+*window_state* = _string_::
+Default value: *normal* +
+Control how the Terminator window opens.
+'normal' means it opens normally.
+'maximise' means it opens in a maximised state.
+'fullscreen' means it opens in a fullscreen state.
+'hidden' means it stays hidden.
+
+*always_on_top* = _boolean_::
+Default value: *False* +
+TODO
+
+*sticky* = _boolean_::
+Default value: *False* +
+TODO
+
+*hide_on_lose_focus* = _boolean_::
+Default value: *False* +
+TODO
+
+*hide_from_taskbar* = _boolean_::
+Default value: *False* +
+TODO
+
+*geometry_hinting* = _boolean_::
+Default value: *False* +
+If True the window will resize in step with font sizes, if False it will
+follow pixels.
+
+*suppress_multiple_term_dialog* = _boolean_::
+Default value: *False* +
+TODO
+
+// --- Window appearance ---
+
+*borderless* = _boolean_::
+Default value: *False* +
+Control whether the Terminator window will be started without window
+borders.
+
+=== Tab Behavior & Appearance
+
+*tab_position* = _string_::
+Default value: *top* +
+Specify where tabs are placed.
+Can be any of: 'top', 'left', 'right', 'bottom', 'hidden'.
+If this is set to 'hidden', the tab bar will not be shown. Hiding the
+tab is not recommended, as it can be very confusing.
+
+*close_button_on_tab* = _boolean_::
+Default value: : *True* +
+If set to True, tabs will have a close button on them.
+
+// what is this???
+*scroll_tabbar* = _boolean_::
+Default value: *False* +
+If set to True, the tab bar will not fill the width of the window.
+The titlebars of the tabs will only take as much space as is necessary
+for the text they contain. Except, that is, if the tabs no longer fit
+the width of the window - in that case scroll buttons will appear to
+move through the tabs.
+
+*homogeneous_tabbar* = _boolean_::
+Default value: *True* +
+TODO
+
+=== Terminal Behavior & Appearance
+
+// --- Terminal behavior ---
+
+*focus* = _string_::
+Default value: *click* +
+Control how focus is given to terminals.
+'click' means the focus only moves to a terminal after you click in it.
+'sloppy' means the focus will follow the mouse pointer.
+'system' means the focus will match that used by a GNOME window manager.
+
+*always_split_with_profile* = _boolean_::
+Default value: *False* +
+Control whether splits/tabs will continue to use the profile of their
+peer terminal. If set to False, they will always use the default profile.
+
+*link_single_click* = _boolean_::
+Default value: *False* +
+TODO
+
+// --- Copy & Paste behavior ---
+
+*putty_paste_style* = _boolean_::
+Default value: *False* +
+If set to True, right-click will paste the Primary selection,
+while middle-click will popup the context menu.
+
+*putty_paste_style_source_clipboard* = _boolean_::
+Default value: *False* +
+TODO
+
+*disable_mouse_paste* = _boolean_::
+Default value: *False* +
+TODO
+
+*smart_copy* = _boolean_::
+Default value: *True* +
+If set to True, and there is no selection, the shortcut is allowed to
+pass through. This is useful for overloading Ctrl-C to copy a selection,
+or send the SIGINT to the current process if there is no selection.
+If False, the shortcut does not pass through at all, and the SIGINT does
+not get sent.
+
+*clear_select_on_copy* = _boolean_::
+Default value: *False* +
+TODO
+
+// --- Terminal appearance ---
+
+*handle_size* = _integer_::
+Default value: *1* +
+Control the width of the separator between terminals.
+Anything outside the range 0-20 (inclusive) will be ignored and use your
+default theme value.
+
+*inactive_color_offset* = _float_::
+Default value: *0.8* +
+Specify how much to reduce the color values of fonts in terminals that
+do not have focus.
+
+*inactive_bg_color_offset* = _float_::
+Default value: *1.0* +
+Specify how much to reduce the color values of the background in
+terminals that do not have focus.
+
+*cell_width* = _float_::
+Default value: *1.0* +
+TODO
+
+*cell_height* = _float_::
+Default value: *1.0* +
+TODO
+
+*title_at_bottom* = _boolean_::
+Default value: *False* +
+TODO
+
+=== Miscellaneous
+
+*dbus* = _boolean_::
+Default value: *True* +
+Control whether or not Terminator will load its DBus server.
+When this server is loaded, running Terminator multiple times will cause
+the first Terminator process to open additional windows.
+If this configuration item is set to False, or the python dbus module is
+unavailable, running Terminator multiple times will run a separate
+Terminator process for each invocation.
+
+*extra_styling* = _boolean_::
+Default value: *True* +
+TODO
+
+*broadcast_default* = _string_::
+Default value: *group* +
+Specify default broadcast behavior.
+Can be any of: 'all', 'group', 'off'.
+
+// try_posix_regexp ???
+
+*use_custom_url_handler* = _boolean_::
+Default value: *False* +
+If set to True, URL handling will be given over entirely to the program
+specified by 'custom_url_handler'.
+
+*custom_url_handler* = _string_::
+Path to a program which accepts a URI as an argument and does something
+relevant with it. This option is ignored unless 'use_custom_url_handler'
+is set to True.
+
+*case_sensitive* = _boolean_::
+Default value: *True* +
+TODO
+
+*invert_search* = _boolean_::
+Default value: *False* +
+TODO
+
+*enabled_plugins* = _list of strings_::
+Default value: *['LaunchpadBugURLHandler', 'LaunchpadCodeURLHandler', 'APTURLHandler']* +
+A list of plugins which should be loaded by default. All other plugin
+classes will be ignored.
+
+== profiles
+These are the options Terminator currently supports in the *profiles*
+section. Each profile should be its own subsection with a header in the
+format *+[[name]]+*.

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -64,7 +64,7 @@ If set to True, the window will always stay on top of other windows. +
 Default value: *False*
 
 *sticky* = _boolean_::
-TODO +
+If set to True, the window will be visible on all workspaces. +
 Default value: *False*
 
 *hide_on_lose_focus* = _boolean_::
@@ -112,10 +112,6 @@ the width of the window - in that case scroll buttons will appear to
 move through the tabs. +
 Default value: *False*
 
-*homogeneous_tabbar* = _boolean_::
-TODO +
-Default value: *True*
-
 === Terminal Behavior & Appearance
 
 // --- Terminal behavior ---
@@ -140,12 +136,15 @@ Default value: *False*
 // --- Copy & Paste behavior ---
 
 *putty_paste_style* = _boolean_::
-If set to True, right-click will paste the Primary selection,
-while middle-click will popup the context menu. +
+If set to True, right-click will paste text, while middle-click will
+popup the context menu. The source for the pasted text depends on the
+value of *putty_paste_style_source_clipboard*. +
 Default value: *False*
 
 *putty_paste_style_source_clipboard* = _boolean_::
-TODO +
+If set to True, the Clipboard will be used as source for pasting in
+PuTTY style. Otherwise, the Primary Selection will be used. +
+This option is ignored unless *putty_paste_style* is set to True. +
 Default value: *False*
 
 *disable_mouse_paste* = _boolean_::
@@ -183,11 +182,11 @@ terminals that do not have focus. +
 Default value: *1.0*
 
 *cell_width* = _float_::
-TODO +
+Specify the horizontal scale of character cells in the terminal. +
 Default value: *1.0*
 
 *cell_height* = _float_::
-TODO +
+Specify the vertical scale of character cells in the terminal. +
 Default value: *1.0*
 
 *title_at_bottom* = _boolean_::
@@ -402,7 +401,7 @@ maximised. +
 Default value: *<Ctrl><Shift>Z*
 
 *hide_window*::
-TODO +
+Hide/Show all Terminator windows. +
 Default value: *<Ctrl><Shift><Alt>A*
 
 === Grouping & Broadcasting
@@ -575,19 +574,22 @@ If set to True, the mouse pointer will be hidden when typing. +
 Default value: *True*
 
 *term* = _string_::
-TODO +
+Specify the value Terminator will assign to the 'TERM' environment
+variable. +
 Default value: *xterm-256color*
 
 *colorterm* = _string_::
-TODO +
+Specify the value Terminator will assign to the 'COLORTERM' environment
+variable. +
 Default value: *truecolor*
 
 *split_to_group* = _boolean_::
-TODO +
+If set to True, the terminal created by splitting will be inserted in
+the current terminal's group. +
 Default value: *False*
 
 *autoclean_groups* = _boolean_::
-TODO +
+If set to True, empty groups will be removed. +
 Default value: *True*
 
 // --- Font ---
@@ -702,9 +704,13 @@ Default value: *False*
 === Background
 
 *background_darkness* = _float_::
-TODO +
+Specify the transparency of the background color.
+The value must be between 0.0 and 1.0.
+This option is ignored unless *background_type* is set to 'transparent'
+or 'image'. +
 Default value: *0.5*
 
+// TODO background_type needs improvements
 *background_type* = _string_::
 Specify what type of background the terminal will have.
 'solid' means the background will be a solid (opaque) color.
@@ -712,7 +718,7 @@ Specify what type of background the terminal will have.
 transparency being the value of *background_darkness*.
 'image' means the background will be an image, whose path is the value
 of *background_image*; the background color will be drawn on top of it,
-with its transparenty being the value of *background_darkness*. +
+with its transparency being the value of *background_darkness*. +
 Default value: *solid*
 
 *background_image* = _path string_::

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -24,7 +24,23 @@ may be overridden with *$XDG_CONFIG_HOME* (in which case it will be
 == FILE FORMAT
 This is what a Terminator config file should look like:
 
-TODO
+----
+# This is a comment
+[global_config]
+  focus = system
+
+[keybindings]
+  full_screen = <Ctrl><Shift>F11
+
+[profiles]
+  [[default]]
+    font = Fixed 10
+    background_color = "#000000" # A comment
+    foreground_color = "#FFFFFF" # Note that hex colour values must be quoted
+    scrollback_lines = '500' #More comment. Single quotes are valid too
+    cursor_blink = True
+    custom_command = "echo \"foo#bar\"" #Final comment - this will work as expected.
+----
 
 == global_config
 These are the options Terminator currently supports in the
@@ -44,7 +60,7 @@ Control how the Terminator window opens.
 
 *always_on_top* = _boolean_::
 Default value: *False* +
-TODO
+If set to True, the window will always stay on top of other windows.
 
 *sticky* = _boolean_::
 Default value: *False* +
@@ -60,12 +76,12 @@ TODO
 
 *geometry_hinting* = _boolean_::
 Default value: *False* +
-If True the window will resize in step with font sizes, if False it will
-follow pixels.
+If set to True, the window will resize in step with font sizes.
 
 *suppress_multiple_term_dialog* = _boolean_::
 Default value: *False* +
-TODO
+Specify whether or not Terminator will ask for confirmation when closing
+multiple terminals.
 
 // --- Window appearance ---
 
@@ -84,7 +100,7 @@ If this is set to 'hidden', the tab bar will not be shown. Hiding the
 tab is not recommended, as it can be very confusing.
 
 *close_button_on_tab* = _boolean_::
-Default value: : *True* +
+Default value: *True* +
 If set to True, tabs will have a close button on them.
 
 // what is this???
@@ -118,7 +134,8 @@ peer terminal. If set to False, they will always use the default profile.
 
 *link_single_click* = _boolean_::
 Default value: *False* +
-TODO
+If set to True, clicking a link will open it even if *Ctrl* is not
+pressed.
 
 // --- Copy & Paste behavior ---
 
@@ -133,7 +150,7 @@ TODO
 
 *disable_mouse_paste* = _boolean_::
 Default value: *False* +
-TODO
+If set to True, mouse pasting will be disabled.
 
 *smart_copy* = _boolean_::
 Default value: *True* +

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -2,7 +2,7 @@
 :doctype: manpage
 :manmanual: Manual for Terminator
 :mansource: Terminator
-:revdate: 2023-04-07
+:revdate: 2023-04-21
 :docdate: {revdate}
 
 == NAME
@@ -39,6 +39,17 @@ This is what a Terminator config file should look like:
     scrollback_lines = '500' #More comment. Single quotes are valid too
     cursor_blink = True
     custom_command = "echo \"foo#bar\"" #Final comment - this will work as expected.
+
+[layouts]
+  [[default]]
+    [[[window0]]]
+      type = Window
+      parent = ""
+    [[[child1]]]
+      type = Terminal
+      parent = window0
+
+[plugins]
 ----
 
 // ================================================================== \\
@@ -68,11 +79,11 @@ If set to True, the window will be visible on all workspaces. +
 Default value: *False*
 
 *hide_on_lose_focus* = _boolean_::
-TODO +
+If set to True, the window will be hidden when focus is lost. +
 Default value: *False*
 
 *hide_from_taskbar* = _boolean_::
-TODO +
+If set to True, the window will be hidden from the taskbar. +
 Default value: *False*
 
 *geometry_hinting* = _boolean_::
@@ -225,11 +236,13 @@ does something relevant with it.
 This option is ignored unless *use_custom_url_handler* is set to True.
 
 *case_sensitive* = _boolean_::
-TODO +
+If set to True, uppercase and lowercase characters will be considered
+different when searching text in the terminal. +
 Default value: *True*
 
 *invert_search* = _boolean_::
-TODO +
+If set to True, the search direction will be inverted (bottom to top)
+when searching text in the terminal. +
 Default value: *False*
 
 *enabled_plugins* = _list of strings_::
@@ -347,7 +360,8 @@ Default value: *<Ctrl>Page_Up*
 
 *switch_to_tab_1*, *switch_to_tab_2*, ... *switch_to_tab_10*::
 Move to the **N**th tab.
-TODO note on switch_to_tab_1?
+Note that *<Alt><Shift>1* may be provided as *<Alt>!* or similar,
+depending on the keyboard layout.
 
 === Organisation
 
@@ -549,7 +563,7 @@ Switch to the previous profile.
 == profiles
 These are the options Terminator currently supports in the *profiles*
 section. Each profile should be its own subsection with a header in the
-format *+[[name]]+*.
+format *\[[name]]*.
 
 === General
 
@@ -640,7 +654,8 @@ escape sequence for the terminal bell. +
 Default value: *False*
 
 *urgent_bell* = _boolean_::
-TODO +
+If set to True, the window's urgency hint will be set when an
+application writes the escape sequence for the terminal bell. +
 Default value: *False*
 
 *icon_bell* = _boolean_::
@@ -694,8 +709,11 @@ Specify the background color to use for the terminal.
 This option is ignored unless *use_theme_colors* is set to False. +
 Default value: *#000000*
 
-*palette* = TODO::
-TODO
+*palette* = _string list of colors_::
+Specify the 16-color palette to use for the terminal.
+The value must be a string containing a colon-separated list of colors
+in hex format. +
+For example, "#000000:#cd0000:#00cd00: ... ".
 
 *bold_is_bright* = _boolean_::
 If set to True, bold text will have brighter colors. +
@@ -786,7 +804,8 @@ The value can be:
 'control-h' for the ASCII BS character (Ctrl+H);
 'escape-sequence' for the escape sequence typically bound to backspace
 or delete;
-'automatic' for TODO. +
+'automatic' for letting the terminal automatically decide the character
+sequence to use. +
 Default value: *ascii-del*
 
 *delete_binding* = _string_::
@@ -796,7 +815,8 @@ The value can be:
 'control-h' for the ASCII BS character (Ctrl+H);
 'escape-sequence' for the escape sequence typically bound to backspace
 or delete;
-'automatic' for TODO. +
+'automatic' for letting the terminal automatically decide the character
+sequence to use. +
 Default value: *escape-sequence*
 
 === Titlebar
@@ -855,8 +875,40 @@ Default value: *#0076c9*
 
 // ================================================================== \\
 
-TODO layouts section?
-TODO plugins section?
+== layouts
+The *layouts* section contains all the saved layouts. Each layout should
+be its own subsection with a header in the format *\[[name]]*.
+
+Each object in a layout is a named sub-sub-section with various
+properties.
+
+*type* = _string_::
+Can be any of: 'Window', 'Notebook', 'HPaned', 'VPaned', 'Terminal'.
+
+*parent* = _string_::
+Specify which object is the parent of the component being defined.
+All objects, except those of type Window, must specify a parent.
+
+This is an example of a *layouts* section containing only the layout
+named "default".
+
+----
+[layouts]
+  [[default]]
+    [[[window0]]]
+      type = Window
+      parent = ""
+    [[[child1]]]
+      type = Terminal
+      parent = window0
+----
+
+// ================================================================== \\
+
+== plugins
+Terminator plugins can add their own configuration to the config file,
+and it will appear as a subsection. Please refer to the documentation of
+individual plugins for more information.
 
 == SEE ALSO
 *terminator*(1), http://www.voidspace.org.uk/python/configobj.html

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -2,12 +2,11 @@
 :doctype: manpage
 :manmanual: Manual for Terminator
 :mansource: Terminator
-:revdate: 2023-03-31
+:revdate: 2023-04-03
 :docdate: {revdate}
 
 == NAME
-// ~/.config/terminator/config - the config file for Terminator terminal emulator
-config - TODO
+terminator_config - the config file for Terminator terminal emulator
 
 == DESCRIPTION
 This file contains the configuration for *terminator*(1).
@@ -51,173 +50,173 @@ These are the options Terminator currently supports in the
 // --- Window behavior ---
 
 *window_state* = _string_::
-Default value: *normal* +
 Control how the Terminator window opens.
 'normal' means it opens normally.
 'maximise' means it opens in a maximised state.
 'fullscreen' means it opens in a fullscreen state.
-'hidden' means it stays hidden.
+'hidden' means it stays hidden. +
+Default value: *normal*
 
 *always_on_top* = _boolean_::
-Default value: *False* +
-If set to True, the window will always stay on top of other windows.
+If set to True, the window will always stay on top of other windows. +
+Default value: *False*
 
 *sticky* = _boolean_::
-Default value: *False* +
-TODO
+TODO +
+Default value: *False*
 
 *hide_on_lose_focus* = _boolean_::
-Default value: *False* +
-TODO
+TODO +
+Default value: *False*
 
 *hide_from_taskbar* = _boolean_::
-Default value: *False* +
-TODO
+TODO +
+Default value: *False*
 
 *geometry_hinting* = _boolean_::
-Default value: *False* +
-If set to True, the window will resize in step with font sizes.
+If set to True, the window will resize in step with font sizes. +
+Default value: *False*
 
 *suppress_multiple_term_dialog* = _boolean_::
-Default value: *False* +
 If set to True, Terminator will ask for confirmation when closing
-multiple terminals.
+multiple terminals. +
+Default value: *False*
 
 // --- Window appearance ---
 
 *borderless* = _boolean_::
-Default value: *False* +
-If set to True, the window will be started without window borders.
+If set to True, the window will be started without window borders. +
+Default value: *False*
 
 === Tab Behavior & Appearance
 
 *tab_position* = _string_::
-Default value: *top* +
 Specify where tabs are placed.
 Can be any of: 'top', 'left', 'right', 'bottom', 'hidden'.
 If set to 'hidden', the tab bar will not be shown. Hiding the tab is not
-recommended, as it can be very confusing.
+recommended, as it can be very confusing. +
+Default value: *top*
 
 *close_button_on_tab* = _boolean_::
-Default value: *True* +
-If set to True, tabs will have a close button on them.
+If set to True, tabs will have a close button on them. +
+Default value: *True*
 
 // what is this???
 *scroll_tabbar* = _boolean_::
-Default value: *False* +
 If set to True, the tab bar will not fill the width of the window.
 The titlebars of the tabs will only take as much space as is necessary
 for the text they contain. Except, that is, if the tabs no longer fit
 the width of the window - in that case scroll buttons will appear to
-move through the tabs.
+move through the tabs. +
+Default value: *False*
 
 *homogeneous_tabbar* = _boolean_::
-Default value: *True* +
-TODO
+TODO +
+Default value: *True*
 
 === Terminal Behavior & Appearance
 
 // --- Terminal behavior ---
 
 *focus* = _string_::
-Default value: *click* +
 Specify how focus is given to terminals.
 'click' means the focus only moves to a terminal after you click in it.
 'sloppy' means the focus will follow the mouse pointer.
-'system' means the focus will match that used by a GNOME window manager.
+'system' means the focus will match that used by a GNOME window manager. +
+Default value: *click*
 
 *always_split_with_profile* = _boolean_::
-Default value: *False* +
 Specify whether splits/tabs will continue to use the profile of their
-peer terminal. If set to False, they will always use the default profile.
+peer terminal. If set to False, they will always use the default profile. +
+Default value: *False*
 
 *link_single_click* = _boolean_::
-Default value: *False* +
 If set to True, clicking a link will open it even if *Ctrl* is not
-pressed.
+pressed. +
+Default value: *False*
 
 // --- Copy & Paste behavior ---
 
 *putty_paste_style* = _boolean_::
-Default value: *False* +
 If set to True, right-click will paste the Primary selection,
-while middle-click will popup the context menu.
+while middle-click will popup the context menu. +
+Default value: *False*
 
 *putty_paste_style_source_clipboard* = _boolean_::
-Default value: *False* +
-TODO
+TODO +
+Default value: *False*
 
 *disable_mouse_paste* = _boolean_::
-Default value: *False* +
-If set to True, mouse pasting will be disabled.
+If set to True, mouse pasting will be disabled. +
+Default value: *False*
 
 *smart_copy* = _boolean_::
-Default value: *True* +
 If set to True, and there is no selection, the shortcut is allowed to
 pass through. This is useful for overloading Ctrl-C to copy a selection,
 or send the SIGINT to the current process if there is no selection.
 If False, the shortcut does not pass through at all, and the SIGINT does
-not get sent.
+not get sent. +
+Default value: *True*
 
 *clear_select_on_copy* = _boolean_::
-Default value: *False* +
-TODO
+TODO +
+Default value: *False*
 
 // --- Terminal appearance ---
 
 *handle_size* = _integer_::
-Default value: *1* +
 Specify the width of the separator between terminals.
 Anything outside the range 0-20 (inclusive) will be ignored and use your
-default theme value.
+default theme value. +
+Default value: *1*
 
 *inactive_color_offset* = _float_::
-Default value: *0.8* +
 Specify how much to reduce the color values of fonts in terminals that
-do not have focus.
+do not have focus. +
+Default value: *0.8*
 
 *inactive_bg_color_offset* = _float_::
-Default value: *1.0* +
 Specify how much to reduce the color values of the background in
-terminals that do not have focus.
+terminals that do not have focus. +
+Default value: *1.0*
 
 *cell_width* = _float_::
-Default value: *1.0* +
-TODO
+TODO +
+Default value: *1.0*
 
 *cell_height* = _float_::
-Default value: *1.0* +
-TODO
+TODO +
+Default value: *1.0*
 
 *title_at_bottom* = _boolean_::
-Default value: *False* +
 If set to True, the terminal's titlebar will be drawn at the bottom
-instead of the top.
+instead of the top. +
+Default value: *False*
 
 === Miscellaneous
 
 *dbus* = _boolean_::
-Default value: *True* +
 Specify whether Terminator will load its DBus server.
 When this server is loaded, running Terminator multiple times will cause
 the first Terminator process to open additional windows.
 If this configuration item is set to False, or the python dbus module is
 unavailable, running Terminator multiple times will run a separate
-Terminator process for each invocation.
+Terminator process for each invocation. +
+Default value: *True*
 
 *extra_styling* = _boolean_::
-Default value: *True* +
-TODO
+TODO +
+Default value: *True*
 
 *broadcast_default* = _string_::
-Default value: *group* +
 Specify the default broadcast behavior.
-Can be any of: 'all', 'group', 'off'.
+Can be any of: 'all', 'group', 'off'. +
+Default value: *group*
 
 *use_custom_url_handler* = _boolean_::
-Default value: *False* +
 If set to True, URL handling will be given over entirely to the program
-specified by 'custom_url_handler'.
+specified by 'custom_url_handler'. +
+Default value: *False*
 
 *custom_url_handler* = _string_::
 Specify the path to a program which accepts a URI as an argument and
@@ -225,17 +224,17 @@ does something relevant with it.
 This option is ignored unless *use_custom_url_handler* is set to True.
 
 *case_sensitive* = _boolean_::
-Default value: *True* +
-TODO
+TODO +
+Default value: *True*
 
 *invert_search* = _boolean_::
-Default value: *False* +
-TODO
+TODO +
+Default value: *False*
 
 *enabled_plugins* = _list of strings_::
-Default value: *['LaunchpadBugURLHandler', 'LaunchpadCodeURLHandler', 'APTURLHandler']* +
 Specify which plugins will be loaded by default. All other plugin
-classes will be ignored.
+classes will be ignored. +
+Default value: *['LaunchpadBugURLHandler', 'LaunchpadCodeURLHandler', 'APTURLHandler']*
 
 == keybindings
 These are the options Terminator currently supports in the *keybindings*
@@ -251,75 +250,67 @@ format *+[[name]]+*.
 === General
 
 *allow_bold* = _boolean_::
-Default value: *True* +
-If set to True, text in the terminal can displayed in bold.
+If set to True, text in the terminal can displayed in bold. +
+Default value: *True*
 
 *copy_on_selection* = _boolean_::
-Default value: *False* +
-TODO
+TODO +
+Default value: *False*
 
 *disable_mousewheel_zoom* = _boolean_::
-Default value: *False* +
-If set to True, Ctrl+mouse_wheel will not zoom or unzoom the terminal.
+If set to True, Ctrl+mouse_wheel will not zoom or unzoom the terminal. +
+Default value: *False*
 
 *word_chars* = _string_::
-Default value: **-,./?%&#:_** +
-TODO
-
-*cell_width* = _float_::
-Default value: *1.0* +
-TODO
-
-*cell_height* = _float_::
-Default value: *1.0* +
-TODO
+TODO +
+Default value: **-,./?%&#:_**
 
 *mouse_autohide* = _boolean_::
-Default value: *True* +
-If set to True, the mouse pointer will be hidden when typing.
+If set to True, the mouse pointer will be hidden when typing. +
+Default value: *True*
 
 *term* = _string_::
-Default value: *xterm-256color* +
-TODO
+TODO +
+Default value: *xterm-256color*
 
 *colorterm* = _string_::
-Default value: *truecolor* +
-TODO
+TODO +
+Default value: *truecolor*
 
 *split_to_group* = _boolean_::
-Default value: *False* +
-TODO
+TODO +
+Default value: *False*
 
 *autoclean_groups* = _boolean_::
-Default value: *True* +
-TODO
+TODO +
+Default value: *True*
 
 // --- Font ---
 
 *use_system_font* = _boolean_::
-Default value: *True* +
 If set to True, the system default font will be used for text in the
-terminal. Otherwise, the value of *font* will be used.
+terminal. Otherwise, the value of *font* will be used. +
+Default value: *True*
 
 *font* = _string_::
-Default value: *Mono 10* +
 Specify which font to use for text in the terminal.
-This option is ignored unless *use_system_font* is set to False.
+This option is ignored unless *use_system_font* is set to False. +
+Default value: *Mono 10*
 
 // --- Cursor ---
 
 *cursor_blink* = _boolean_::
-Default value: *True* +
-If set to True, the cursor will blink when not typing.
+If set to True, the cursor will blink when not typing. +
+Default value: *True*
 
 *cursor_shape* = _string_::
-Default value: *block* +
 Specify the shape of the cursor.
-Can be any of: 'block', 'underline', 'ibeam'.
+Can be any of: 'block', 'underline', 'ibeam'. +
+Default value: *block*
 
 *cursor_color_default* = _boolean_::
-Default value: *True* +
-TODO
+TODO +
+Default value: *True*
 
 *cursor_fg_color* = _color string_::
 Specify the foreground color to use for the cursor.
@@ -332,99 +323,98 @@ This option is ignored unless *cursor_color_default* is set to False.
 // --- Bell ---
 
 *audible_bell* = _boolean_::
-Default value: *False* +
 If set to True, a sound will be played when an application writes the
-escape sequence for the terminal bell.
+escape sequence for the terminal bell. +
+Default value: *False*
 
 *visible_bell* = _boolean_::
-Default value: *False* +
 If set to True, the terminal will flash when an application writes the
-escape sequence for the terminal bell.
+escape sequence for the terminal bell. +
+Default value: *False*
 
 *urgent_bell* = _boolean_::
-Default value: *False* +
-TODO
+TODO +
+Default value: *False*
 
 *icon_bell* = _boolean_::
-Default value: *True* +
 If set to True, a small icon will be shown on the terminal titlebar when
-an application writes the escape sequence for the terminal bell.
+an application writes the escape sequence for the terminal bell. +
+Default value: *True*
 
 *force_no_bell* = _boolean_::
-Default value: *False* +
-If set to True, the terminal bell will be completely disabled.
+If set to True, the terminal bell will be completely disabled. +
+Default value: *False*
 
 === Command
 
 *login_shell* = _boolean_::
-Default value: *False* +
-TODO
+TODO +
+Default value: *False*
 
 *use_custom_command* = _boolean_::
-Default value: *False* +
 If set to True, the value of *custom_command* will be used instead of
-the default shell.
+the default shell. +
+Default value: *False*
 
 *custom_command* = _string_::
 Specify the command to execute instead of the default shell.
 This option is ignored unless *use_custom_command* is set to True.
 
 *exit_action* = _string_::
-Default value: *close* +
 Specify the action to perform when the terminal is closed.
 'close' means the terminal will be removed.
 'restart' means the shell (or the command specified in *custom_command*)
 will be restarted.
 'hold' means the terminal will be kept open, even if the process in it
-has terminated.
+has terminated. +
+Default value: *close*
 
 === Colors
 
 *use_theme_colors* = _boolean_::
-Default value: *False* +
 If set to True, the theme's foreground and background colors will be
 used for the terminal. Otherwise, the values of *foreground_color* and
-*background_color* will be used.
+*background_color* will be used. +
+Default value: *False*
 
 *foreground_color* = _color string_::
-Default value: *#AAAAAA* +
 Specify the foreground color to use for the terminal.
-This option is ignored unless *use_theme_colors* is set to False.
+This option is ignored unless *use_theme_colors* is set to False. +
+Default value: *#AAAAAA*
 
 *background_color* = _color string_::
-Default value: *#000000* +
 Specify the background color to use for the terminal.
-This option is ignored unless *use_theme_colors* is set to False.
+This option is ignored unless *use_theme_colors* is set to False. +
+Default value: *#000000*
 
 *palette* = TODO::
 TODO
 
 *bold_is_bright* = _boolean_::
-Default value: *False* +
-If set to True, bold text will have brighter colors.
+If set to True, bold text will have brighter colors. +
+Default value: *False*
 
 === Background
 
 *background_darkness* = _float_::
-Default value: *0.5* +
-TODO
+TODO +
+Default value: *0.5*
 
 *background_type* = _string_::
-Default value: *solid* +
 Specify what type of background the terminal will have.
 'solid' means the background will be a solid (opaque) color.
 'transparent' means the background will be a transparent color, with its
 transparency being the value of *background_darkness*.
 'image' means the background will be an image, whose path is the value
 of *background_image*; the background color will be drawn on top of it,
-with its transparenty being the value of *background_darkness*.
+with its transparenty being the value of *background_darkness*. +
+Default value: *solid*
 
 *background_image* = _path string_::
 Specify the path to an image that will be used as background.
 This option is ignored unless *background_type* is set to 'image'.
 
 *background_image_mode* = _string_::
-Default value: *stretch_and_fill* +
 Specify how the background image will be drawn.
 'stretch_and_fill' means the image will fill the terminal entirely,
 without necessarily maintaining aspect ratio.
@@ -433,123 +423,124 @@ leaving blank bars, while maintaining aspect ratio.
 'scale_and_crop' means the image will fill the terminal entirely,
 eventually getting cropped, while maintaining aspect ratio.
 'tiling' means the image will be repeated as to fill the terminal.
-This option is ignored unless *background_type* is set to 'image'.
+This option is ignored unless *background_type* is set to 'image'. +
+Default value: *stretch_and_fill*
 
 *background_image_align_horiz* = _string_::
-Default value: *center* +
 Specify the horizontal alignment of the background image.
 Can be any of: 'left', 'center', 'right'.
-This option is ignored unless *background_type* is set to 'image'.
+This option is ignored unless *background_type* is set to 'image'. +
+Default value: *center*
 
 *background_image_align_vert* = _string_::
-Default value: *middle* +
 Specify the vertical alignment of the background image.
 Can be any of: 'top', 'middle', 'bottom'.
-This option is ignored unless *background_type* is set to 'image'.
+This option is ignored unless *background_type* is set to 'image'. +
+Default value: *middle*
 
 === Scrolling
 
 *scrollbar_position* = _string_::
-Default value: *right* +
 Specify where the terminal scrollbar is put.
-Can be any of: 'left', 'right', 'hidden'.
+Can be any of: 'left', 'right', 'hidden'. +
+Default value: *right*
 
 *scroll_on_output* = _boolean_::
-Default value: *False* +
 If set to True, the terminall will scroll to the bottom when an
-application writes text to it.
+application writes text to it. +
+Default value: *False*
 
 *scroll_on_keystroke* = _boolean_::
-Default value: *True* +
-If set to True, the terminal will scroll to the bottom when typing.
+If set to True, the terminal will scroll to the bottom when typing. +
+Default value: *True*
 
 *scrollback_infinite* = _boolean_::
-Default value: *False* +
-If set to True, the terminal will keep the entire scrollback history.
+If set to True, the terminal will keep the entire scrollback history. +
+Default value: *False*
 
 *scrollback_lines* = _integer_::
-Default value: *500* +
 Specify how many lines of scrollback history will be kept by the
 terminal. Lines that don't fit in the scrollback history will be
 discarted. Note that setting large values can slow down rewrapping and
 resizing.
-This option is ignored unless *scrollback_infinite* is set to False.
+This option is ignored unless *scrollback_infinite* is set to False. +
+Default value: *500*
 
 === Compatibility
 
 *backspace_binding* = _string_::
-Default value: *ascii-del* +
 Specify what code will be generated by the backspace key.
 The value can be:
 'ascii-del' for the ASCII DEL character;
 'control-h' for the ASCII BS character (Ctrl+H);
 'escape-sequence' for the escape sequence typically bound to backspace
 or delete;
-'automatic' for TODO.
+'automatic' for TODO. +
+Default value: *ascii-del*
 
 *delete_binding* = _string_::
-Default value: *escape-sequence* +
 Specify what code will be generated by the delete key.
 The value can be:
 'ascii-del' for the ASCII DEL character;
 'control-h' for the ASCII BS character (Ctrl+H);
 'escape-sequence' for the escape sequence typically bound to backspace
 or delete;
-'automatic' for TODO.
+'automatic' for TODO. +
+Default value: *escape-sequence*
 
 === Titlebar
 
 *show_titlebar* = _boolean_::
-Default value: *True* +
 If set to True, the terminal will have a titlebar showing the current
-title of that terminal.
+title of that terminal. +
+Default value: *True*
 
 *title_hide_sizetext* = _boolean_::
-Default value: *False* +
 If set to True, the size of the terminal will not be written on its
-titlebar.
+titlebar. +
+Default value: *False*
 
 *title_use_system_font* = _boolean_::
-Default value: *True* +
 If set to True, the system default font will be used for text in the
-terminal's titlebar. Otherwise, the value of *title_font* will be used.
+terminal's titlebar. Otherwise, the value of *title_font* will be used. +
+Default value: *True*
 
 *title_font* = _string_::
-Default value: *Sans 9* +
 Specify which font to use for text in the terminal's titlebar.
-This option is ignored unless *title_use_system_font* is set to False.
+This option is ignored unless *title_use_system_font* is set to False. +
+Default value: *Sans 9*
 
 // --- Titlebar colors ---
 
 *title_transmit_fg_color* = _color string_::
-Default value: *#ffffff* +
 Specify the foreground color to use for the terminal's titlebar in case
-the terminal is focused.
+the terminal is focused. +
+Default value: *#ffffff*
 
 *title_transmit_bg_color* = _color string_::
-Default value: *#c80003* +
 Specify the background color to use for the terminal's titlebar in case
-the terminal is focused.
+the terminal is focused. +
+Default value: *#c80003*
 
 *title_inactive_fg_color* = _color string_::
-Default value: *#000000* +
 Specify the foreground color to use for the terminal's titlebar in case
-the terminal is unfocused.
+the terminal is unfocused. +
+Default value: *#000000*
 
 *title_inactive_bg_color* = _color string_::
-Default value: *#c0bebf* +
 Specify the background color to use for the terminal's titlebar in case
-the terminal is unfocused.
+the terminal is unfocused. +
+Default value: *#c0bebf*
 
 *title_receive_fg_color* = _color string_::
-Default value: *#ffffff* +
 Specify the foreground color to use for the terminal's titlebar in case
-the terminal is in a group and is receiving input while unfocused.
+the terminal is in a group and is receiving input while unfocused. +
+Default value: *#ffffff*
 
 *title_receive_bg_color* = _color string_::
-Default value: *#0076c9* +
 Specify the background color to use for the terminal's titlebar in case
-the terminal is in a group and is receiving input while unfocused.
+the terminal is in a group and is receiving input while unfocused. +
+Default value: *#0076c9*
 
 == SEE ALSO
 *terminator*(1), http://www.voidspace.org.uk/python/configobj.html

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -2,7 +2,7 @@
 :doctype: manpage
 :manmanual: Manual for Terminator
 :mansource: Terminator
-:revdate: 2023-04-21
+:revdate: 2023-04-22
 :docdate: {revdate}
 
 == NAME
@@ -64,10 +64,10 @@ These are the options Terminator currently supports in the
 
 *window_state* = _string_::
 Control how the Terminator window opens.
-'normal' means it opens normally.
-'maximise' means it opens in a maximised state.
-'fullscreen' means it opens in a fullscreen state.
-'hidden' means it stays hidden. +
+'normal' to open normally.
+'maximise' to open in a maximised state.
+'fullscreen' to open in a fullscreen state.
+'hidden' to stay hidden. +
 Default value: *normal*
 
 *always_on_top* = _boolean_::
@@ -171,15 +171,16 @@ not get sent. +
 Default value: *True*
 
 *clear_select_on_copy* = _boolean_::
-TODO +
+If set to True, text selection will be cleared after copying using the
+*copy* keybinding. +
 Default value: *False*
 
 // --- Terminal appearance ---
 
 *handle_size* = _integer_::
 Specify the width of the separator between terminals.
-Anything outside the range 0-20 (inclusive) will be ignored and use your
-default theme value. +
+Anything outside the range 0-20 (inclusive) will be ignored and the
+default theme value will be used instead. +
 Default value: *1*
 
 *inactive_color_offset* = _float_::
@@ -217,7 +218,8 @@ Terminator process for each invocation. +
 Default value: *True*
 
 *extra_styling* = _boolean_::
-TODO +
+If set to True, Terminator may load an additional CSS styling file,
+depending on the theme. +
 Default value: *True*
 
 *broadcast_default* = _string_::
@@ -485,15 +487,15 @@ Open the Preferences window and show the Keybindings tab. +
 Default value: *<Ctrl><Shift>K*
 
 *copy*::
-Copy the selected text to the clipboard. +
+Copy the selected text to the Clipboard. +
 Default value: *<Ctrl><Shift>C*
 
 *paste*::
-Paste the current contents of the clipboard. +
+Paste the current contents of the Clipboard. +
 Default value: *<Ctrl><Shift>V*
 
 *paste_selection*::
-TODO
+Paste the current contents of the Primary Selection.
 
 *toggle_scrollbar*::
 Toggle the scrollbar. +
@@ -572,7 +574,8 @@ If set to True, text in the terminal can displayed in bold. +
 Default value: *True*
 
 *copy_on_selection* = _boolean_::
-TODO +
+If set to True, text selections will be automatically copied to the
+Clipboard, in addition to being copied to the Primary Selection. +
 Default value: *False*
 
 *disable_mousewheel_zoom* = _boolean_::
@@ -580,7 +583,12 @@ If set to True, Ctrl+mouse_wheel will not zoom or unzoom the terminal. +
 Default value: *False*
 
 *word_chars* = _string_::
-TODO +
+Specify the characters that will be considered part of a single word
+when selecting text by word.
+Hyphen and alphanumerics do not need to be specified.
+Ranges can be given, e.g. "A-Z". +
+For example, if *word_chars* = "," then "foo,bar" is considered a single
+word. +
 Default value: **-,./?%&#:_**
 
 *mouse_autohide* = _boolean_::
@@ -630,7 +638,9 @@ Can be any of: 'block', 'underline', 'ibeam'. +
 Default value: *block*
 
 *cursor_color_default* = _boolean_::
-TODO +
+If set to True, the background and foreground colors of the terminal
+will be used as foreground and background colors for the cursor,
+respectively. +
 Default value: *True*
 
 *cursor_fg_color* = _color string_::
@@ -670,7 +680,9 @@ Default value: *False*
 === Command
 
 *login_shell* = _boolean_::
-TODO +
+If set to True, the terminal will run the default shell (or the command
+specified by *custom_command*) as a login shell.
+This means the first argument passed to the shell/command will be '-l'. +
 Default value: *False*
 
 *use_custom_command* = _boolean_::
@@ -684,11 +696,11 @@ This option is ignored unless *use_custom_command* is set to True.
 
 *exit_action* = _string_::
 Specify the action to perform when the terminal is closed.
-'close' means the terminal will be removed.
-'restart' means the shell (or the command specified in *custom_command*)
-will be restarted.
-'hold' means the terminal will be kept open, even if the process in it
-has terminated. +
+'close' to remove the terminal.
+'restart' to restart the shell (or the command specified by
+*custom_command*).
+'hold' to keep the terminal open, even if the process in it has
+terminated. +
 Default value: *close*
 
 === Colors
@@ -728,15 +740,16 @@ This option is ignored unless *background_type* is set to 'transparent'
 or 'image'. +
 Default value: *0.5*
 
-// TODO background_type needs improvements
 *background_type* = _string_::
 Specify what type of background the terminal will have.
-'solid' means the background will be a solid (opaque) color.
-'transparent' means the background will be a transparent color, with its
-transparency being the value of *background_darkness*.
-'image' means the background will be an image, whose path is the value
-of *background_image*; the background color will be drawn on top of it,
-with its transparency being the value of *background_darkness*. +
+'solid' for a solid (opaque) background.
+'transparent' for a transparent background.
+'image' for a background image. +
+If this is set to 'transparent', the transparency of the background will
+be the value of *background_darkness*.
+If this is set to 'image', the image specified by *background_image*
+will be the background; the background color will then be drawn on top
+of it, with a transparency specified by *background_darkness*. +
 Default value: *solid*
 
 *background_image* = _path string_::
@@ -745,13 +758,13 @@ This option is ignored unless *background_type* is set to 'image'.
 
 *background_image_mode* = _string_::
 Specify how the background image will be drawn.
-'stretch_and_fill' means the image will fill the terminal entirely,
-without necessarily maintaining aspect ratio.
-'scale_and_fit' means the image will fit inside the terminal, eventually
-leaving blank bars, while maintaining aspect ratio.
-'scale_and_crop' means the image will fill the terminal entirely,
-eventually getting cropped, while maintaining aspect ratio.
-'tiling' means the image will be repeated as to fill the terminal.
+'stretch_and_fill' to fill the terminal entirely, without necessarily
+maintaining aspect ratio.
+'scale_and_fit' to fit the image inside the terminal, eventually leaving
+blank bars, while maintaining aspect ratio.
+'scale_and_crop' to fill the terminal entirely, eventually cropping the
+image, while maintaining aspect ratio.
+'tiling' to repeat the image as to fill the terminal.
 This option is ignored unless *background_type* is set to 'image'. +
 Default value: *stretch_and_fill*
 
@@ -911,5 +924,4 @@ and it will appear as a subsection. Please refer to the documentation of
 individual plugins for more information.
 
 == SEE ALSO
-*terminator*(1), http://www.voidspace.org.uk/python/configobj.html
-// this link might be dead
+*terminator*(1), https://configobj.readthedocs.io/

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -2,7 +2,7 @@
 :doctype: manpage
 :manmanual: Manual for Terminator
 :mansource: Terminator
-:revdate: 2023-04-03
+:revdate: 2023-04-07
 :docdate: {revdate}
 
 == NAME
@@ -40,6 +40,8 @@ This is what a Terminator config file should look like:
     cursor_blink = True
     custom_command = "echo \"foo#bar\"" #Final comment - this will work as expected.
 ----
+
+// ================================================================== \\
 
 == global_config
 These are the options Terminator currently supports in the
@@ -236,11 +238,314 @@ Specify which plugins will be loaded by default. All other plugin
 classes will be ignored. +
 Default value: *['LaunchpadBugURLHandler', 'LaunchpadCodeURLHandler', 'APTURLHandler']*
 
+// ================================================================== \\
+
 == keybindings
 These are the options Terminator currently supports in the *keybindings*
 section.
 
+=== Creation & Destruction
+
+*split_horiz*::
+Split the current terminal horizontally. +
+Default value: *<Ctrl><Shift>O*
+
+*split_vert*::
+Split the current terminal vertically. +
+Default value: *<Ctrl><Shift>E*
+
+*split_auto*::
+Split the current terminal automatically, along the longer side. +
+Default value: *<Ctrl><Shift>A*
+
+*new_tab*::
+Open a new tab. +
+Default value: *<Ctrl><Shift>T*
+
+*new_window*::
+Open a new window as part of the existing process. +
+Default value: *<Ctrl><Shift>I*
+
+*new_terminator*::
+Spawn a new Terminator process. +
+Default value: *<Super>I*
+
+*layout_launcher*::
+Open the layout launcher. +
+Default value: *<Alt>L*
+
+*close_term*::
+Close the current terminal. +
+Default value: *<Ctrl><Shift>W*
+
+*close_window*::
+Close the current window. +
+Default value: *<Ctrl><Shift>Q*
+
+=== Navigation
+
+*cycle_next*::
+Focus the next terminal. This is an alias for *go_next*. +
+Default value: *<Ctrl>Tab*
+
+*cycle_prev*::
+Focus the previous terminal. This is an alias for *go_prev*. +
+Default value: *<Ctrl><Shift>Tab*
+
+*go_next*::
+Focus the next terminal. +
+Default value: *<Ctrl><Shift>N*
+
+*go_prev*::
+Focus the previous terminal. +
+Default value: *<Ctrl><Shift>P*
+
+*go_up*::
+Focus the terminal above the current one. +
+Default value: *<Alt>Up*
+
+*go_down*::
+Focus the terminal below the current one. +
+Default value: *<Alt>Down*
+
+*go_left*::
+Focus the terminal to the left of the current one. +
+Default value: *<Alt>Left*
+
+*go_right*::
+Focus the terminal to the right of the current one. +
+Default value: *<Alt>Right*
+
+// --- Scroll ---
+
+*page_up*::
+Scroll the terminal up one page.
+
+*page_down*::
+Scroll the terminal down one page.
+
+*page_up_half*::
+Scroll the terminal up half a page.
+
+*page_down_half*::
+Scroll the terminal down half a page.
+
+*line_up*::
+Scroll the terminal up one line.
+
+*line_down*::
+Scroll the terminal down one line.
+
+// --- Tab ---
+
+*next_tab*::
+Move to the next tab. +
+Default value: *<Ctrl>Page_Down*
+
+*prev_tab*::
+Move to the previous tab. +
+Default value: *<Ctrl>Page_Up*
+
+*switch_to_tab_1*, *switch_to_tab_2*, ... *switch_to_tab_10*::
+Move to the **N**th tab.
+TODO note on switch_to_tab_1?
+
+=== Organisation
+
+*resize_up*::
+Move the parent dragbar up. +
+Default value: *<Ctrl><Shift>Up*
+
+*resize_down*::
+Move the parent dragbar down. +
+Default value: *<Ctrl><Shift>Down*
+
+*resize_left*::
+Move the parent dragbar left. +
+Default value: *<Ctrl><Shift>Left*
+
+*resize_right*::
+Move the parent dragbar right. +
+Default value: *<Ctrl><Shift>Right*
+
+*rotate_cw*::
+Rotate terminals clockwise. +
+Default value: *<Super>R*
+
+*rotate_ccw*::
+Rotate terminals counter+clockwise. +
+Default value: *<Super><Shift>R*
+
+*move_tab_right*::
+Move the current tab to the right by swapping position with the next
+tab. +
+Default value: *<Ctrl><Shift>Page_Down*
+
+*move_tab_left*::
+Move the current tab to the left by swapping position with the previous
+tab. +
+Default value: *<Ctrl><Shift>Page_Up*
+
+=== Focus
+
+*full_screen*::
+Toggle window to fullscreen. +
+Default value: *F11*
+
+*toggle_zoom*::
+Toggle maximisation of the current terminal. +
+Default value: *<Ctrl><Shift>X*
+
+*scaled_zoom*::
+Toggle maximisation of the current terminal and scale the font when
+maximised. +
+Default value: *<Ctrl><Shift>Z*
+
+*hide_window*::
+TODO +
+Default value: *<Ctrl><Shift><Alt>A*
+
+=== Grouping & Broadcasting
+
+*create_group*::
+Create a new group.
+
+// --- Grouping: All ---
+
+*group_all*::
+Group all terminals together. +
+Default value: *<Super>G*
+
+*ungroup_all*::
+Ungroup all terminals.
+
+*group_all_toggle*::
+Toggle grouping of all terminals.
+
+// --- Grouping: Window ---
+
+*group_win*::
+Group all terminals in the current window together.
+
+*ungroup_win*::
+Ungroup all terminals in the current window. +
+Default value: *<Super><Shift>W*
+
+*group_win_toggle*::
+Toggle grouping of all terminals in the current window.
+
+// --- Grouping: Tab ---
+
+*group_tab*::
+Group all terminals in the current tab together. +
+Default value: *<Super>T*
+
+*ungroup_tab*::
+Ungroup all terminals in the current tab. +
+Default value: *<Super><Shift>T*
+
+*group_tab_toggle*::
+Toggle grouping of all terminals in the current tab.
+
+// Broadcasting
+
+*broadcast_off*::
+Turn broadcasting off.
+
+*broadcast_group*::
+Broadcast to all terminals in the same group as the current terminal.
+
+*broadcast_all*::
+Broadcast to all terminals.
+
+=== Miscellaneous
+
+*help*::
+Open the full HTML manual in the browser. +
+Default value: *F1*
+
+*preferences*::
+Open the Preferences window.
+
+*preferences_keybindings*::
+Open the Preferences window and show the Keybindings tab. +
+Default value: *<Ctrl><Shift>K*
+
+*copy*::
+Copy the selected text to the clipboard. +
+Default value: *<Ctrl><Shift>C*
+
+*paste*::
+Paste the current contents of the clipboard. +
+Default value: *<Ctrl><Shift>V*
+
+*paste_selection*::
 TODO
+
+*toggle_scrollbar*::
+Toggle the scrollbar. +
+Default value: *<Ctrl><Shift>S*
+
+*search*::
+Search for text in the terminal scrollback history. +
+Default value: *<Ctrl><Shift>F*
+
+*reset*::
+Reset the terminal state. +
+Default value: *<Ctrl><Shift>R*
+
+*reset_clear*::
+Reset the terminal state and clear the terminal window. +
+Default value: *<Ctrl><Shift>G*
+
+*zoom_in*::
+Increase the font size by one unit. +
+Default value: *<Ctrl>plus*
+
+*zoom_out*::
+Decrease the font size by one unit. +
+Default value: *<Ctrl>minus*
+
+*zoom_normal*::
+Restore the original font size. +
+Default value: *<Ctrl>0*
+
+*zoom_in_all*::
+Increase the font size by one unit for all terminals.
+
+*zoom_out_all*::
+Decrease the font size by one unit for all terminals.
+
+*zoom_normal_all*::
+Restore the original font size for all terminals.
+
+*edit_window_title*::
+Rename the current window. +
+Default value: *<Ctrl><Alt>W*
+
+*edit_tab_title*::
+Rename the current tab. +
+Default value: *<Ctrl><Alt>A*
+
+*edit_terminal_title*::
+Rename the current terminal. +
+Default value: *<Ctrl><Alt>X*
+
+*insert_number*::
+Insert the current terminal's number, i.e. 1 to 12. +
+Default value: *<Super>1*
+
+*insert_padded*::
+Insert the current terminal's number, but zero padded, i.e. 01 to 12. +
+Default value: *<Super>0*
+
+*next_profile*::
+Switch to the next profile.
+
+*previous_profile*::
+Switch to the previous profile.
+
+// ================================================================== \\
 
 == profiles
 These are the options Terminator currently supports in the *profiles*
@@ -541,6 +846,11 @@ Default value: *#ffffff*
 Specify the background color to use for the terminal's titlebar in case
 the terminal is in a group and is receiving input while unfocused. +
 Default value: *#0076c9*
+
+// ================================================================== \\
+
+TODO layouts section?
+TODO plugins section?
 
 == SEE ALSO
 *terminator*(1), http://www.voidspace.org.uk/python/configobj.html

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -44,7 +44,7 @@ This is what a Terminator config file should look like:
 
 == global_config
 These are the options Terminator currently supports in the
-*global_config* section:
+*global_config* section.
 
 === Window Behavior & Appearance
 
@@ -80,15 +80,14 @@ If set to True, the window will resize in step with font sizes.
 
 *suppress_multiple_term_dialog* = _boolean_::
 Default value: *False* +
-Specify whether or not Terminator will ask for confirmation when closing
+If set to True, Terminator will ask for confirmation when closing
 multiple terminals.
 
 // --- Window appearance ---
 
 *borderless* = _boolean_::
 Default value: *False* +
-Control whether the Terminator window will be started without window
-borders.
+If set to True, the window will be started without window borders.
 
 === Tab Behavior & Appearance
 
@@ -96,8 +95,8 @@ borders.
 Default value: *top* +
 Specify where tabs are placed.
 Can be any of: 'top', 'left', 'right', 'bottom', 'hidden'.
-If this is set to 'hidden', the tab bar will not be shown. Hiding the
-tab is not recommended, as it can be very confusing.
+If set to 'hidden', the tab bar will not be shown. Hiding the tab is not
+recommended, as it can be very confusing.
 
 *close_button_on_tab* = _boolean_::
 Default value: *True* +
@@ -122,14 +121,14 @@ TODO
 
 *focus* = _string_::
 Default value: *click* +
-Control how focus is given to terminals.
+Specify how focus is given to terminals.
 'click' means the focus only moves to a terminal after you click in it.
 'sloppy' means the focus will follow the mouse pointer.
 'system' means the focus will match that used by a GNOME window manager.
 
 *always_split_with_profile* = _boolean_::
 Default value: *False* +
-Control whether splits/tabs will continue to use the profile of their
+Specify whether splits/tabs will continue to use the profile of their
 peer terminal. If set to False, they will always use the default profile.
 
 *link_single_click* = _boolean_::
@@ -168,7 +167,7 @@ TODO
 
 *handle_size* = _integer_::
 Default value: *1* +
-Control the width of the separator between terminals.
+Specify the width of the separator between terminals.
 Anything outside the range 0-20 (inclusive) will be ignored and use your
 default theme value.
 
@@ -192,13 +191,14 @@ TODO
 
 *title_at_bottom* = _boolean_::
 Default value: *False* +
-TODO
+If set to True, the terminal's titlebar will be drawn at the bottom
+instead of the top.
 
 === Miscellaneous
 
 *dbus* = _boolean_::
 Default value: *True* +
-Control whether or not Terminator will load its DBus server.
+Specify whether Terminator will load its DBus server.
 When this server is loaded, running Terminator multiple times will cause
 the first Terminator process to open additional windows.
 If this configuration item is set to False, or the python dbus module is
@@ -211,10 +211,8 @@ TODO
 
 *broadcast_default* = _string_::
 Default value: *group* +
-Specify default broadcast behavior.
+Specify the default broadcast behavior.
 Can be any of: 'all', 'group', 'off'.
-
-// try_posix_regexp ???
 
 *use_custom_url_handler* = _boolean_::
 Default value: *False* +
@@ -222,9 +220,9 @@ If set to True, URL handling will be given over entirely to the program
 specified by 'custom_url_handler'.
 
 *custom_url_handler* = _string_::
-Path to a program which accepts a URI as an argument and does something
-relevant with it. This option is ignored unless 'use_custom_url_handler'
-is set to True.
+Specify the path to a program which accepts a URI as an argument and
+does something relevant with it.
+This option is ignored unless *use_custom_url_handler* is set to True.
 
 *case_sensitive* = _boolean_::
 Default value: *True* +
@@ -236,10 +234,323 @@ TODO
 
 *enabled_plugins* = _list of strings_::
 Default value: *['LaunchpadBugURLHandler', 'LaunchpadCodeURLHandler', 'APTURLHandler']* +
-A list of plugins which should be loaded by default. All other plugin
+Specify which plugins will be loaded by default. All other plugin
 classes will be ignored.
+
+== keybindings
+These are the options Terminator currently supports in the *keybindings*
+section.
+
+TODO
 
 == profiles
 These are the options Terminator currently supports in the *profiles*
 section. Each profile should be its own subsection with a header in the
 format *+[[name]]+*.
+
+=== General
+
+*allow_bold* = _boolean_::
+Default value: *True* +
+If set to True, text in the terminal can displayed in bold.
+
+*copy_on_selection* = _boolean_::
+Default value: *False* +
+TODO
+
+*disable_mousewheel_zoom* = _boolean_::
+Default value: *False* +
+If set to True, Ctrl+mouse_wheel will not zoom or unzoom the terminal.
+
+*word_chars* = _string_::
+Default value: **-,./?%&#:_** +
+TODO
+
+*cell_width* = _float_::
+Default value: *1.0* +
+TODO
+
+*cell_height* = _float_::
+Default value: *1.0* +
+TODO
+
+*mouse_autohide* = _boolean_::
+Default value: *True* +
+If set to True, the mouse pointer will be hidden when typing.
+
+*term* = _string_::
+Default value: *xterm-256color* +
+TODO
+
+*colorterm* = _string_::
+Default value: *truecolor* +
+TODO
+
+*split_to_group* = _boolean_::
+Default value: *False* +
+TODO
+
+*autoclean_groups* = _boolean_::
+Default value: *True* +
+TODO
+
+// --- Font ---
+
+*use_system_font* = _boolean_::
+Default value: *True* +
+If set to True, the system default font will be used for text in the
+terminal. Otherwise, the value of *font* will be used.
+
+*font* = _string_::
+Default value: *Mono 10* +
+Specify which font to use for text in the terminal.
+This option is ignored unless *use_system_font* is set to False.
+
+// --- Cursor ---
+
+*cursor_blink* = _boolean_::
+Default value: *True* +
+If set to True, the cursor will blink when not typing.
+
+*cursor_shape* = _string_::
+Default value: *block* +
+Specify the shape of the cursor.
+Can be any of: 'block', 'underline', 'ibeam'.
+
+*cursor_color_default* = _boolean_::
+Default value: *True* +
+TODO
+
+*cursor_fg_color* = _color string_::
+Specify the foreground color to use for the cursor.
+This option is ignored unless *cursor_color_default* is set to False.
+
+*cursor_bg_color* = _color string_::
+Specify the background color to use for the cursor.
+This option is ignored unless *cursor_color_default* is set to False.
+
+// --- Bell ---
+
+*audible_bell* = _boolean_::
+Default value: *False* +
+If set to True, a sound will be played when an application writes the
+escape sequence for the terminal bell.
+
+*visible_bell* = _boolean_::
+Default value: *False* +
+If set to True, the terminal will flash when an application writes the
+escape sequence for the terminal bell.
+
+*urgent_bell* = _boolean_::
+Default value: *False* +
+TODO
+
+*icon_bell* = _boolean_::
+Default value: *True* +
+If set to True, a small icon will be shown on the terminal titlebar when
+an application writes the escape sequence for the terminal bell.
+
+*force_no_bell* = _boolean_::
+Default value: *False* +
+If set to True, the terminal bell will be completely disabled.
+
+=== Command
+
+*login_shell* = _boolean_::
+Default value: *False* +
+TODO
+
+*use_custom_command* = _boolean_::
+Default value: *False* +
+If set to True, the value of *custom_command* will be used instead of
+the default shell.
+
+*custom_command* = _string_::
+Specify the command to execute instead of the default shell.
+This option is ignored unless *use_custom_command* is set to True.
+
+*exit_action* = _string_::
+Default value: *close* +
+Specify the action to perform when the terminal is closed.
+'close' means the terminal will be removed.
+'restart' means the shell (or the command specified in *custom_command*)
+will be restarted.
+'hold' means the terminal will be kept open, even if the process in it
+has terminated.
+
+=== Colors
+
+*use_theme_colors* = _boolean_::
+Default value: *False* +
+If set to True, the theme's foreground and background colors will be
+used for the terminal. Otherwise, the values of *foreground_color* and
+*background_color* will be used.
+
+*foreground_color* = _color string_::
+Default value: *#AAAAAA* +
+Specify the foreground color to use for the terminal.
+This option is ignored unless *use_theme_colors* is set to False.
+
+*background_color* = _color string_::
+Default value: *#000000* +
+Specify the background color to use for the terminal.
+This option is ignored unless *use_theme_colors* is set to False.
+
+*palette* = TODO::
+TODO
+
+*bold_is_bright* = _boolean_::
+Default value: *False* +
+If set to True, bold text will have brighter colors.
+
+=== Background
+
+*background_darkness* = _float_::
+Default value: *0.5* +
+TODO
+
+*background_type* = _string_::
+Default value: *solid* +
+Specify what type of background the terminal will have.
+'solid' means the background will be a solid (opaque) color.
+'transparent' means the background will be a transparent color, with its
+transparency being the value of *background_darkness*.
+'image' means the background will be an image, whose path is the value
+of *background_image*; the background color will be drawn on top of it,
+with its transparenty being the value of *background_darkness*.
+
+*background_image* = _path string_::
+Specify the path to an image that will be used as background.
+This option is ignored unless *background_type* is set to 'image'.
+
+*background_image_mode* = _string_::
+Default value: *stretch_and_fill* +
+Specify how the background image will be drawn.
+'stretch_and_fill' means the image will fill the terminal entirely,
+without necessarily maintaining aspect ratio.
+'scale_and_fit' means the image will fit inside the terminal, eventually
+leaving blank bars, while maintaining aspect ratio.
+'scale_and_crop' means the image will fill the terminal entirely,
+eventually getting cropped, while maintaining aspect ratio.
+'tiling' means the image will be repeated as to fill the terminal.
+This option is ignored unless *background_type* is set to 'image'.
+
+*background_image_align_horiz* = _string_::
+Default value: *center* +
+Specify the horizontal alignment of the background image.
+Can be any of: 'left', 'center', 'right'.
+This option is ignored unless *background_type* is set to 'image'.
+
+*background_image_align_vert* = _string_::
+Default value: *middle* +
+Specify the vertical alignment of the background image.
+Can be any of: 'top', 'middle', 'bottom'.
+This option is ignored unless *background_type* is set to 'image'.
+
+=== Scrolling
+
+*scrollbar_position* = _string_::
+Default value: *right* +
+Specify where the terminal scrollbar is put.
+Can be any of: 'left', 'right', 'hidden'.
+
+*scroll_on_output* = _boolean_::
+Default value: *False* +
+If set to True, the terminall will scroll to the bottom when an
+application writes text to it.
+
+*scroll_on_keystroke* = _boolean_::
+Default value: *True* +
+If set to True, the terminal will scroll to the bottom when typing.
+
+*scrollback_infinite* = _boolean_::
+Default value: *False* +
+If set to True, the terminal will keep the entire scrollback history.
+
+*scrollback_lines* = _integer_::
+Default value: *500* +
+Specify how many lines of scrollback history will be kept by the
+terminal. Lines that don't fit in the scrollback history will be
+discarted. Note that setting large values can slow down rewrapping and
+resizing.
+This option is ignored unless *scrollback_infinite* is set to False.
+
+=== Compatibility
+
+*backspace_binding* = _string_::
+Default value: *ascii-del* +
+Specify what code will be generated by the backspace key.
+The value can be:
+'ascii-del' for the ASCII DEL character;
+'control-h' for the ASCII BS character (Ctrl+H);
+'escape-sequence' for the escape sequence typically bound to backspace
+or delete;
+'automatic' for TODO.
+
+*delete_binding* = _string_::
+Default value: *escape-sequence* +
+Specify what code will be generated by the delete key.
+The value can be:
+'ascii-del' for the ASCII DEL character;
+'control-h' for the ASCII BS character (Ctrl+H);
+'escape-sequence' for the escape sequence typically bound to backspace
+or delete;
+'automatic' for TODO.
+
+=== Titlebar
+
+*show_titlebar* = _boolean_::
+Default value: *True* +
+If set to True, the terminal will have a titlebar showing the current
+title of that terminal.
+
+*title_hide_sizetext* = _boolean_::
+Default value: *False* +
+If set to True, the size of the terminal will not be written on its
+titlebar.
+
+*title_use_system_font* = _boolean_::
+Default value: *True* +
+If set to True, the system default font will be used for text in the
+terminal's titlebar. Otherwise, the value of *title_font* will be used.
+
+*title_font* = _string_::
+Default value: *Sans 9* +
+Specify which font to use for text in the terminal's titlebar.
+This option is ignored unless *title_use_system_font* is set to False.
+
+// --- Titlebar colors ---
+
+*title_transmit_fg_color* = _color string_::
+Default value: *#ffffff* +
+Specify the foreground color to use for the terminal's titlebar in case
+the terminal is focused.
+
+*title_transmit_bg_color* = _color string_::
+Default value: *#c80003* +
+Specify the background color to use for the terminal's titlebar in case
+the terminal is focused.
+
+*title_inactive_fg_color* = _color string_::
+Default value: *#000000* +
+Specify the foreground color to use for the terminal's titlebar in case
+the terminal is unfocused.
+
+*title_inactive_bg_color* = _color string_::
+Default value: *#c0bebf* +
+Specify the background color to use for the terminal's titlebar in case
+the terminal is unfocused.
+
+*title_receive_fg_color* = _color string_::
+Default value: *#ffffff* +
+Specify the foreground color to use for the terminal's titlebar in case
+the terminal is in a group and is receiving input while unfocused.
+
+*title_receive_bg_color* = _color string_::
+Default value: *#0076c9* +
+Specify the background color to use for the terminal's titlebar in case
+the terminal is in a group and is receiving input while unfocused.
+
+== SEE ALSO
+*terminator*(1), http://www.voidspace.org.uk/python/configobj.html
+// this link might be dead


### PR DESCRIPTION
This took some time, but it's here!
In a previous PR (#733) I rewrote `terminator.1` in AsciiDoc. Now I've done the same for `terminator_config.5`.

The information in `terminator_config.5` was severely outdated and most of settings added through the years were missing.
I've also added a small script, `gen_manpages.sh`, that should be used to generate the manpages after changing the `.adoc` files.