### PR TITLE
Clean up VTE notification-received signal check

### DIFF
--- a/terminatorlib/plugins/command_notify.py
+++ b/terminatorlib/plugins/command_notify.py
@@ -22,12 +22,10 @@ from gi.repository import GObject, GLib, Notify, Vte
 VERSION = '0.1.0'
 
 ### Test for proper signal
-try:
-    Vte.Terminal().connect('notification-received',lambda *args: None,None)
+if GObject.signal_lookup('notification-received', Vte.Terminal):
     AVAILABLE = ['CommandNotify']
-except TypeError as e:
+else:
     AVAILABLE = []
-    pass
 
 class CommandNotify(plugin.Plugin):
     capabilities = ['command_watch']


### PR DESCRIPTION
This prompts a crash with some versions of VTE and Python (see https://gitlab.gnome.org/GNOME/vte/-/issues/2858), and although the crash has been fixed in VTE, VTE's main developer said that creating an instance and connecting to a signal isn't the right way to do this check.  Use the test they recommend instead.

Fixes: #984