### PR TITLE
Fix: Add CLI command to reload configuration

### DIFF
--- a/terminator
+++ b/terminator
@@ -111,11 +111,9 @@ if __name__ == '__main__':
                 elif OPTIONS.toggle_visibility:
                     dbg('requesting to toggle windows visibility')
                     ipc.toggle_visibility_cmdline(optionslist)
-
-                if OPTIONS.reload:
+                elif OPTIONS.reload:
                     dbg('requesting to reload configuration for all windows')
                     ipc.reload_configuration()
-
                 elif OPTIONS.unhide:
                     print('requesting to unhide windows')
                     ipc.unhide_cmdline(optionslist)


### PR DESCRIPTION
Commit 2e1dd1f breaks --new-tab and --toggle-visibilty.

On each call a new window is created, from else on line 122.

Introduced if cut the last else from the two first if causing last else to be called every time.