### PR TITLE
Ensure that when the layout item is changed the layout sub item also gets reset to first item, else KeyError is thrown

### DIFF
--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -2115,6 +2115,12 @@ class LayoutEditor:
 
     def on_layout_selection_changed(self, selection):
         """A different layout was selected"""
+        #reset the layout item to first item when a diff
+        #layout is selected and highlight
+        if self.treestore.get_iter_first():
+            path = Gtk.TreePath.new_from_indices([0])
+            self.treeview.set_cursor(path, None, False)
+
         (listmodel, rowiter) = selection.get_selected()
         if not rowiter:
             # Something is wrong, just jump to the first item in the list
@@ -2136,6 +2142,7 @@ class LayoutEditor:
         command.set_sensitive(False)
         chooser.set_sensitive(False)
         workdir.set_sensitive(False)
+        self.treeview.grab_focus()
 
     def on_layout_item_selection_changed(self, selection):
         """A different item in the layout was selected"""


### PR DESCRIPTION
- KeyError when a single window layout is selected after selecting a multiple tab layouts second terminal as per issue #973 

- ensure that when the layout item is changed the layout sub item also gets reset to first item, else KeyError is thrown as described in bug