### PR TITLE
WIP: Feature/save user session venv (#879)

### DIFF
--- a/terminatorlib/plugins/save_user_session_layout.py
+++ b/terminatorlib/plugins/save_user_session_layout.py
@@ -1,0 +1,69 @@
+import os
+import sys 
+
+# Fix imports when testing this file directly
+if __name__ == '__main__':
+  sys.path.append( os.path.join(os.path.dirname(__file__), "../.."))
+
+from gi.repository import Gtk,Vte
+
+from terminatorlib.config import Config
+import terminatorlib.plugin as plugin
+from terminatorlib.translation import _
+from terminatorlib.util import get_config_dir, err, dbg, gerr
+from terminatorlib.terminator import Terminator
+from terminatorlib import util
+
+
+# AVAILABLE must contain a list of all the classes that you want exposed
+AVAILABLE = ['SaveUserSessionLayout']
+
+class SaveUserSessionLayout(plugin.MenuItem):
+    capabilities = ['terminal_menu', 'session']
+
+    config = None
+    conf_file = os.path.join(get_config_dir(),"save_last_session_cwd")
+    conf_sessions = []
+    emit_close_count = 0
+
+    vte_version = Vte.get_minor_version()
+
+    def __init__(self):
+      dbg("SaveUserSessionLayout Init")
+      plugin.MenuItem.__init__(self)
+
+    def callback(self, menuitems, menu, terminal):
+        """ Add save menu item to the menu"""
+        vte_terminal = terminal.get_vte()
+        item = Gtk.MenuItem.new_with_mnemonic(_('Save _UserSessionLayout'))
+        item.connect("activate", self.save_all_session_layouts, terminal)
+        menuitems.append(item)
+        
+    def save_all_session_layouts(self, menuitem, terminal):
+        for term in Terminator().terminals:
+          self.save_session_layout("", "")
+
+    #not used, but capability can be used to load automatically
+    def load_session_layout(self, debugtab=False, widget=None, cwd=None, metadata=None, profile=None):
+      dbg("SaveUserSessionLayout load layout")
+      terminator = Terminator()
+      util.spawn_new_terminator(terminator.origcwd, ['-u', '-l', 'SaveUserSessionLayout'])
+
+    def save_session_layout(self, debugtab=False, widget=None, cwd=None, metadata=None, profile=None):
+
+      config = Config()
+      terminator = Terminator()
+      current_layout = terminator.describe_layout(save_cwd = True)
+      dbg("SaveUserSessionLayout: save layout(%s)" % current_layout)
+      res = config.replace_layout("SaveUserSessionLayout", current_layout)
+      if (not res):
+        r = config.add_layout("SaveUserSessionLayout", current_layout)
+      config.save()
+      return True
+    
+   
+    def close(self, term, event, arg1 = None):
+        if (self.emit_close_count == 0):
+            self.emit_close_count = self.emit_close_count + 1
+            self.save_session_layout("", "")
+

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -4,6 +4,7 @@
 
 
 import os
+import sys
 import signal
 import gi
 from gi.repository import GLib, GObject, Pango, Gtk, Gdk, GdkPixbuf, cairo
@@ -19,6 +20,7 @@ from .util import dbg, err, spawn_new_terminator, make_uuid, manual_lookup, disp
 from . import util
 from .config import Config
 from .cwd import get_pid_cwd
+from .venv import get_pid_venv
 from .factory import Factory
 from .terminator import Terminator
 from .titlebar import Titlebar
@@ -94,6 +96,7 @@ class Terminal(Gtk.VBox):
 
     group = None
     cwd = None
+    venv = None
     origcwd = None
     command = None
     clipboard = None
@@ -106,6 +109,7 @@ class Terminal(Gtk.VBox):
     layout_command = None
     relaunch_command = None
     directory = None
+    virtual_env = None
 
     is_held_open = False
 
@@ -140,6 +144,7 @@ class Terminal(Gtk.VBox):
         self.config = Config()
 
         self.cwd = get_pid_cwd()
+        self.venv = get_pid_venv() # TODO: vritual env still needs to be activated in the current terminal
         self.origcwd = self.terminator.origcwd
         self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
 
@@ -262,6 +267,21 @@ class Terminal(Gtk.VBox):
             # Fall back to old gtk2 method
             dbg('calling get_pid_cwd')
             return(get_pid_cwd(self.pid))
+        
+    def get_venv(self):
+        """Return our virtual environment"""
+
+        vte_venv = False #= self.vte.get_current_virtual_environment_uri()
+        if vte_venv:
+            # OSC7 pwd gives an answer
+            # return remote venv - if possible
+            return(GLib.filename_from_uri(vte_venv)[0])
+        else:
+            # Fall back to old gtk2 method
+            dbg('calling get_pid_venv')
+            return(get_pid_venv(self.pid))
+
+
 
     def close(self):
         """Close ourselves"""
@@ -1509,6 +1529,11 @@ class Terminal(Gtk.VBox):
         if cwd is not None:
             self.cwd = cwd
 
+    def set_venv(self, venv=None):
+        """Set our virtual environment"""
+        if venv is not None:
+            self.venv = venv
+
     def held_open(self, widget=None, respawn=False, debugserver=False):
         self.is_held_open = True
         self.titlebar.update()
@@ -1557,6 +1582,10 @@ class Terminal(Gtk.VBox):
                 options.working_directory != '':
             self.set_cwd(options.working_directory)
             options.working_directory = ''
+
+        # virtualenv set in layout config
+        if self.virtual_env:
+            self.set_virtual_env(self.virtual_env)
 
         if type(command) is list:
             shell = util.path_lookup(command[0])
@@ -1816,10 +1845,14 @@ class Terminal(Gtk.VBox):
         layout['uuid'] = self.uuid
         if save_cwd:
             layout['directory'] = self.get_cwd()
+
+            if self.get_venv() is not None:
+                layout['venv'] = self.get_venv()
+
         name = 'terminal%d' % count
         count = count + 1
         global_layout[name] = layout
-        return count
+        return count   
 
     def create_layout(self, layout):
         """Apply our layout"""
@@ -1837,6 +1870,8 @@ class Terminal(Gtk.VBox):
             self.titlebar.set_custom_string(layout['title'])
         if 'directory' in layout and layout['directory'] != '':
             self.directory = layout['directory']
+        if 'venv' in layout and layout['venv'] != '':
+            self.virtual_env = layout['venv']
         if 'uuid' in layout and layout['uuid'] != '':
             self.uuid = make_uuid(layout['uuid'])
 

--- a/terminatorlib/venv.py
+++ b/terminatorlib/venv.py
@@ -1,10 +1,10 @@
 # Terminator by Chris Jones <cmsj@tenshu.net>
 # GPL v2 only
-"""cwd.py - function necessary to get the cwd for a given pid on various OSes
+"""venv.py - function necessary to get the current virtual environment for a given pid on various OSes
 
 
->>> cwd = get_pid_cwd(None)
->>> cwd.__class__.__name__
+>>> venv = get_pid_venv(None)
+>>> venv.__class__.__name__
 'str'
 
 """
@@ -12,21 +12,16 @@
 import psutil
 from .util import dbg
 
-def get_pid_cwd(pid = None):
-    """Determine the cwd of the current process"""
-    psinfo =  psutil.Process(pid).as_dict()
-    dbg('psinfo: %s %s' % (psinfo['cwd'],psinfo['pid']))
-    # return func
-    return psinfo['cwd']
-
 def get_pid_venv(pid = None):
     """Determine the virtual environment of the current process"""
     psinfo =  psutil.Process(pid).as_dict()
     dbg('psinfo: %s' % (psinfo))
     #dbg('psinfo: %s %s' % (psinfo['venv'],psinfo['pid']))
+
     # prefix = getattr(sys, "base_prefix", None) or getattr(sys, "real_prefix", None) or sys.prefix
     # if prefix != sys.prefix: # session is in a virtual environment
     #     return sys.prefix
+    
     # return func
     return "my-venv" #psinfo['venv']
 

--- a/terminatorlib/version.py
+++ b/terminatorlib/version.py
@@ -20,4 +20,4 @@ TerminatorVersion supplies our version number.
 """
 
 APP_NAME = 'terminator'
-APP_VERSION = '2.1.3'
+APP_VERSION = '2.1.4'


### PR DESCRIPTION

Additionally to the current working directory, it would be nice to also store the python virtual environment that is currently used in the config file and re-activate it on Session restore.

This solves #879