### PR TITLE
- [bug 678] fix argument handling of the --execute flag

### DIFF
--- a/terminatorlib/optionparse.py
+++ b/terminatorlib/optionparse.py
@@ -114,7 +114,7 @@ icon for the window (by file or name)'))
                 help=argparse.SUPPRESS)
 
     global options
-    options = parser.parse_args()
+    options, extra = parser.parse_known_args()
 
     if options.version:
         print('%s %s' % (version.APP_NAME, version.APP_VERSION))
@@ -175,4 +175,5 @@ icon for the window (by file or name)'))
     if util.DEBUG == True:
         dbg('command line options: %s' % options)
 
+    options.extra = extra
     return(options,optionslist)

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1539,6 +1539,12 @@ class Terminal(Gtk.VBox):
             options.command = None
         elif options and options.execute:
             command = options.execute
+            dbg('cmd: %s' % command)
+            if len(options.extra) and options.extra[0] == '--':
+                options.execute.extend(options.extra[1:])
+                command = options.execute
+                dbg('cmd with extra args: %s' % command)
+
             self.relaunch_command = command
             options.execute = None
         elif self.relaunch_command:


### PR DESCRIPTION
- [bug 939] execute still broken
- [bug 923] terminator -x gets confused by

- fixed double dash -- by handling extra arguments, need to cross check against all use cases
- currently its done in terminal.py need to check if other dependencies but first I want to get
- the behavior right

As per #939 #923 the use cases need to be further tested since I am not aware of previous behavior .

terminator -x echo -- hi  # fails
terminator -x /bin/zsh -i -c "ls; exec $SHELL"  # fails
terminator -u -x /bin/zsh -i -c "ls; exec $SHELL"  # works, but -u should not be required