### PR TITLE
Add command line option --toggle-visibility

### DIFF
--- a/doc/terminator.1
+++ b/doc/terminator.1
@@ -171,6 +171,13 @@ be displayed.
 If this is specified and Terminator is already running, DBus will be
 used to spawn a new tab in the first Terminator window.
 .RE
+.sp
+\fB\-\-toggle\-visibility\fP
+.RS 4
+If this is specified and Terminator is already running, DBus will be
+used to toggle Terminator window visibility. Usable under Wayland to
+replace hide keyboad shortcut.
+.RE
 .SH "KEYBINDINGS"
 .sp
 The following default keybindings can be used to control Terminator.
@@ -347,8 +354,9 @@ of the current one (zoom).
 .sp
 \fBCtrl+Shift+Alt+A\fP
 .RS 4
-Hide the initial window. Note that this is a global binding, and can
-only be bound once.
+Hide the initial window. Note that this is a X11 global binding, and can
+only be bound once. On Wayland use window manager keyboard shortcuts to
+call \fBterminator \-\-toggle\-visibility\fP.
 .RE
 .SS "Grouping & Broadcasting"
 .sp

--- a/doc/terminator.adoc
+++ b/doc/terminator.adoc
@@ -108,6 +108,11 @@ be displayed.
 If this is specified and Terminator is already running, DBus will be
 used to spawn a new tab in the first Terminator window.
 
+*--toggle-visibility*::
+If this is specified and Terminator is already running, DBus will be
+used to toggle Terminator window visibility. Usable under Wayland to
+replace hide keyboad shortcut.
+
 == KEYBINDINGS
 The following default keybindings can be used to control Terminator.
 Most of these keybindings can be changed in the Preferences.
@@ -221,8 +226,9 @@ Toggle between showing all terminals and only showing a scaled version
 of the current one (zoom).
 
 *Ctrl+Shift+Alt+A*::
-Hide the initial window. Note that this is a global binding, and can
-only be bound once.
+Hide the initial window. Note that this is a X11 global binding, and can
+only be bound once. On Wayland use window manager keyboard shortcuts to
+call *terminator --toggle-visibility*.
 
 === Grouping & Broadcasting
 The following items relate to grouping and broadcasting.

--- a/terminator
+++ b/terminator
@@ -102,6 +102,9 @@ if __name__ == '__main__':
                 if OPTIONS.new_tab:
                     dbg('Requesting a new tab')
                     ipc.new_tab_cmdline(optionslist)
+                elif OPTIONS.toggle_visibility:
+                    dbg('requesting to toggle windows visibility')
+                    ipc.toggle_visibility_cmdline(optionslist)
                 elif OPTIONS.unhide:
                     print('requesting to unhide windows')
                     ipc.unhide_cmdline(optionslist)

--- a/terminatorlib/ipc.py
+++ b/terminatorlib/ipc.py
@@ -101,6 +101,12 @@ class DBusService(Borg, dbus.service.Object):
         window.tab_new()
 
     @dbus.service.method(BUS_NAME, in_signature='a{ss}')
+    def toggle_visibility_cmdline(self,options=dbus.Dictionary):
+        dbg('toggle_visibility_cmdline')
+        for window in self.terminator.get_windows():
+            window.on_hide_window()
+
+    @dbus.service.method(BUS_NAME, in_signature='a{ss}')
     def unhide_cmdline(self,options=dbus.Dictionary):
         dbg('unhide_cmdline')
         for window in self.terminator.get_windows():
@@ -342,6 +348,10 @@ def new_window_cmdline(session, options):
 def new_tab_cmdline(session, options):
     """Call the dbus method to open a new tab in the first window"""
     session.new_tab_cmdline(options)
+
+@with_proxy
+def toggle_visibility_cmdline(session,options):
+    session.toggle_visibility_cmdline(options)
 
 @with_proxy
 def unhide_cmdline(session,options):

--- a/terminatorlib/optionparse.py
+++ b/terminatorlib/optionparse.py
@@ -96,6 +96,8 @@ icon for the window (by file or name)'))
             help=_('Comma separated list of methods to limit debugging to'))
     parser.add_argument('--new-tab', action='store_true', dest='new_tab',
             help=_('If Terminator is already running, just open a new tab'))
+    parser.add_argument('--toggle-visibility', action='store_true', dest='toggle_visibility',
+            help=_('If Terminator is already running, toggle windows visibility'))
     parser.add_argument('--unhide', action='store_true', dest='unhide',
             help=_('If Terminator is already running, just unhide all hidden windows'))
     parser.add_argument('--list-profiles', action='store_true', dest='list_profiles',

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -103,6 +103,7 @@ class Window(Container, Gtk.Window):
 
         self.apply_icon(icon_to_apply)
         self.pending_set_rough_geometry_hint = False
+        self.hidefunc = self.hide
 
     def do_get_property(self, prop):
         """Handle gobject getting a property"""


### PR DESCRIPTION
Useful for Wayland where global shortcuts are not available. Use window manager to bind "terminator --toggle-visibilty" to a keyboard shortcut.

Related bug: https://github.com/gnome-terminator/terminator/issues/427
