### PR TITLE
Add session save and restore menu actions

### DIFF
--- a/terminatorlib/terminal_popup_menu.py
+++ b/terminatorlib/terminal_popup_menu.py
@@ -7,7 +7,7 @@ from gi.repository import Gtk, Gdk
 
 from .version import APP_NAME
 from .translation import _
-from .terminator import Terminator
+from .terminator import LAST_SESSION_LAYOUT, Terminator
 from .util import err, dbg, spawn_new_terminator
 from .config import Config
 from .prefseditor import PrefsEditor
@@ -337,6 +337,7 @@ class TerminalPopupMenu(object):
                 item.connect('activate', terminal.force_set_profile, profile)
                 submenu.append(item)
 
+        self.add_session_menu(menu, terminal)
         self.add_layout_launcher(menu)
 
         try:
@@ -420,6 +421,24 @@ class TerminalPopupMenu(object):
         item.set_submenu(submenu)
         layouts = self.config.list_layouts()
         for layout in layouts:
+                if layout == LAST_SESSION_LAYOUT:
+                    continue
                 item = Gtk.MenuItem(layout)
                 item.connect('activate', lambda x: spawn_new_terminator(self.terminator.origcwd, ['-u', '-l', x.get_label()]))
                 submenu.append(item)
+
+    def add_session_menu(self, menu, terminal):
+        """Add session save and restore actions to the menu."""
+        item = Gtk.MenuItem.new_with_mnemonic(_('_Session'))
+        menu.append(item)
+        submenu = Gtk.Menu()
+        item.set_submenu(submenu)
+
+        item = Gtk.MenuItem.new_with_mnemonic(_('_Save session'))
+        item.connect('activate', self.terminator.save_session_layout)
+        submenu.append(item)
+
+        item = Gtk.MenuItem.new_with_mnemonic(_('_Restore session'))
+        item.connect('activate', self.terminator.restore_session_layout,
+                     terminal.get_toplevel())
+        submenu.append(item)

--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -19,6 +19,8 @@ from .util import dbg, err, enumerate_descendants
 from .factory import Factory
 from .translation import _
 
+LAST_SESSION_LAYOUT = '__last_session__'
+
 try:
     from gi.repository import GdkX11
 except ImportError:
@@ -116,6 +118,37 @@ class Terminator(Borg):
         if dbus_service:
             self.dbus_name = dbus_service.bus_name.get_name()
             self.dbus_path = dbus_service.bus_path
+
+    def save_session_layout(self, *args):
+        """Persist the current layout, including each terminal cwd."""
+        if self.doing_layout:
+            return
+
+        layout = self.describe_layout(save_cwd=True)
+        if not layout:
+            return
+
+        if not self.config.replace_layout(LAST_SESSION_LAYOUT, layout):
+            self.config.add_layout(LAST_SESSION_LAYOUT, layout)
+        self.config.save()
+
+    def restore_session_layout(self, _widget=None, window=None):
+        """Replace a window with the saved session layout."""
+        if LAST_SESSION_LAYOUT not in self.config.list_layouts():
+            err('no saved session layout found')
+            return
+
+        old_window = window if window in self.windows else None
+
+        try:
+            self.create_layout(LAST_SESSION_LAYOUT)
+            self.layout_done()
+        except (KeyError, ValueError) as ex:
+            err('session layout restore failed: %s' % ex)
+            return
+
+        if old_window:
+            old_window.destroy()
 
     def get_windows(self):
         """Return a list of windows"""


### PR DESCRIPTION
## Summary
Add terminal context menu actions for saving and restoring a lightweight session layout.
This introduces a new `Session` submenu in the terminal popup menu with:
- `Save session`
- `Restore session`

Saving persists the current Terminator layout using the existing layout serialization path, including each terminal’s current working directory. Restoring loads the saved session layout in the current process and replaces the window where restore was requested.

## Scope
This restores :
- windows/panes/tabs layout
- working directories

## Implementation Notes
- Saves the session as a reserved layout named `__last_session__`.
- Hides `__last_session__` from the normal Layouts submenu.
- Restoring creates the saved layout, then destroys the initiating window so the session replaces the current window rather than opening an extra one.

## Testing
- `python -m py_compile terminatorlib/terminator.py terminatorlib/terminal_popup_menu.py`
- `pytest -q terminatorlib/borg.py terminatorlib/config.py terminatorlib/cwd.py terminatorlib/factory.py terminatorlib/util.py tests/test_borg.py tests/test_signalman.py`