### PR TITLE
Preferences freeze for 3-4 seconds when opened with TypeError in keybinding filter

### DIFF
--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -461,7 +461,7 @@ class PrefsEditor:
         #lets hide whatever we can in nested scope
         def filter_visible(model, treeiter, data):
             act  = model[treeiter][0]
-            keys = data[act] if act in data else ""
+            keys = data.get(act) or ""
             desc = model[treeiter][1]
             kval = model[treeiter][2]
             mask = model[treeiter][3]


### PR DESCRIPTION
### Steps to reproduce

1. Run Terminator
2. Right-click in the terminal → Preferences
3. UI freezes for ~3-4 seconds before showing the Preferences window

### Observed behavior

The Preferences window takes 3-4 seconds to appear. The following error is logged to syslog:
```
terminator.desktop: TypeError: object of type 'NoneType' has no len()
```

### Root cause

In `terminatorlib/prefseditor.py:filter_visible()`, when a keybinding exists in the merged config dict but its value is None (which happens when a plugin registers a keybinding and the main config overrides it with an unbound/null value), data[act] returns None. The code then calls len(None), raising TypeError.
GTK's TreeModelFilter likely swallows the exception but the overhead of repeatedly hitting this error for every row causes the multi-second freeze.

### Fix

Changed data[act] if act in data else "" → data.get(act) or "", ensuring keys is always a string regardless of whether the dict value is None, missing, or empty.