### PR TITLE
Add Ctrl+Backspace keybind to delete word

### DIFF
--- a/doc/terminator_config.5
+++ b/doc/terminator_config.5
@@ -766,6 +766,13 @@ Reset the terminal state and clear the terminal window.
 Default value: \fB<Ctrl><Shift>G\fP
 .RE
 .sp
+\fBdelete_word\fP
+.RS 4
+Delete the word before the cursor.
+.br
+Default value: \fB<Ctrl>BackSpace\fP
+.RE
+.sp
 \fBzoom_in\fP
 .RS 4
 Increase the font size by one unit.

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -513,6 +513,10 @@ Default value: *<Ctrl><Shift>R*
 Reset the terminal state and clear the terminal window. +
 Default value: *<Ctrl><Shift>G*
 
+*delete_word*::
+Delete the word before the cursor. +
+Default value: *<Ctrl>BackSpace*
+
 *zoom_in*::
 Increase the font size by one unit. +
 Default value: *<Ctrl>plus*

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -179,6 +179,7 @@ DEFAULTS = {
             'full_screen'      : 'F11',
             'reset'            : '<Shift><Control>r',
             'reset_clear'      : '<Shift><Control>g',
+            'delete_word'      : '<Control>BackSpace',
             'hide_window'      : '<Shift><Control><Alt>a',
             'create_group'     : '',
             'group_all'        : '<Super>g',

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -159,6 +159,7 @@ class PrefsEditor:
                         'full_screen'      : _('Toggle fullscreen'),
                         'reset'            : _('Reset the terminal'),
                         'reset_clear'      : _('Reset and clear the terminal'),
+                        'delete_word'      : _('Delete the word before the cursor'),
                         'hide_window'      : _('Toggle window visibility'),
                         'create_group'     : _('Create new group'),
                         'group_all'        : _('Group all terminals'),

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -2031,6 +2031,9 @@ class Terminal(Gtk.VBox):
     def key_reset_clear(self):
         self.vte.reset (True, True)
 
+    def key_delete_word(self):
+        self.feed([27, 127])
+
     def key_create_group(self):
         self.titlebar.create_group()
 


### PR DESCRIPTION
Most users expect Ctrl+Backspace to delete the entire word placed to the left of the cursor. This PR adds a customizable keybind (defaults to Ctrl+Backspace) that does that.