### PR TITLE
[bug 846] 846-mouseless-keyboard-url-open-fails-to-extract-text-and-c…

### DIFF
--- a/terminatorlib/plugins/mousefree_url_handler.py
+++ b/terminatorlib/plugins/mousefree_url_handler.py
@@ -122,10 +122,12 @@ class MouseFreeURLHandler(plugin.Plugin):
         dbg("selected URL (%s %s)" % (self.matches_ptr, "not found"))
         return None
 
-    def on_focus_in(self, widget, event):
+    def on_focus_in(self, widget, event, event_type = None):
         dbg("focus-in clear url search buffer widget: %s" % widget)
-        self.cur_term = widget
-        self.vte      = widget.get_vte()
+
+        self.cur_term = widget.get_toplevel().get_focussed_terminal()
+        self.vte      = self.cur_term.get_vte()
+
         self.clear_search()
 
     def on_keypress(self, widget, event):


### PR DESCRIPTION

-fixed text extract
-clear search between commands using return key press -found a use case for KeyBindUtil for common keys like return, alt, shift

**Test**

- Should work normally in searching  urls  `<Alt>j <Alt>k and <Alt><Return>`
- Search current urls, Then run any command (this should clear search). Now try to get more URL text on screen. Now search should work for all urls.
