### PR TITLE
fix: remove unused GObject and Gtk imports with legacy aliases

### DIFF
--- a/terminatorlib/ipc.py
+++ b/terminatorlib/ipc.py
@@ -16,8 +16,6 @@ from .util import dbg, err, enumerate_descendants
 from .terminal import Terminal
 from .container import Container
 from .configjson import ConfigJson
-from gi.repository import Gtk as gtk
-from gi.repository import GObject as gobject
 
 CONFIG = Config()
 if not CONFIG['dbus']:


### PR DESCRIPTION
Fixes #1031

## Summary

This PR resolves the deprecation warning that appears in syslog when right-clicking to open the popup menu:

```
TerminalPopupMenu::show: When using gi.repository you must not import static modules like "gobject". 
Please change all occurrences of "import gobject" to "from gi.repository import GObject".
```

## Changes

Removed two unused import statements from `terminatorlib/ipc.py`:
- `from gi.repository import Gtk as gtk`
- `from gi.repository import GObject as gobject`

These imports were not used anywhere in the file, but the lowercase aliases (`gobject` and `gtk`) triggered PyGI deprecation warnings because they resemble the legacy static module names from PyGTK.

## Root Cause

When the popup menu loads plugins, it imports the `ipc` module, which had these problematic import statements. Even though the aliases weren't used, PyGI's import hook detected them and logged the deprecation warning.

## Testing

Verified that the warning no longer appears after removing the unused imports.