### PR TITLE
[bug 808] Plugins-dont-receive-keboard-signals-on-newly-opened-windows

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -156,6 +156,13 @@ class Terminal(Gtk.VBox):
         dbg('composite_support: %s' % self.composite_support)
 
         self.vte.show()
+
+        #force to load for new window/terminal use case loading plugin
+        #and connecting signals, note the line update_url_matches also
+        #calls load_plugins, but it won't reload since already loaded
+
+        self.load_plugins(force = True)
+
         self.update_url_matches()
 
         self.terminalbox = self.create_terminalbox()
@@ -284,6 +291,10 @@ class Terminal(Gtk.VBox):
         terminalbox.show_all()
 
         return(terminalbox)
+
+    def load_plugins(self, force = False):
+        registry = plugin.PluginRegistry()
+        registry.load_plugins(force)
 
     def _add_regex(self, name, re):
         match = -1


### PR DESCRIPTION
Ref: https://github.com/gnome-terminator/terminator/issues/808

Some plugins using KeyBindUtil https://github.com/gnome-terminator/terminator/issues/805 don't receive Key events in newly opened window / terminal. Reloading of plugins helps and gives plugins an option to reconnect terminal events. This patch given on way or opens up a discussion on this and to test this, may be a better solution exists.

DEPENDENCY

Examples:

https://github.com/gnome-terminator/terminator/issues/706
https://github.com/gnome-terminator/terminator/pull/682