### PR TITLE
Fix ConfigBase.get_item() raising KeyError for any falsey default

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -886,7 +886,7 @@ class ConfigBase(Borg):
             dbg('%s found in plugin %s: %s' % (
                     key, plugin, self.plugins[plugin][key]))
             return(self.plugins[plugin][key])
-        elif default:
+        elif default is not None:
             return default
         else:
             raise KeyError('ConfigBase::get_item: unknown key %s' % key)


### PR DESCRIPTION
Currently, running `ConfigBase.get_item()` with any "falsey" default such as `""`, `0`, `False`, etc. will result in a KeyError being raised. This alters the `elif` to specifically check if a value other than `None` is being provided as a default.



Not (currently) in this PR, but it might be worth using a custom sentinel value so `None` could also be used as a default value?