### PR TITLE
Revert "modify terminator separater size setting in gui to start from 1"

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -84,7 +84,7 @@ DEFAULTS = {
         'global_config':   {
             'dbus'                  : True,
             'focus'                 : 'click',
-            'handle_size'           : 1,
+            'handle_size'           : -1,
             'geometry_hinting'      : False,
             'window_state'          : 'normal',
             'borderless'            : False,

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -353,9 +353,9 @@
     </data>
   </object>
   <object class="GtkAdjustment" id="adjustment1">
-    <property name="lower">1</property>
+    <property name="lower">-1</property>
     <property name="upper">20</property>
-    <property name="value">1</property>
+    <property name="value">-1</property>
     <property name="step-increment">1</property>
     <property name="page-increment">2</property>
   </object>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1381,8 +1381,6 @@ class PrefsEditor:
         value = int(value)          # Cast to int.
         if value > 20:
             value = 20
-        if value < 1:
-            value = 1
         self.config['handle_size'] = value
         self.config.save()
         guiget = self.builder.get_object


### PR DESCRIPTION
This reverts commit c8cd50ba9a7c1b4ecac83c2336122d4133cfabe2.

This commit oddly rendering saved layouts.  I decided to revert it after not finding an easy way to achieve both.

Fixes #766