### PR TITLE
[bug 852] - 852-terminator_py_get_focussed_terminal_always_returns_none

### DIFF
--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -614,7 +614,7 @@ class Terminator(Borg):
     def get_focussed_terminal(self):
         """iterate over all the terminals to find which, if any, has focus"""
         for terminal in self.terminals:
-            if terminal.has_focus():
+            if terminal.get_vte().has_focus():
                 return(terminal)
         return(None)
 


### PR DESCRIPTION
- added get_vte().has_focus() for a valid focussed terminal to return