### PR TITLE
 [bug 802] - Ability to undo or restore changes to the preferences #802

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -713,22 +713,55 @@ class ConfigBase(Borg):
         return filename
 
     def save_config_with_suffix(self, suffix):
-        filename = self.get_config_filename()
-        #save the current config, to revert any changes make in preferences
-        cur_loaded_file = filename + suffix
-        shutil.copy2(filename, cur_loaded_file)
+        try:
+            filename = self.get_config_filename()
+
+            #save the current config, to revert any changes make in preferences
+            #save the current config to config_dir path which is at least writable
+            cfg_filename    = os.path.join(get_config_dir(), 'config')
+            cur_loaded_file = cfg_filename + suffix
+
+            if os.path.exists(filename) and cur_loaded_file:
+                dbg('copy file:%s to' \
+                    ' file:%s' % (filename, cur_loaded_file))
+                shutil.copy2(filename, cur_loaded_file)
+            elif cur_loaded_file:
+                open(cur_loaded_file, 'a').close()
+            else:
+                err('ConfigBase:: Unable to get filename to save')
+        except Exception as ex:
+            err('ConfigBase::save_config_with_suffix' \
+                    ' Unable to save config: %s' % ex)
 
     def restore_config_with_suffix(self, suffix):
-        filename = self.get_config_filename()
-        cur_loaded_file = filename + suffix
-        dbg("restoring from file:%s to file:%s" % (cur_loaded_file, filename))
-        shutil.copy2(cur_loaded_file, filename)
+        try:
+            filename = self.get_config_filename()
+
+            cfg_filename    = os.path.join(get_config_dir(), 'config')
+            cur_loaded_file = cfg_filename + suffix
+            if os.path.exists(cur_loaded_file):
+                if not os.access(filename, os.W_OK):
+                    dbg('path:%s not writable' \
+                        ' restoring to path:%s' % (filename,cfg_filename))
+                    filename = cfg_filename
+
+                dbg('restore from file:%s to file:%s'
+                        % (cur_loaded_file, filename))
+                shutil.copy2(cur_loaded_file, filename)
+        except Exception as ex:
+            err('ConfigBase::restore_config_with_suffix' \
+                    ' Unable to restore config: %s' % ex)
 
     def remove_config_with_suffix(self, suffix):
-        filename = self.get_config_filename()
-        cur_loaded_file = filename + suffix
-        if os.path.exists(cur_loaded_file):
-            os.remove(cur_loaded_file)
+        try:
+            cfg_filename    = os.path.join(get_config_dir(), 'config')
+            cur_loaded_file = cfg_filename + suffix
+            if os.path.exists(cur_loaded_file):
+                dbg('remove file:%s' % (cur_loaded_file))
+                os.remove(cur_loaded_file)
+        except Exception as ex:
+            err('ConfigBase::remove_config_with_suffix' \
+                    ' Unable to remove config: %s' % ex)
 
     def reload(self):
         """Force a reload of the base config"""
@@ -795,7 +828,8 @@ class ConfigBase(Borg):
                 open(filename, 'a').close()
 
             backup_file = filename + '~'
-            shutil.copy2(filename, backup_file)
+            if os.path.exists(filename):
+                shutil.copy2(filename, backup_file)
 
             with open(filename, 'wb') as fh:
                 parser.write(fh)

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -622,12 +622,7 @@ class ConfigBase(Borg):
             dbg('config already loaded')
             return
 
-        if self.command_line_options and self.command_line_options.config:
-            filename = self.command_line_options.config
-        else:
-            filename = os.path.join(get_config_dir(), 'config')
-            if not os.path.exists(filename):
-                filename = os.path.join(get_system_config_dir(), 'config')
+        filename = self.get_config_filename()
         dbg('looking for config file: %s' % filename)
         try:
             #
@@ -705,6 +700,35 @@ class ConfigBase(Borg):
                     dbg('skipping missing section %s' % section_name)
 
         self.loaded = True
+
+    def get_config_filename(self):
+        filename = ''
+        if self.command_line_options and self.command_line_options.config:
+            filename = self.command_line_options.config
+        else:
+            filename = os.path.join(get_config_dir(), 'config')
+            if not os.path.exists(filename):
+                filename = os.path.join(get_system_config_dir(), 'config')
+
+        return filename
+
+    def save_config_with_suffix(self, suffix):
+        filename = self.get_config_filename()
+        #save the current config, to revert any changes make in preferences
+        cur_loaded_file = filename + suffix
+        shutil.copy2(filename, cur_loaded_file)
+
+    def restore_config_with_suffix(self, suffix):
+        filename = self.get_config_filename()
+        cur_loaded_file = filename + suffix
+        dbg("restoring from file:%s to file:%s" % (cur_loaded_file, filename))
+        shutil.copy2(cur_loaded_file, filename)
+
+    def remove_config_with_suffix(self, suffix):
+        filename = self.get_config_filename()
+        cur_loaded_file = filename + suffix
+        if os.path.exists(cur_loaded_file):
+            os.remove(cur_loaded_file)
 
     def reload(self):
         """Force a reload of the base config"""

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -424,6 +424,7 @@
     <property name="title" translatable="yes">Terminator Preferences</property>
     <property name="default-width">640</property>
     <property name="default-height">400</property>
+    <signal name="destroy" handler="on_destroy_event" swapped="no"/>
     <child>
       <object class="GtkBox" id="dialog_vbox1">
         <property name="visible">True</property>
@@ -1241,7 +1242,7 @@
                               </packing>
                             </child>
                             <child>
-                              <!-- n-columns=2 n-rows=4 -->
+                              <!-- n-columns=2 n-rows=5 -->
                               <object class="GtkGrid" id="grid4">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -4411,6 +4412,21 @@ Much of the behavior of Terminator is based on GNOME Terminal, and we are adding
               </packing>
             </child>
             <child>
+              <object class="GtkButton" id="restoreconfigbutton">
+                <property name="label">Discard Changes</property>
+                <property name="use-action-appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="on_restoreconfigbutton_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="okbutton">
                 <property name="label">gtk-close</property>
                 <property name="use-action-appearance">False</property>
@@ -4423,7 +4439,7 @@ Much of the behavior of Terminator is based on GNOME Terminal, and we are adding
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -235,13 +235,24 @@ class PrefsEditor:
         nb = guiget('notebook1')
         nb.set_current_page(cur_page)
 
+        self.config.base.save_config_with_suffix('_cur')
+
+    def on_destroy_event(self, _widget):
+        self.config.base.remove_config_with_suffix('_cur')
+
     def on_closebutton_clicked(self, _button):
         """Close the window"""
+        self.config.base.remove_config_with_suffix('_cur')
         terminator = Terminator()
         terminator.reconfigure()
         self.window.destroy()
         self.calling_window.preventHide = False
         del(self)
+
+    def on_restoreconfigbutton_clicked(self, _button):
+        """restore config to load time"""
+        self.config.base.restore_config_with_suffix('_cur')
+        self.on_closebutton_clicked(_button)
 
     def set_values(self):
         """Update the preferences window with all the configuration from


### PR DESCRIPTION
**Changes** 
- added basic config restore option from preferences window
 - changes to glade made in addition to addition of destory signal
 - minor cleaup in config to have a single function return confilg filename via get_config_filename

**Things to Cross Check**
- position of restore button in preference window
- name of button
- additional behavior like enabling button only on change or a simple standard way like current one is ok ?