### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/terminatorlib/plugins/maven.py
+++ b/terminatorlib/plugins/maven.py
@@ -32,9 +32,9 @@ class MavenPluginURLHandler(plugin.URLHandler):
     maven_filters = {}
     maven_filters['apache_maven_plugin_shortname'] = 'clean|compiler|deploy|failsafe|install|resources|site|surefire|verifier|ear|ejb|jar|rar|war|shade|changelog|changes|checkstyle|clover|doap|docck|javadoc|jxr|linkcheck|pmd|project-info-reports|surefire-report|ant|antrun|archetype|assembly|dependency|enforcer|gpg|help|invoker|jarsigner|one|patch|pdf|plugin|release|reactor|remote-resources|repository|scm|source|stage|toolchains|eclipse|idea'
     maven_filters['codehaus_maven_plugin_shortname'] = 'jboss|jboss-packaging|tomcat|was6|antlr|antlr3|aspectj|axistools|castor|commons-attributes|gwt|hibernate3|idlj|javacc|jaxb2|jpox|jspc|openjpa|rmic|sablecc|sqlj|sysdeo-tomcat|xmlbeans|xdoclet|netbeans-freeform|nbm|clirr|cobertura|taglist|scmchangelog|findbugs|fitnesse|selenium|animal-sniffer|appassembler|build-helper|exec|keytool|latex|ounce|rpm|sql|versions|apt|cbuilds|jspc|native|retrotranslator|springws|smc|ideauidesigner|dita|docbook|javancss|jdepend|dashboard|emma|sonar|jruby|dbunit|shitty|batik|buildnumber|ianal|jalopy|jasperreports|l10n|minijar|native2ascii|osxappbundle|properties|solaris|truezip|unix|virtualization|wagon|webstart|xml|argouml|dbupgrade|chronos|ckjm|codenarc|deb|ec2|enchanter|ejbdoclet|graphing|j2me|javascript tools|jardiff|kodo|macker|springbeandoc|mock-repository|nsis|pomtools|setup|simian-report|syslog|visibroker|weblogic|webdoclet|xjc|xsltc'
-    maven_filters['apache_maven_plugin_artifact_id'] = 'maven\-(%(apache_maven_plugin_shortname)s)\-plugin' % maven_filters
-    maven_filters['codehaus_maven_plugin_artifact_id'] = '(%(codehaus_maven_plugin_shortname)s)\-maven\-plugin' % maven_filters
-    maven_filters['maven_plugin_version'] = '[a-zA-Z0-9\.-]+'
+    maven_filters['apache_maven_plugin_artifact_id'] = r'maven\-(%(apache_maven_plugin_shortname)s)\-plugin' % maven_filters
+    maven_filters['codehaus_maven_plugin_artifact_id'] = r'(%(codehaus_maven_plugin_shortname)s)\-maven\-plugin' % maven_filters
+    maven_filters['maven_plugin_version'] = r'[a-zA-Z0-9\.-]+'
     maven_filters['maven_plugin_goal'] = '[a-zA-Z-]+'
     maven_filters['maven_plugin'] = '(%(apache_maven_plugin_artifact_id)s|%(codehaus_maven_plugin_artifact_id)s)(:%(maven_plugin_version)s:%(maven_plugin_goal)s)?' % maven_filters
     maven_filters['maven_plugin_named_groups'] = '(?P<artifact_id>%(apache_maven_plugin_artifact_id)s|%(codehaus_maven_plugin_artifact_id)s)(:%(maven_plugin_version)s:(?P<goal>%(maven_plugin_goal)s))?' % maven_filters

--- a/terminatorlib/plugins/mousefree_url_handler.py
+++ b/terminatorlib/plugins/mousefree_url_handler.py
@@ -51,7 +51,7 @@ class MouseFreeURLHandler(plugin.Plugin):
     vte          = None
     cur_term     = None
     #basic pattern
-    searchtext  = "https?\:\/\/[^\s]+[\/\w]"
+    searchtext  = r"https?\:\/\/[^\s]+[\/\w]"
 
     def __init__(self):
         self.connect_signals()

--- a/terminatorlib/plugins/url_handlers.py
+++ b/terminatorlib/plugins/url_handlers.py
@@ -13,7 +13,7 @@ class LaunchpadBugURLHandler(plugin.URLHandler):
     Launchpad Bug URL"""
     capabilities = ['url_handler']
     handler_name = 'launchpad_bug'
-    match = '\\b(lp|LP):?\s?#?[0-9]+(,\s*#?[0-9]+)*\\b'
+    match = r'\b(lp|LP):?\s?#?[0-9]+(,\s*#?[0-9]+)*\b'
     nameopen = "Open Launchpad bug"
     namecopy = "Copy bug URL"
 
@@ -36,7 +36,7 @@ class LaunchpadCodeURLHandler(plugin.URLHandler):
     lpfilters['series'] = lpfilters['project']
     lpfilters['branch'] = '[a-zA-Z0-9]{1}[a-zA-Z0-9_+@.-]+'
 
-    match = '\\b((lp|LP):%(project)s(/%(series)s)?|(lp|LP):%(group)s/(%(project)s|\+junk)/%(branch)s)\\b' % lpfilters
+    match = r'\b((lp|LP):%(project)s(/%(series)s)?|(lp|LP):%(group)s/(%(project)s|\+junk)/%(branch)s)\b' % lpfilters
 
     def callback(self, url):
         """Look for the number in the supplied string and return it as a URL"""


### PR DESCRIPTION
Hello. I am a Void Linux package maintainer and I have noticed that terminator produces the following syntax warnings when issuing `python3 -m compileall`:

```
./usr/lib/python3.12/site-packages/terminatorlib/plugins/maven.py:35: SyntaxWarning: invalid escape sequence '\-'
  maven_filters['apache_maven_plugin_artifact_id'] = 'maven\-(%(apache_maven_plugin_shortname)s)\-plugin' % maven_filters
./usr/lib/python3.12/site-packages/terminatorlib/plugins/maven.py:36: SyntaxWarning: invalid escape sequence '\-'
  maven_filters['codehaus_maven_plugin_artifact_id'] = '(%(codehaus_maven_plugin_shortname)s)\-maven\-plugin' % maven_filters
./usr/lib/python3.12/site-packages/terminatorlib/plugins/maven.py:37: SyntaxWarning: invalid escape sequence '\.'
  maven_filters['maven_plugin_version'] = '[a-zA-Z0-9\.-]+'
./usr/lib/python3.12/site-packages/terminatorlib/plugins/mousefree_url_handler.py:54: SyntaxWarning: invalid escape sequence '\:'
  searchtext  = "https?\:\/\/[^\s]+[\/\w]"
./usr/lib/python3.12/site-packages/terminatorlib/plugins/url_handlers.py:16: SyntaxWarning: invalid escape sequence '\s'
  match = '\\b(lp|LP):?\s?#?[0-9]+(,\s*#?[0-9]+)*\\b'
./usr/lib/python3.12/site-packages/terminatorlib/plugins/url_handlers.py:39: SyntaxWarning: invalid escape sequence '\+'
  match = '\\b((lp|LP):%(project)s(/%(series)s)?|(lp|LP):%(group)s/(%(project)s|\+junk)/%(branch)s)\\b' % lpfilters
```

This pull request fixes them.

It looks like I'm not the only one who has noticed this problem:

resolves #920

@ScottMcCormack Does this pull request fix the issue for you? Your issue is related to version `2.1.3`, so the warnings might be slightly different on `master`.