### PR TITLE
-[bug 949]  #949 its reported in the issue that the save button in la…

### DIFF
--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -1625,6 +1625,7 @@ class PrefsEditor:
 
         self.config.copy_layout_item(config_layout, current_layout, 'directory')
         self.config.copy_layout_item(config_layout, current_layout, 'command')
+        self.config.copy_layout_item(config_layout, current_layout, 'profile')
         dbg("updated layout from terminator:(%s)" % current_layout)
 
         if self.config.replace_layout(name, current_layout):


### PR DESCRIPTION
Its reported in the issue that the save button in layout overrides the profile, custom command, working dir. The same does not happen when close button is pressed or pref window is closed. In my observation,I have seen that the profile is overwritten, but custom command and wording dir are updated.

The updation of working dir and custom command when editing without save button seems a bit different but I haven't changed that part for now.

For sake of consistency I have ensured the updation of profile (which anyways gets updated from drop down menu) but is over written by save button, happens when save button is pressed.
