### PR TITLE
fix: handle both string and bytes in feed method for drag-and-drop

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1282,7 +1282,7 @@ class Terminal(Gtk.VBox):
             # Never send a CRLF to the terminal from here
             txt = txt.rstrip('\r\n')
             for term in self.terminator.get_target_terms(self):
-                term.feed(txt.encode())
+                term.feed(txt)
             return
 
         widgetsrc = data.terminator.terminals[int(selection_data.get_data())]
@@ -1715,6 +1715,9 @@ class Terminal(Gtk.VBox):
 
     def feed(self, text):
         """Feed the supplied text to VTE"""
+        # Ensure text is bytes for feed_child
+        if isinstance(text, str):
+            text = text.encode()
         self.vte.feed_child(text)
 
     def zoom_in(self):


### PR DESCRIPTION
## Summary
- Makes the `feed()` method robust to accept both strings and bytes
- Removes double-encoding in drag-and-drop handler
- Fixes AttributeError when dragging files into terminal

## Fixes
Closes #1051

## Changes
1. Modified `feed()` method to check if text is a string and encode it before passing to `vte.feed_child()`
2. Removed `.encode()` call in `on_drag_data_received()` since `feed()` now handles encoding

This resolves the issue where `txt` could be bytes in some cases but the code tried to encode it again, causing an AttributeError.

## Test plan
- Drag a file or folder into Terminator window
- Verify the file path is pasted into the terminal
- Verify no AttributeError occurs
- Test with various file types and paths containing special characters