### PR TITLE
Add window decoration style setting (Dark/Light/Auto)

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -121,6 +121,7 @@ DEFAULTS = {
             'detachable_tabs'       : True,
 
             'new_tab_after_current_tab': False,
+            'window_decoration_style': 'auto',
         },
         'keybindings': {
             'zoom_in'          : '<Control>plus',

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -349,6 +349,23 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="WindowDecorationStyleListStore">
+    <columns>
+      <!-- column-name variant -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Dark</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Light</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Auto</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkListStore" id="WindowStateListStore">
     <columns>
       <!-- column-name state -->
@@ -1011,7 +1028,7 @@
                             <property name="spacing">36</property>
                             <property name="homogeneous">True</property>
                             <child>
-                              <!-- n-columns=3 n-rows=7 -->
+                              <!-- n-columns=3 n-rows=8 -->
                               <object class="GtkGrid" id="grid3">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1279,6 +1296,38 @@
                                   <packing>
                                     <property name="left-attach">2</property>
                                     <property name="top-attach">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="window_decoration_style_label">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Window decoration style:</property>
+                                    <property name="xalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">7</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBox" id="window_decoration_style_combo">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="model">WindowDecorationStyleListStore</property>
+                                    <property name="active">0</property>
+                                    <signal name="changed" handler="on_window_decoration_style_combo_changed" swapped="no"/>
+                                    <child>
+                                      <object class="GtkCellRendererText" id="cellrenderertext_window_decoration_style"/>
+                                      <attributes>
+                                        <attribute name="text">0</attribute>
+                                      </attributes>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">7</property>
                                   </packing>
                                 </child>
                               </object>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -327,6 +327,16 @@ class PrefsEditor:
         # Extra styling
         widget = guiget('extrastylingcheck')
         widget.set_active(self.config['extra_styling'])
+        # Window decoration style
+        option = self.config['window_decoration_style']
+        widget = guiget('window_decoration_style_combo')
+        if option == 'light':
+            active = 1
+        elif option == 'auto':
+            active = 2
+        else:
+            active = 0
+        widget.set_active(active)
         # Tab bar position
         option = self.config['tab_position']
         widget = guiget('tabposcombo')
@@ -900,6 +910,21 @@ class PrefsEditor:
         """Extra styling setting changed"""
         self.config['extra_styling'] = widget.get_active()
         self.config.save()
+
+    def on_window_decoration_style_combo_changed(self, widget):
+        """Window decoration style changed"""
+        selected = widget.get_active()
+        if selected == 1:
+            value = 'light'
+        elif selected == 2:
+            value = 'auto'
+        else:
+            value = 'dark'
+        self.config['window_decoration_style'] = value
+        self.config.save()
+        terminator = Terminator()
+        for window in terminator.windows:
+            window.apply_window_decoration_style(value)
 
     def on_hidefromtaskbcheck_toggled(self, widget):
         """Hide from taskbar setting changed"""
@@ -1914,6 +1939,8 @@ class PrefsEditor:
             self.config['foreground_color'] = forecol
             self.config['background_color'] = backcol
         self.config.save()
+        terminator = Terminator()
+        terminator.reconfigure()
 
     def on_use_theme_colors_checkbutton_toggled(self, widget):
         """Update colour pickers"""

--- a/terminatorlib/terminator.py
+++ b/terminatorlib/terminator.py
@@ -517,6 +517,11 @@ class Terminator(Borg):
         for window in self.windows:
             window.set_blur_behind(should_blur)
 
+        # Update window decoration style (handles 'auto' mode)
+        decoration_style = self.config['window_decoration_style']
+        for window in self.windows:
+            window.apply_window_decoration_style(decoration_style)
+
     def on_css_parsing_error(self, provider, section, error, user_data=None):
         """Report CSS parsing issues"""
         file_path = section.get_file().get_path()

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -174,6 +174,7 @@ class Window(Container, Gtk.Window):
         self.set_always_on_top(alwaysontop)
         self.set_real_transparency()
         self.set_sticky(sticky)
+        self.apply_window_decoration_style(self.config['window_decoration_style'])
         if self.hidebound:
             self.set_hidden(hidden)
             self.set_skip_taskbar_hint(skiptaskbar)
@@ -384,6 +385,95 @@ class Window(Container, Gtk.Window):
         if value == True:
             self.stick()
 
+    def apply_window_decoration_style(self, style):
+        """Set the window decoration to dark or light theme variant"""
+        if style == 'auto':
+            style = self._detect_decoration_style()
+        settings = Gtk.Settings.get_default()
+        settings.set_property("gtk-application-prefer-dark-theme",
+                              style == 'dark')
+        current_theme = settings.get_property("gtk-theme-name")
+        if style == 'dark':
+            if not current_theme.endswith('-dark'):
+                dark_theme = current_theme + '-dark'
+                if self._theme_exists(dark_theme):
+                    settings.set_property("gtk-theme-name", dark_theme)
+        else:
+            if current_theme.endswith('-dark'):
+                light_theme = current_theme[:-5]
+                if self._theme_exists(light_theme):
+                    settings.set_property("gtk-theme-name", light_theme)
+        self._set_theme_variant_x11(style)
+
+    def _detect_decoration_style(self):
+        """Detect dark or light based on terminal background color luminance"""
+        bg_color = self.config['background_color']
+        try:
+            bg_color = bg_color.lstrip('#')
+            r = int(bg_color[0:2], 16) / 255.0
+            g = int(bg_color[2:4], 16) / 255.0
+            b = int(bg_color[4:6], 16) / 255.0
+            luminance = 0.299 * r + 0.587 * g + 0.114 * b
+            return 'light' if luminance >= 0.5 else 'dark'
+        except (ValueError, IndexError):
+            return 'dark'
+
+    def _theme_exists(self, theme_name):
+        """Check if a GTK theme exists on the system"""
+        import os
+        search_dirs = [
+            os.path.join(os.path.expanduser('~'), '.local', 'share', 'themes'),
+            os.path.join(os.path.expanduser('~'), '.themes'),
+            '/usr/share/themes',
+            '/usr/local/share/themes',
+        ]
+        for d in search_dirs:
+            if os.path.isdir(os.path.join(d, theme_name)):
+                return True
+        return False
+
+    def _set_theme_variant_x11(self, variant):
+        """Set _GTK_THEME_VARIANT X11 property for WM-drawn titlebar"""
+        if display_manager() != 'X11':
+            return
+        if self.get_window() is None:
+            return
+
+        try:
+            import ctypes
+            import ctypes.util
+
+            libx11_path = ctypes.util.find_library('X11')
+            if not libx11_path:
+                return
+            libx11 = ctypes.cdll.LoadLibrary(libx11_path)
+
+            libx11.XInternAtom.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+            libx11.XInternAtom.restype = ctypes.c_ulong
+
+            libx11.XChangeProperty.argtypes = [
+                ctypes.c_void_p, ctypes.c_ulong, ctypes.c_ulong,
+                ctypes.c_ulong, ctypes.c_int, ctypes.c_int,
+                ctypes.c_char_p, ctypes.c_int
+            ]
+            libx11.XChangeProperty.restype = ctypes.c_int
+
+            libx11.XFlush.argtypes = [ctypes.c_void_p]
+            libx11.XFlush.restype = ctypes.c_int
+
+            display = ctypes.c_void_p(hash(GdkX11.x11_get_default_xdisplay()))
+            xid = self.get_window().get_xid()
+
+            variant_atom = libx11.XInternAtom(display, b'_GTK_THEME_VARIANT', 0)
+            utf8_atom = libx11.XInternAtom(display, b'UTF8_STRING', 0)
+
+            variant_bytes = variant.encode('utf-8')
+            libx11.XChangeProperty(display, xid, variant_atom, utf8_atom,
+                                   8, 0, variant_bytes, len(variant_bytes))
+            libx11.XFlush(display)
+        except Exception as e:
+            dbg('_set_theme_variant_x11: failed: %s' % e)
+
     def set_real_transparency(self, value=True):
         """Enable RGBA if supported on the current screen"""
         if self.is_composited() == False:
@@ -397,7 +487,7 @@ class Window(Container, Gtk.Window):
                 self.set_visual(visual)
 
     def on_window_realize(self, widget):
-        """Apply blur hint once the window is realized"""
+        """Apply window hints once the window is realized"""
         profiles = self.config.base.profiles
         should_blur = False
         for profile in profiles.values():
@@ -406,6 +496,7 @@ class Window(Container, Gtk.Window):
                 should_blur = True
                 break
         self.set_blur_behind(should_blur)
+        self._set_theme_variant_x11(self.config['window_decoration_style'])
 
     def set_blur_behind(self, enable=True):
         """Set or remove the KDE blur-behind-window hint via X11 property"""


### PR DESCRIPTION
## Summary

On Ubuntu with a Light system theme, the window titlebar (decoration) is white while Terminator's terminal background is dark, creating a visual mismatch. This PR adds a configurable window decoration style setting to control the titlebar appearance.

## Changes

- Added `window_decoration_style` option to global config (Preferences → Global → "Window decoration style")
- Three modes available:
  - **Dark** – Forces dark window decoration
  - **Light** – Forces light window decoration
  - **Auto** (default) – Automatically selects dark or light based on the terminal background color luminance
- Auto mode reacts in real-time when the background color is changed via Preferences
- On X11, sets `_GTK_THEME_VARIANT` window property for WM-drawn titlebar
- On Wayland, switches GTK theme name to its dark/light variant (e.g. `Yaru-blue` ↔ `Yaru-blue-dark`)

## Files Modified

- `terminatorlib/config.py` – Added `window_decoration_style` to global config defaults
- `terminatorlib/window.py` – Added `apply_window_decoration_style()`, auto-detection logic, and X11 property support
- `terminatorlib/prefseditor.py` – Added combo box handler and linked color scheme changes to reconfigure
- `terminatorlib/preferences.glade` – Added UI controls (label + combo box + list store)
- `terminatorlib/terminator.py` – Added decoration style update in `reconfigure()` for auto mode reactivity

## Note

The config key is named `window_decoration_style` (not `titlebar_*`) to distinguish from Terminator's internal per-terminal titlebar.