### PR TITLE
Fix keypress focus check for non-window toplevels

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -986,7 +986,8 @@ class Terminal(Gtk.VBox):
         #         maybe we can emit the key event and let Terminator() care?
         groupsend = self.terminator.groupsend
         groupsend_type = self.terminator.groupsend_type
-        window_focussed = self.vte.get_toplevel().get_property('has-toplevel-focus')
+        toplevel = self.vte.get_toplevel()
+        window_focussed = isinstance(toplevel, Gtk.Window) and toplevel.get_property('has-toplevel-focus')
         if groupsend != groupsend_type['off'] and window_focussed and self.vte.is_focus():
             if self.group and groupsend == groupsend_type['group']:
                 self.terminator.group_emit(self, self.group, 'key-press-event',


### PR DESCRIPTION
This PR is aimed at fixing an issue when trying to maximize a pane which was part of a group with more than one pane.
This change makes `on_keypress()` safer by only checking `has-toplevel-focus` when `self.vte.get_toplevel()` is actually a `Gtk.Window`. That avoids errors in case where the VTE toplevel is not the expected window type, while preserving the existing group-send behavior when focus is valid.