### PR TITLE
fix: convert enabled flag from string to boolean in custom commands

### DIFF
--- a/terminatorlib/plugins/custom_commands.py
+++ b/terminatorlib/plugins/custom_commands.py
@@ -73,7 +73,9 @@ class CustomCommandsMenu(plugin.MenuItem):
         name = s["name"]
         name_parse = s.get("name_parse", "True")
         command = s["command"]
-        enabled = s["enabled"] and s["enabled"] or False
+        enabled = s.get("enabled", "True")
+        if isinstance(enabled, str):
+            enabled = enabled.lower() in ('true', '1', 'yes')
         if "position" in s:
           self.cmd_list[int(s["position"])] = {'enabled' : enabled,
                                                'name' : name,


### PR DESCRIPTION
fixes #1047

the enabled config value is stored as a string but was being used directly as boolean, causing disabled commands to still appear in the right click menu. added proper string to boolean conversion to handle the 'False' string value correctly.