### PR TITLE
[bug 971] - Save button throws KeyError when a multiple tab layout is…

### DIFF
--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -53,7 +53,7 @@ class Notebook(Container, Gtk.Notebook):
 
         self.show_all()
 
-    def configure(self):
+    def configure(self, clear_last_active_term = True):
         """Apply widget-wide settings"""
         # FIXME: The old reordered handler updated Terminator.terminals with
         # the new order of terminals. We probably need to preserve this for
@@ -76,7 +76,14 @@ class Notebook(Container, Gtk.Notebook):
 #        style.xthickness = 0
 #        style.ythickness = 0
 #        self.modify_style(style)
-        self.last_active_term = {}
+
+        #when on_closebutton_clicked is called from prefseditor, it reconfigures
+        #the terminator. if they are cleared then
+        #self.last_active_term[self.get_nth_page(tabnum)] fails in container.py
+        #in describe_layout
+
+        if clear_last_active_term:
+            self.last_active_term = {}
 
     def create_window_detach(self, notebook, widget, x, y):
         """Create a window to contain a detached tab"""

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -244,7 +244,7 @@ class PrefsEditor:
         """Close the window"""
         self.config.base.remove_config_with_suffix('_cur')
         terminator = Terminator()
-        terminator.reconfigure()
+        terminator.reconfigure(clear_last_active_term = False)
         self.window.destroy()
         self.calling_window.preventHide = False
         del(self)

--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -365,7 +365,7 @@ class Terminator(Borg):
             self.cur_gtk_theme_name = new_gtk_theme_name
             self.reconfigure()
 
-    def reconfigure(self):
+    def reconfigure(self, clear_last_active_term = True):
         """Update configuration for the whole application"""
 
         if self.style_providers != []:
@@ -505,7 +505,7 @@ class Terminator(Borg):
         for window in self.windows:
             child = window.get_child()
             if maker.isinstance(child, 'Notebook'):
-                child.configure()
+                child.configure(clear_last_active_term)
 
     def on_css_parsing_error(self, provider, section, error, user_data=None):
         """Report CSS parsing issues"""


### PR DESCRIPTION
Issue is described in #971 the KeyError should not be raised after following the steps.

The solution is to pass on flag so that the current terminals are not cleared on terminator.reconfigure when called from Preference window close button. Need to check if there is another efficient way to handle or parameter passing across to notebook.py is ok. 

