### PR TITLE
Feat: Add keybinding for inserting terminal name

### DIFF
--- a/doc/terminator_config.5
+++ b/doc/terminator_config.5
@@ -823,6 +823,13 @@ Rename the current terminal.
 Default value: \fB<Ctrl><Alt>X\fP
 .RE
 .sp
+\fBinsert_name\fP
+.RS 4
+Insert the current terminal\(cqs name, e.g. user@host:~/pwd.
+.br
+Default value: \fB<Super>2\fP
+.RE
+.sp
 \fBinsert_number\fP
 .RS 4
 Insert the current terminal\(cqs number, i.e. 1 to 12.

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -546,6 +546,10 @@ Default value: *<Ctrl><Alt>A*
 Rename the current terminal. +
 Default value: *<Ctrl><Alt>X*
 
+*insert_name*::
+Insert the current terminal's name, i.e. user@host:~/pwd +
+Default value: *<Super>2*
+
 *insert_number*::
 Insert the current terminal's number, i.e. 1 to 12. +
 Default value: *<Super>1*

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -195,6 +195,7 @@ DEFAULTS = {
             'broadcast_off'    : '',
             'broadcast_group'  : '',
             'broadcast_all'    : '',
+            'insert_name'      : '<Super>2',
             'insert_number'    : '<Super>1',
             'insert_padded'    : '<Super>0',
             'edit_window_title': '<Control><Alt>w',
@@ -202,7 +203,7 @@ DEFAULTS = {
             'edit_terminal_title': '<Control><Alt>x',
             'layout_launcher'  : '<Alt>l',
             'next_profile'     : '',
-            'previous_profile' : '', 
+            'previous_profile' : '',
             'preferences'      : '',
             'preferences_keybindings' : '<Control><Shift>k',
             'help'             : 'F1'

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -175,6 +175,7 @@ class PrefsEditor:
                         'broadcast_off'    : _('Don\'t broadcast key presses'),
                         'broadcast_group'  : _('Broadcast key presses to group'),
                         'broadcast_all'    : _('Broadcast key events to all'),
+                        'insert_name'    : _('Insert terminal name'),
                         'insert_number'    : _('Insert terminal number'),
                         'insert_padded'    : _('Insert zero padded terminal number'),
                         'edit_window_title': _('Edit window title'),

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -2088,6 +2088,9 @@ class Terminal(Gtk.VBox):
         self.set_groupsend(None, self.terminator.groupsend_type['all'])
         self.terminator.focus_changed(self)
 
+    def key_insert_name(self):
+        self.emit('insert-term-name')
+
     def key_insert_number(self):
         self.emit('enumerate', False)
 


### PR DESCRIPTION
Fix #960.

Implement key binding for inserting the terminal name and set Super+2 as the default combination in the configuration. Add documentation.