### PR TITLE
Add mod4 key binding to keybindings.py

### DIFF
--- a/terminatorlib/keybindings.py
+++ b/terminatorlib/keybindings.py
@@ -41,7 +41,8 @@ class Keybindings:
         'super':    Gdk.ModifierType.SUPER_MASK,
         'hyper':    Gdk.ModifierType.HYPER_MASK,
         'cmd':      Gdk.ModifierType.META_MASK,
-        'mod2':	    Gdk.ModifierType.MOD2_MASK
+        'mod2':	    Gdk.ModifierType.MOD2_MASK,
+        'mod4':     Gdk.ModifierType.MOD4_MASK,
     }
 
     empty = {}


### PR DESCRIPTION
quick addition to keybindings.py  for working around this issue https://github.com/gnome-terminator/terminator/issues/1008

it looks like super key in wayland has changed is keycode, it's now recognize has mod4 in gtk lib

this quick patch does not fix setting preference with the gui, but at least you can set your keybinding in the config file and it works

```
 next_tab = <Primary><mod4>semicolon
 prev_tab = <Primary><mod4>comma
```