### PR TITLE
[bug 889] - simplify and clean keybinding merge code #889

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -123,6 +123,10 @@ DEFAULTS = {
             'new_tab_after_current_tab': False,
         },
         'keybindings': {
+            'zoom'             : '',
+            'unzoom'           : '',
+            'maximise'         : '',
+            'open_debug_tab'   : '',
             'zoom_in'          : '<Control>plus',
             'zoom_out'         : '<Control>minus',
             'zoom_normal'      : '<Control>0',


### PR DESCRIPTION
- Current list of Keybindings in Preferences->Keybindings are shown after merging Keybindings
- The merge happens in prefseditor.py
- Cleaning and moving the code from prefseditor.py
- Adding a function to get plugin via name
- Adding some missing keybindings in config.py and prefseditor.py and syncing them for consistency
- These changes were also part of: Feature: is there any way to Hide or Sort context menu items? #773 and Pull request: [Plugin ContextMenuPlugin] 773-Feature-is-there-any-way-to-Hide-or-Sort-context-menu #842
- So decoupling these as separate issue
-
**Testing**
- Preferences->Keybindings needs to be tested
- No Visual or Working changes only cleanup