### PR TITLE
Add plugin to resolve commit hashes to URLs

### DIFF
--- a/terminatorlib/plugins/resolve_hash.py
+++ b/terminatorlib/plugins/resolve_hash.py
@@ -1,0 +1,30 @@
+from terminatorlib.plugin import URLHandler
+
+from resolvehash.resolvehash import parse_config, find_hash
+
+AVAILABLE = ["ResolveHashURLHandler"]
+
+
+class ResolveHashURLHandler(URLHandler):
+    capabilities = ["url_handler"]
+    handler_name = "resolve_hash"
+    name = "Nasqueron Resolve Hash"
+
+    # Long enough hexadecimal expressions are good hash candidates
+    match = r"\b[0-9a-f]{7,40}\b"
+
+    def __init__(self):
+        URLHandler.__init__(self)
+        self.config = parse_config()
+
+    def callback(self, needle_hash):
+        try:
+            final_url = find_hash(self.config, needle_hash)
+
+            if final_url.startswith("http"):
+                return final_url
+
+        except Exception:
+            pass
+
+        return None


### PR DESCRIPTION
Summary

This PR adds a plugin that makes commit hashes clickable in Terminator by resolving them to their corresponding URLs.

Details

- detects hash-like hexadecimal strings in terminal output
- resolves them using the configured resolver
- opens the matching URL when available