### PR TITLE
Properly parse file:/// URIs

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -300,6 +300,7 @@ class Terminal(Gtk.VBox):
         registry.load_plugins(force)
 
     def _add_regex(self, name, re):
+        dbg(f"adding regex: {re}")
         match = -1
         if regex.FLAGS_PCRE2:
             try:
@@ -323,19 +324,23 @@ class Terminal(Gtk.VBox):
         passchars = "-A-Za-z0-9,?;.:/!%$^*&~\"#'"
         hostchars = r"-A-Za-z0-9:\[\]"
         pathchars = "-A-Za-z0-9_$.+!*(),;:@&=?/~#%'"
-        schemes   = "(news:|telnet:|nntp:|file:/|https?:|ftps?:|webcal:|ssh:)"
+        schemes   = "(news:|telnet:|nntp:|https?:|ftps?:|webcal:|ssh:)"
         user      = "[" + userchars + "]+(:[" + passchars + "]+)?"
         urlpath   = "/[" + pathchars + "]*[^]'.}>) \t\r\n,\\\"]"
 
         lboundry = "\\b"
         rboundry = "\\b"
 
+        re = (lboundry + "file:/" + "//?(:[0-9]+)?(" + urlpath + ")" +
+                rboundry + "/?")
+        self._add_regex('file', re)
+
         re = (lboundry + schemes +
                 "//(" + user + "@)?[" + hostchars  +".]+(:[0-9]+)?(" +
                 urlpath + ")?" + rboundry + "/?")
         self._add_regex('full_uri', re)
 
-        if self.matches['full_uri'] == -1:
+        if self.matches['full_uri'] == -1 or self.matches['file'] == -1:
             err ('Terminal::update_url_matches: Failed adding URL matches')
         else:
             re = (lboundry +


### PR DESCRIPTION
Previously, file URIs were lumped in with full uris that would be used for HTTP, FTP, etc.  This caused file:/// uri parser to ignore any file with a root dir that had a character that was not a valid hostname character to be ignored.

fixes #865 