### PR TITLE
Background blur

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -221,6 +221,7 @@ DEFAULTS = {
                 'background_image_mode' : 'stretch_and_fill',
                 'background_image_align_horiz': 'center',
                 'background_image_align_vert' : 'middle',
+                'background_blur'       : False,
                 'backspace_binding'     : 'ascii-del',
                 'delete_binding'        : 'escape-sequence',
                 'cursor_blink'          : True,

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -3139,6 +3139,23 @@
                             <property name="position">6</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkCheckButton" id="background_blur_checkbutton">
+                            <property name="label" translatable="yes">Blur background (KDE)</property>
+                            <property name="use-action-appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="halign">start</property>
+                            <property name="draw-indicator">True</property>
+                            <signal name="toggled" handler="on_background_blur_checkbutton_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">7</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="position">3</property>

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -3132,28 +3132,27 @@
                                 <property name="position">1</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="background_blur_checkbutton">
+                                <property name="label" translatable="yes">Blur background (KDE)</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="halign">start</property>
+                                <property name="draw-indicator">True</property>
+                                <signal name="toggled" handler="on_background_blur_checkbutton_toggled" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
                             <property name="position">6</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="background_blur_checkbutton">
-                            <property name="label" translatable="yes">Blur background (KDE)</property>
-                            <property name="use-action-appearance">False</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="halign">start</property>
-                            <property name="draw-indicator">True</property>
-                            <signal name="toggled" handler="on_background_blur_checkbutton_toggled" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">7</property>
                           </packing>
                         </child>
                       </object>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -775,7 +775,11 @@ class PrefsEditor:
         # Background shading
         widget = guiget('background_darkness_scale')
         widget.set_value(float(self.config['background_darkness']))
-   
+
+        # Background blur
+        widget = guiget('background_blur_checkbutton')
+        widget.set_active(self.config['background_blur'])
+
         ## Scrolling tab
         # Scrollbar position
         widget = guiget('scrollbar_position_combobox')
@@ -1120,6 +1124,11 @@ class PrefsEditor:
         if value > 1.0:
           value = 1.0
         self.config['background_darkness'] = value
+        self.config.save()
+
+    def on_background_blur_checkbutton_toggled(self, widget):
+        """Background blur setting changed"""
+        self.config['background_blur'] = widget.get_active()
         self.config.save()
 
     def on_palette_combobox_changed(self, widget):
@@ -1758,8 +1767,10 @@ class PrefsEditor:
 
         if backtype in ('transparent', 'image'):
             guiget('darken_background_scale').set_sensitive(True)
+            guiget('background_blur_checkbutton').set_sensitive(True)
         else:
             guiget('darken_background_scale').set_sensitive(False)
+            guiget('background_blur_checkbutton').set_sensitive(False)
 
     def on_profile_selection_changed(self, selection):
         """A different profile was selected"""

--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -507,6 +507,16 @@ class Terminator(Borg):
             if maker.isinstance(child, 'Notebook'):
                 child.configure()
 
+        # Update blur hint on all windows
+        should_blur = False
+        for profile in profiles.values():
+            if (profile.get('background_blur', False) and
+                    profile.get('background_type', 'solid') in ('transparent', 'image')):
+                should_blur = True
+                break
+        for window in self.windows:
+            window.set_blur_behind(should_blur)
+
     def on_css_parsing_error(self, provider, section, error, user_data=None):
         """Report CSS parsing issues"""
         file_path = section.get_file().get_path()

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -128,6 +128,7 @@ class Window(Container, Gtk.Window):
         self.connect('window-state-event', self.on_window_state_changed)
         self.connect('focus-out-event', self.on_focus_out)
         self.connect('focus-in-event', self.on_focus_in)
+        self.connect('realize', self.on_window_realize)
 
         # Attempt to grab a global hotkey for hiding the window.
         # If we fail, we'll never hide the window, iconifying instead.
@@ -394,7 +395,71 @@ class Window(Container, Gtk.Window):
             visual = screen.get_rgba_visual()
             if visual:
                 self.set_visual(visual)
-    
+
+    def on_window_realize(self, widget):
+        """Apply blur hint once the window is realized"""
+        profiles = self.config.base.profiles
+        should_blur = False
+        for profile in profiles.values():
+            if (profile.get('background_blur', False) and
+                    profile.get('background_type', 'solid') in ('transparent', 'image')):
+                should_blur = True
+                break
+        self.set_blur_behind(should_blur)
+
+    def set_blur_behind(self, enable=True):
+        """Set or remove the KDE blur-behind-window hint via X11 property"""
+        if display_manager() != 'X11':
+            return
+        if self.get_window() is None:
+            return
+
+        try:
+            import ctypes
+            import ctypes.util
+
+            libx11_path = ctypes.util.find_library('X11')
+            if not libx11_path:
+                dbg('set_blur_behind: libX11 not found')
+                return
+            libx11 = ctypes.cdll.LoadLibrary(libx11_path)
+
+            # Set explicit argtypes/restype to avoid pointer truncation on 64-bit
+            libx11.XInternAtom.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+            libx11.XInternAtom.restype = ctypes.c_ulong
+
+            libx11.XChangeProperty.argtypes = [
+                ctypes.c_void_p, ctypes.c_ulong, ctypes.c_ulong,
+                ctypes.c_ulong, ctypes.c_int, ctypes.c_int,
+                ctypes.POINTER(ctypes.c_ubyte), ctypes.c_int
+            ]
+            libx11.XChangeProperty.restype = ctypes.c_int
+
+            libx11.XDeleteProperty.argtypes = [ctypes.c_void_p, ctypes.c_ulong, ctypes.c_ulong]
+            libx11.XDeleteProperty.restype = ctypes.c_int
+
+            libx11.XFlush.argtypes = [ctypes.c_void_p]
+            libx11.XFlush.restype = ctypes.c_int
+
+            display = ctypes.c_void_p(GdkX11.x11_get_default_xdisplay())
+            xid = self.get_window().get_xid()
+
+            blur_atom = libx11.XInternAtom(display, b'_KDE_NET_WM_BLUR_BEHIND_REGION', 0)
+            cardinal_atom = libx11.XInternAtom(display, b'CARDINAL', 0)
+
+            if enable:
+                data = (ctypes.c_ubyte * 4)(0, 0, 0, 0)
+                libx11.XChangeProperty(display, xid, blur_atom, cardinal_atom,
+                                       32, 0, data, 1)
+                dbg('set_blur_behind: enabled blur hint on window %s' % xid)
+            else:
+                libx11.XDeleteProperty(display, xid, blur_atom)
+                dbg('set_blur_behind: removed blur hint from window %s' % xid)
+
+            libx11.XFlush(display)
+        except Exception as e:
+            dbg('set_blur_behind: failed: %s' % e)
+
     def show(self, startup=False):
         """Undo the startup show request if started in hidden mode"""
         #Present is necessary to grab focus when window is hidden from taskbar.

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -441,7 +441,7 @@ class Window(Container, Gtk.Window):
             libx11.XFlush.argtypes = [ctypes.c_void_p]
             libx11.XFlush.restype = ctypes.c_int
 
-            display = ctypes.c_void_p(GdkX11.x11_get_default_xdisplay())
+            display = ctypes.c_void_p(hash(GdkX11.x11_get_default_xdisplay()))
             xid = self.get_window().get_xid()
 
             blur_atom = libx11.XInternAtom(display, b'_KDE_NET_WM_BLUR_BEHIND_REGION', 0)


### PR DESCRIPTION
## Summary

Adds a `background_blur` profile option that requests KDE KWin to blur the content behind transparent Terminator windows, creating a frosted-glass effect.

When `background_blur = True` and `background_type` is `transparent` or `image`, Terminator sets the `_KDE_NET_WM_BLUR_BEHIND_REGION` X11 window property via ctypes/libX11. KWin reads this property and applies its blur desktop effect behind the window.

Addresses Issue #116, but only for KDE.

### Changes

- **config.py**: Added `background_blur: False` to profile defaults
- **window.py**: Added `set_blur_behind()` method (ctypes X11 property) and `on_window_realize` signal to apply on startup
- **terminator.py**: Wired blur into the reconfigure cycle so toggling the preference takes effect immediately
- **prefseditor.py**: Added checkbox init, callback, and sensitivity logic
- **preferences.glade**: Added "Blur background (KDE)" checkbox in the Background tab

### Scope

- **KDE KWin on X11**: Full support via window property hint
- **Picom/other X11 compositors**: Property is safely ignored; users configure blur on the compositor side
- **Wayland**: Not implemented
- **GNOME/Mutter**: No per-window blur support in this compositor
- Default off, zero-cost when disabled, fails silently on unsupported setups

### Config example

```ini
[profiles]
  [[default]]
    background_type = transparent
    background_darkness = 0.8
    background_blur = True
```

### Testing

Tested on KDE Plasma / X11 with KWin blur desktop effect enabled. Verify with:

```bash
xprop -name Terminator | grep BLUR
# Should show: _KDE_NET_WM_BLUR_BEHIND_REGION(CARDINAL) = 0
```
