### PR TITLE
Fix Insert Term Name Plugin error

### DIFF
--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -585,7 +585,7 @@ class Terminator(Borg):
 
         for term in self.get_target_terms(widget):
             name = term.titlebar.get_custom_string() or term.get_window_title()
-            term.feed(name)
+            term.feed(name.encode())
 
     def get_sibling_terms(self, widget):
         termset = []


### PR DESCRIPTION
The "Insert terminal name" Plugin causes the following traceback Traceback (most recent call last):
  File "/Users/mattrose/Code/terminator/terminatorlib/terminator.py", line 588, in do_insert_term_name
    term.feed(name)
  File "/Users/mattrose/Code/terminator/terminatorlib/terminal.py", line 1709, in feed
    self.vte.feed_child(text)

This PR fixes it so the plugin inserts the terminal name, as intended.