### PR TITLE
Searchbar improvements

### DIFF
--- a/terminatorlib/searchbar.py
+++ b/terminatorlib/searchbar.py
@@ -43,6 +43,10 @@ class Searchbar(Gtk.HBox):
 
         self.config = Config()
 
+        if not self.config.base.get_item('case_sensitive'):
+            self.regex_flags_pcre2 |= regex.PCRE2_CASELESS
+            self.regex_flags_glib |= regex.GLIB_CASELESS
+
         self.get_style_context().add_class("terminator-terminal-searchbar")
 
         # Search text
@@ -55,6 +59,8 @@ class Searchbar(Gtk.HBox):
         # Label
         label = Gtk.Label(label=_('Search:'))
         label.show()
+        label.set_margin_start(10)
+        label.set_margin_end(5)
 
         # Close Button
         close = Gtk.Button()
@@ -166,7 +172,10 @@ class Searchbar(Gtk.HBox):
             self.end_search()
         elif (event.state & Gdk.ModifierType.SHIFT_MASK)\
                 and (event.keyval == Gdk.KEY_Return or event.keyval == Gdk.KEY_KP_Enter):
-            self.prev_search(None)
+            if self.search_is_inverted:
+                self.next_search(None)
+            else:
+                self.prev_search(None)
             return True
 
     def start_search(self):


### PR DESCRIPTION
- Fixed a bug where search is always initialized as case-sensitive, even if the "March Case" checkbox is unchecked.
- If search order is inverted, Shift+Enter will now search forward (instead of searching backward, which is the same direction as just pressing Enter).
- While we're at it, add some margin to the "Search:" label to improve how it looks