### PR TITLE
fix traceback in layout_done

### DIFF
--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -338,7 +338,8 @@ class Terminator(Borg):
                 # For windows without a notebook ensure Terminal is visible and focused
                 if window_last_active_term_mapping[window]:
                     term = self.find_terminal_by_uuid(window_last_active_term_mapping[window].urn)
-                    term.ensure_visible_and_focussed()
+                    if term:
+                        term.ensure_visible_and_focussed()
 
         # Build list of new windows using prelayout list
         new_win_list = []


### PR DESCRIPTION
Got this while testing layouts.  Easy fix

Traceback (most recent call last):
  File "/home/mattrose/Code/terminator/./terminator", line 137, in <module>
    TERMINATOR.layout_done()
  File "/home/mattrose/Code/terminator/terminatorlib/terminator.py", line 341, in layout_done
    term.ensure_visible_and_focussed()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'ensure_visible_and_focussed'