### PR TITLE
[bug-760] working directory feature is broken 

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -499,6 +499,34 @@ class Config(object):
         """Set a layout"""
         return(self.base.set_layout(layout, tree))
 
+    def copy_layout_item(self, src_layout, dst_layout, item):
+        items = {}
+        for child in src_layout:
+            section   = src_layout[child]
+            sec_type  = section.get('type', None)
+            if sec_type != 'Terminal':
+                continue
+
+            cp_item = section.get(item, None)
+            uuid    = str(section.get('uuid', None))
+            if cp_item:
+                items[uuid] = cp_item
+
+        dbg("items to be copied:%s" % items)
+        for child in dst_layout:
+            section   = dst_layout[child]
+            sec_type  = section.get('type', None)
+            if sec_type != 'Terminal':
+                continue
+
+            uuid       = str(section.get('uuid', None))
+            update_item = items.get(uuid, None)
+            if uuid and update_item:
+               dbg("update layout item:(%s) with value:(%s)"
+                                            % (item, update_item))
+               section[item] = update_item
+
+
 class ConfigBase(Borg):
     """Class to provide access to our user configuration"""
     loaded = None

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -2133,7 +2133,7 @@ class LayoutEditor:
 
     def on_layout_profile_workingdir_activate(self, widget):
         """A new working directory has been entered for this item"""
-        workdir = widget.get_text()
+        workdir = os.path.expanduser(widget.get_text())
         layout = self.config.layout_get_config(self.layout_name)
         layout[self.layout_item]['directory'] = workdir
         self.config.save()

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1572,6 +1572,14 @@ class PrefsEditor:
         (model, rowiter) = selected.get_selected()
         name = model.get_value(rowiter, 0)
 
+        config_layout  = self.config.base.get_layout(name)
+        dbg("layout from terminator:(%s)" % current_layout)
+        dbg("layout from config:(%s)" % config_layout)
+
+        self.config.copy_layout_item(config_layout, current_layout, 'directory')
+        self.config.copy_layout_item(config_layout, current_layout, 'command')
+        dbg("updated layout from terminator:(%s)" % current_layout)
+
         if self.config.replace_layout(name, current_layout):
             treeview.set_cursor(model.get_path(rowiter), column=treeview.get_column(0), start_editing=False)
         self.config.save()

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1493,7 +1493,7 @@ class Terminal(Gtk.VBox):
     def set_cwd(self, cwd=None):
         """Set our cwd"""
         if cwd is not None:
-            self.cwd = cwd
+            self.cwd = os.path.expanduser(cwd)
 
     def held_open(self, widget=None, respawn=False, debugserver=False):
         self.is_held_open = True


### PR DESCRIPTION
**Issue** Ref: https://github.com/gnome-terminator/terminator/issues/760

    - as per the bug the layout does not get updated when "Save" button in layout is pressed
    - it does get updated if the window is closed by pressing top x close icon.
    - on pressing Save, it seems that the prefseditor takes this from current_layout = terminator.describe_layout() and saves it in config
    - whereas the current changes are done per key stroke and config is updated
    - this patch copies the parameters like directory and command when Save is press and on_layoutrefreshbutton_clicked() is called
    - Hence working dir and command are copied when Save is pressed using uuid to match terminals.
    - If there is a command registered then the terminal runs the command and exits. so one is not able to see the results.


**Observation**

It was reported in bug that this used to work in previous versions, but I could not find that for me it only worked after the patch.

_command in layout issue:_

I have notices in the released version 2.1.3 and in the master branch I was working that if a command is present the terminator exits after being launched. I could trace it to terminal.py in following lines. I am not sure if thats the default behavior but it seemed confusing when program exited. 

elif self.config['exit_action'] in ('close', 'left'):
            self.cnxids.new(self.vte, 'child-exited',
                                            lambda x, y: self.emit('close-term'))

**Testing**

- Launch terminator
- Right-click and Preferences->Layout
- Try changing working directory and press Save below.
-  exit terminator and relaunch
- the previous state would be same unmodified

- after this patch that should work



