### PR TITLE
Alter get_text_range call based on VTE version

### DIFF
--- a/terminatorlib/plugins/logger.py
+++ b/terminatorlib/plugins/logger.py
@@ -6,7 +6,7 @@ terminals """
 
 import os
 import sys
-from gi.repository import Gtk
+from gi.repository import Gtk,Vte
 import terminatorlib.plugin as plugin
 from terminatorlib.translation import _
 
@@ -19,6 +19,7 @@ class Logger(plugin.MenuItem):
     dialog_action = Gtk.FileChooserAction.SAVE
     dialog_buttons = (_("_Cancel"), Gtk.ResponseType.CANCEL,
                       _("_Save"), Gtk.ResponseType.OK)
+    vte_version = Vte.get_minor_version()
 
     def __init__(self):
         plugin.MenuItem.__init__(self)
@@ -40,8 +41,11 @@ class Logger(plugin.MenuItem):
         
     def write_content(self, terminal, row_start, col_start, row_end, col_end):
         """ Final function to write a file """
-        content = terminal.get_text_range(row_start, col_start, row_end, col_end,
+        if self.vte_version < 72:
+            content = terminal.get_text_range(row_start, col_start, row_end, col_end,
                                           lambda *a: True)
+        else:
+            content = terminal.get_text_range_format(Vte.Format.TEXT,row_start, col_start, row_end, col_end)
         content = content[0]
         fd = self.loggers[terminal]["fd"]
         # Don't write the last char which is always '\n'


### PR DESCRIPTION
In vte 0.72 there was a regression that caused Vte.Terminal.get_text_range() to fail to return the text requested However, in the same version, there was a new call introduced that does retrieve the text, so if I detect a vte minor version above 72, I call that instead.

Fixes #776 