### PR TITLE
tests: fix accelerator_parse hash mismatch on Python 3.14

### DIFF
--- a/tests/test_prefseditor_keybindings.py
+++ b/tests/test_prefseditor_keybindings.py
@@ -56,7 +56,7 @@ def test_non_empty_default_keybinding_accels_are_distinct():
     from terminatorlib import config
 
     all_default_accelerators = [
-        Gtk.accelerator_parse(accel)
+        tuple(Gtk.accelerator_parse(accel))
         for accel in config.DEFAULTS["keybindings"].values()
         if accel != ""  # ignore empty key bindings
     ]
@@ -156,7 +156,7 @@ def test_duplicate_accels_not_possible_to_set(accel_params):
     binding = liststore.get_value(liststore.get_iter(path), 0)
 
     all_default_accelerators = {
-        Gtk.accelerator_parse(accel)
+        tuple(Gtk.accelerator_parse(accel))
         for accel in config.DEFAULTS["keybindings"].values()
         if accel != ""  # ignore empty key bindings
     }


### PR DESCRIPTION
## Summary

Fixes #1089

`Gtk.accelerator_parse()` returns a `gi._gi.ResultTuple`, a subclass of `tuple` that has `__hash__` hardcoded to `0`. Plain Python tuples use content-based hashing.

This breaks set membership checks in two tests:

```python
all_default_accelerators = {
    Gtk.accelerator_parse(accel)   # ResultTuple, hash=0
    ...
}
assert (key, mods) in all_default_accelerators  # plain tuple, hash≠0 → always False
```

Even though `ResultTuple == plain_tuple` returns `True`, Python set lookup first checks the hash bucket. Since `hash(plain_tuple) != 0` in general, the element is never found.

## Fix

Wrap `Gtk.accelerator_parse()` with `tuple()` in both affected set/list comprehensions so all objects share the same hash implementation:

```python
all_default_accelerators = {
    tuple(Gtk.accelerator_parse(accel))
    ...
}
```

## Affected tests

- `test_non_empty_default_keybinding_accels_are_distinct`
- `test_duplicate_accels_not_possible_to_set`