### PR TITLE
Pass terminal to URLHandler plugins

### DIFF
--- a/terminatorlib/plugin.py
+++ b/terminatorlib/plugin.py
@@ -175,8 +175,13 @@ class URLHandler(Plugin):
         for terminal in terminator.terminals:
             terminal.match_add(self.handler_name, self.match)
 
-    def callback(self, url):
-        """Callback to transform the enclosed URL"""
+    def callback(self, url, terminal=None):
+        """Callback to transform the enclosed URL
+
+        Args:
+            url: The matched URL string
+            terminal: Optional Terminal instance where the match occurred
+        """
         raise NotImplementedError
 
     def unload(self):

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1656,7 +1656,10 @@ class Terminal(Gtk.VBox):
 
                 for urlplugin in plugins:
                     if match == self.matches[urlplugin.handler_name]:
-                        newurl = urlplugin.callback(url, terminal=self)
+                        try:
+                            newurl = urlplugin.callback(url, terminal=self)
+                        except TypeError:
+                            newurl = urlplugin.callback(url)
                         if newurl: # If the plugin returns None, it's a false match.
                             dbg('URL prepared by %s plugin' \
                                     % urlplugin.handler_name)

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1656,7 +1656,7 @@ class Terminal(Gtk.VBox):
 
                 for urlplugin in plugins:
                     if match == self.matches[urlplugin.handler_name]:
-                        newurl = urlplugin.callback(url)
+                        newurl = urlplugin.callback(url, terminal=self)
                         if newurl: # If the plugin returns None, it's a false match.
                             dbg('URL prepared by %s plugin' \
                                     % urlplugin.handler_name)


### PR DESCRIPTION
Adds a new optional parameter to URLHandler's callback

This is so we can get the cwd where the match occurred