### PR TITLE
fix: convert enabled string to boolean in custom commands

### DIFF
--- a/terminatorlib/plugins/custom_commands.py
+++ b/terminatorlib/plugins/custom_commands.py
@@ -73,7 +73,9 @@ class CustomCommandsMenu(plugin.MenuItem):
         name = s["name"]
         name_parse = s.get("name_parse", "True")
         command = s["command"]
-        enabled = s["enabled"] and s["enabled"] or False
+        enabled = s.get("enabled", False)
+        if isinstance(enabled, str):
+            enabled = enabled.lower() in ("true", "1", "yes")
         if "position" in s:
           self.cmd_list[int(s["position"])] = {'enabled' : enabled,
                                                'name' : name,


### PR DESCRIPTION
## Summary
- Fixes disabled custom commands appearing in the right-click menu
- Properly converts string 'False'/'True' values to boolean

## Details
The `enabled` flag from config was being stored as a string ('False' or 'True') instead of being converted to boolean. Since non-empty strings are truthy in Python, the expression `s["enabled"] and s["enabled"] or False` would evaluate to the string "False" for disabled commands, causing them to still appear in the menu.

The fix:
1. Uses `s.get("enabled", False)` for safer access
2. Explicitly checks if the value is a string
3. Converts string values ("true", "1", "yes") to boolean True, others to False

## Testing
- Verified the logic handles both string and boolean values correctly
- Disabled commands will now properly evaluate to False and not appear in the menu

Fixes #1047