### PR TITLE
Fix TypeError in reconfigure() of terminal.py (line 753)

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -750,7 +750,7 @@ class Terminal(Gtk.VBox):
             self.bgcolor.parse(self.config['background_color'])
 
         if self.config['background_type'] in ('transparent', 'image'):
-            self.bgcolor.alpha = self.config['background_darkness']
+            self.bgcolor.alpha = float(self.config['background_darkness'])
         else:
             self.bgcolor.alpha = 1
 


### PR DESCRIPTION
Resolved a bug where 'self.bgcolor.alpha' expected a number but received a string, causing a TypeError. The issue was traced to background darkness configuration handling.