### PR TITLE
Enable sixel support in VTE if it's available.

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -155,6 +155,9 @@ class Terminal(Gtk.VBox):
             self.composite_support = True
         dbg('composite_support: %s' % self.composite_support)
 
+        if hasattr(self.vte, "set_enable_sixel"):
+            self.vte.set_enable_sixel(True)
+
         self.vte.show()
         self.update_url_matches()
 


### PR DESCRIPTION
The actual sixel related change is very small. It should be safe and (I hope) uncontroversial.

The flake.nix I used to dev/test this is also included. It enables one to (relatively) easily install a modified instance of VTE compiled with SIXEL support included. If it's unwanted, I don't mind dropping it from the pull request. I'm sorta new to Nix so I doubt it's perfect.