### PR TITLE
Ask before closing, even if there is only one terminal

### DIFF
--- a/doc/terminator_config.5
+++ b/doc/terminator_config.5
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: terminator_config
 .\"    Author: [see the "AUTHOR(S)" section]
-.\" Generator: Asciidoctor 2.0.18
-.\"      Date: 2023-04-22
+.\" Generator: Asciidoctor 2.0.16
+.\"      Date: 2023-10-10
 .\"    Manual: Manual for Terminator
 .\"    Source: Terminator
 .\"  Language: English
 .\"
-.TH "TERMINATOR_CONFIG" "5" "2023-04-22" "Terminator" "Manual for Terminator"
+.TH "TERMINATOR_CONFIG" "5" "2023-10-10" "Terminator" "Manual for Terminator"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -130,12 +130,11 @@ If set to True, the window will resize in step with font sizes.
 Default value: \fBFalse\fP
 .RE
 .sp
-\fBsuppress_multiple_term_dialog\fP = \fIboolean\fP
+\fBask_before_closing\fP = \fIstring\fP
 .RS 4
-If set to True, Terminator will ask for confirmation when closing
-multiple terminals.
-.br
-Default value: \fBFalse\fP
+Specify when to ask for confirmation before closing a window or a tab.
+Can be any of: \*(Aqalways\*(Aq, \*(Aqmultiple_terminals\*(Aq, \*(Aqnever\*(Aq.
+Default value: \fBmultiple_terminals\fP
 .RE
 .sp
 \fBborderless\fP = \fIboolean\fP

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -2,7 +2,7 @@
 :doctype: manpage
 :manmanual: Manual for Terminator
 :mansource: Terminator
-:revdate: 2023-04-22
+:revdate: 2023-10-10
 :docdate: {revdate}
 
 == NAME
@@ -90,10 +90,10 @@ Default value: *False*
 If set to True, the window will resize in step with font sizes. +
 Default value: *False*
 
-*suppress_multiple_term_dialog* = _boolean_::
-If set to True, Terminator will ask for confirmation when closing
-multiple terminals. +
-Default value: *False*
+*ask_before_closing* = _string_::
+Specify when to ask for confirmation before closing a window or a tab.
+Can be any of: 'always', 'multiple_terminals', 'never'.
+Default value: *multiple_terminals*
 
 // --- Window appearance ---
 

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -105,7 +105,7 @@ DEFAULTS = {
             'enabled_plugins'       : ['LaunchpadBugURLHandler',
                                        'LaunchpadCodeURLHandler',
                                        'APTURLHandler'],
-            'suppress_multiple_term_dialog': False,
+            'ask_before_closing'    : 'multiple_terminals',
             'always_split_with_profile': False,
             'putty_paste_style'     : False,
             'putty_paste_style_source_clipboard': False,

--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -379,35 +379,33 @@ class Notebook(Container, Gtk.Notebook):
         maker = Factory()
         child = nb.get_nth_page(tabnum)
 
+        confirm_close = self.construct_confirm_close(self.window, child)
+        if confirm_close != Gtk.ResponseType.ACCEPT:
+            dbg('user cancelled request')
+            return
+
         if maker.isinstance(child, 'Terminal'):
             dbg('child is a single Terminal')
+
             del nb.last_active_term[child]
             child.close()
             # FIXME: We only do this del and return here to avoid removing the
             # page below, which child.close() implicitly does
             del(label)
-            return
         elif maker.isinstance(child, 'Container'):
             dbg('child is a Container')
-            result = self.construct_confirm_close(self.window, _('tab'))
 
-            if result == Gtk.ResponseType.ACCEPT:
-                containers = None
-                objects = None
-                containers, objects = enumerate_descendants(child)
+            containers = None
+            objects = None
+            containers, objects = enumerate_descendants(child)
 
-                while len(objects) > 0:
-                    descendant = objects.pop()
-                    descendant.close()
-                    while Gtk.events_pending():
-                        Gtk.main_iteration()
-                return
-            else:
-                dbg('user cancelled request')
-                return
+            while len(objects) > 0:
+                descendant = objects.pop()
+                descendant.close()
+                while Gtk.events_pending():
+                    Gtk.main_iteration()
         else:
             err('Notebook::closetab: child is unknown type %s' % child)
-            return
 
     def resizeterm(self, widget, keyname):
         """Handle a keyboard event requesting a terminal resize"""

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -280,22 +280,14 @@ class Window(Container, Gtk.Window):
     def on_delete_event(self, window, event, data=None):
         """Handle a window close request"""
         maker = Factory()
-        if maker.isinstance(self.get_child(), 'Terminal'):
-            if self.is_zoomed():
-                return(self.confirm_close(window, _('window')))
-            else:
-                dbg('Only one child, closing is fine')
-                return(False)
-        elif maker.isinstance(self.get_child(), 'Container'):
-            return(self.confirm_close(window, _('window')))
+
+        if (maker.isinstance(self.get_child(), 'Terminal') or
+            maker.isinstance(self.get_child(), 'Container')):
+            confirm_close = self.construct_confirm_close(window, _('window'))
+            return (confirm_close != Gtk.ResponseType.ACCEPT)
         else:
             dbg('unknown child: %s' % self.get_child())
-
-    def confirm_close(self, window, type):
-        """Display a confirmation dialog when the user is closing multiple
-        terminals in one window"""
-        
-        return(not (self.construct_confirm_close(window, type) == Gtk.ResponseType.ACCEPT))
+            return False # close anyway
 
     def on_destroy_event(self, widget, data=None):
         """Handle window destruction"""

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -281,12 +281,13 @@ class Window(Container, Gtk.Window):
         """Handle a window close request"""
         maker = Factory()
 
-        if (maker.isinstance(self.get_child(), 'Terminal') or
-            maker.isinstance(self.get_child(), 'Container')):
-            confirm_close = self.construct_confirm_close(window, _('window'))
+        child = self.get_child()
+        if (maker.isinstance(child, 'Terminal') or
+            maker.isinstance(child, 'Container')):
+            confirm_close = self.construct_confirm_close(window, child)
             return (confirm_close != Gtk.ResponseType.ACCEPT)
         else:
-            dbg('unknown child: %s' % self.get_child())
+            dbg('unknown child: %s' % child)
             return False # close anyway
 
     def on_destroy_event(self, widget, data=None):


### PR DESCRIPTION
(Partially?) solves #830

This is apparently a very requested feature. This PR makes it possible for the "Close?" confirmation dialog to appear even if there is only one terminal.

## Settings: suppress_multiple_term_dialog ---> ask_before_closing
The `suppress_multiple_term_dialog` setting has been replaced with `ask_before_closing`, which can have values '_never_', '_multiple_terminals_' and '_always_'.
'_multiple_terminals_' is the default, so that Terminator's default behavior remains the same. The "Do not show this message next time" checkbox sets `ask_before_closing` to '_never_', regardless of its previous value.

## GUI changes
The confirm close dialog is the same as before, for multiple terminals. For one terminal, it is like this:
![terminator-confirm-close](https://github.com/gnome-terminator/terminator/assets/47713809/20e10bb8-d5e7-4bdc-b033-a1390ab88727)

## Code changes
`Container.construct_confirm_close` has been significantly modified. The translation for "Close multiple terminals?" was broken and a few translatable texts were added.