### PR TITLE
Fix whole-app crash when dragging a tab out of a window; add explicit Detach Tab action

### DIFF
--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -207,7 +207,8 @@ DEFAULTS = {
             'previous_profile' : '', 
             'preferences'      : '',
             'preferences_keybindings' : '<Control><Shift>k',
-            'help'             : 'F1'
+            'help'             : 'F1',
+            'detach_tab'       : '<Shift><Control>d'
         },
         'profiles': {
             'default':  {

--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -80,12 +80,7 @@ class Notebook(Container, Gtk.Notebook):
         self.last_active_term = {}
 
     def create_window_detach(self, notebook, widget, x, y):
-        """A tab has been dropped outside any tab bar. GTK emits this
-        signal in the middle of its drag-and-drop bookkeeping; removing
-        the page here (and potentially dissolving this notebook via
-        hoover) leaves GTK dereferencing freed drag state afterwards,
-        crashing the whole process (issue #1022). Defer the detach until
-        the drag has fully ended."""
+        """Defer detaching a dropped tab until the drag has ended (#1022)"""
         dbg('deferring detach of dropped tab: %s' % widget)
         GObject.idle_add(self.detach_tab_to_new_window, widget, x, y)
 
@@ -113,9 +108,7 @@ class Notebook(Container, Gtk.Notebook):
         return False
 
     def on_tab_drag_failed(self, notebook, context, result):
-        """After a failed tab drag, force a re-allocation: under Wayland
-        the restored tab label is sometimes not redrawn until the next
-        mouse-over (GTK issue #3143)"""
+        """Re-allocate after a failed tab drag so the label repaints (GTK#3143)"""
         GObject.idle_add(self.queue_resize)
         return False
 

--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -80,7 +80,7 @@ class Notebook(Container, Gtk.Notebook):
         self.last_active_term = {}
 
     def create_window_detach(self, notebook, widget, x, y):
-        """Defer detaching a dropped tab until the drag has ended (#1022)"""
+        """Defer detaching a dropped tab until the drag has ended"""
         dbg('deferring detach of dropped tab: %s' % widget)
         GObject.idle_add(self.detach_tab_to_new_window, widget, x, y)
 
@@ -108,7 +108,7 @@ class Notebook(Container, Gtk.Notebook):
         return False
 
     def on_tab_drag_failed(self, notebook, context, result):
-        """Re-allocate after a failed tab drag so the label repaints (GTK#3143)"""
+        """Re-allocate after a failed tab drag so the label repaints"""
         GObject.idle_add(self.queue_resize)
         return False
 

--- a/terminatorlib/notebook.py
+++ b/terminatorlib/notebook.py
@@ -38,6 +38,7 @@ class Notebook(Container, Gtk.Notebook):
         self.connect('switch-page', self.deferred_on_tab_switch)
         self.connect('scroll-event', self.on_scroll_event)
         self.connect('create-window', self.create_window_detach)
+        self.connect_after('drag-failed', self.on_tab_drag_failed)
         self.configure()
 
         self.set_can_focus(False)
@@ -79,21 +80,44 @@ class Notebook(Container, Gtk.Notebook):
         self.last_active_term = {}
 
     def create_window_detach(self, notebook, widget, x, y):
-        """Create a window to contain a detached tab"""
-        dbg('creating window for detached tab: %s' % widget)
-        maker = Factory()
+        """A tab has been dropped outside any tab bar. GTK emits this
+        signal in the middle of its drag-and-drop bookkeeping; removing
+        the page here (and potentially dissolving this notebook via
+        hoover) leaves GTK dereferencing freed drag state afterwards,
+        crashing the whole process (issue #1022). Defer the detach until
+        the drag has fully ended."""
+        dbg('deferring detach of dropped tab: %s' % widget)
+        GObject.idle_add(self.detach_tab_to_new_window, widget, x, y)
 
+    def detach_tab_to_new_window(self, widget, x=None, y=None):
+        """Detach the tab containing widget into a newly created window"""
+        child = self.find_tab_root(widget)
+        if self.page_num(child) == -1:
+            err('could not find tab to detach for %s' % widget)
+            return False
+
+        dbg('detaching tab into new window: %s' % child)
+        maker = Factory()
         window = maker.make('Window')
-        window.move(x, y)
+        if x is not None and y is not None:
+            window.move(x, y)
         size = self.window.get_size()
         window.resize(size.width, size.height)
 
-        self.detach_tab(widget)
-        self.disconnect_child(widget)
+        self.detach_tab(child)
+        self.disconnect_child(child)
         self.hoover()
-        window.add(widget)
+        window.add(child)
 
         window.show_all()
+        return False
+
+    def on_tab_drag_failed(self, notebook, context, result):
+        """After a failed tab drag, force a re-allocation: under Wayland
+        the restored tab label is sometimes not redrawn until the next
+        mouse-over (GTK issue #3143)"""
+        GObject.idle_add(self.queue_resize)
+        return False
 
     def create_layout(self, layout):
         """Apply layout configuration"""
@@ -290,6 +314,7 @@ class Notebook(Container, Gtk.Notebook):
                    'group-tab-toggle': top_window.group_tab_toggle,
                    'ungroup-tab': top_window.ungroup_tab,
                    'move-tab': top_window.move_tab,
+                   'detach-tab': top_window.detach_tab_to_new_window,
                    'tab-new': [top_window.tab_new, widget],
                    'navigate': top_window.navigate_terminal,
                    'zoom': top_window.zoom,

--- a/terminatorlib/paned.py
+++ b/terminatorlib/paned.py
@@ -111,6 +111,7 @@ class Paned(Container):
                     'group-tab-toggle': top_window.group_tab_toggle,
                     'ungroup-tab': top_window.ungroup_tab,
                     'move-tab': top_window.move_tab,
+                    'detach-tab': top_window.detach_tab_to_new_window,
                     'maximise': [top_window.zoom, False],
                     'tab-new': [top_window.tab_new, widget],
                     'navigate': top_window.navigate_terminal,

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -143,6 +143,7 @@ class PrefsEditor:
                         'resize_right'     : _('Resize the terminal right'),
                         'move_tab_right'   : _('Move the tab right'),
                         'move_tab_left'    : _('Move the tab left'),
+                        'detach_tab'       : _('Detach the tab into a new window'),
                         'toggle_zoom'      : _('Maximize terminal'),
                         'scaled_zoom'      : _('Zoom terminal'),
                         'next_tab'         : _('Switch to the next tab'),

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -74,6 +74,7 @@ class Terminal(Gtk.VBox):
         'group-all-toggle': (GObject.SignalFlags.RUN_LAST, None, ()),
         'move-tab': (GObject.SignalFlags.RUN_LAST, None,
             (GObject.TYPE_STRING,)),
+        'detach-tab': (GObject.SignalFlags.RUN_LAST, None, ()),
         'group-win': (GObject.SignalFlags.RUN_LAST, None, ()),
         'group-win-toggle': (GObject.SignalFlags.RUN_LAST, None, ()),
         'ungroup-win': (GObject.SignalFlags.RUN_LAST, None, ()),
@@ -2087,6 +2088,9 @@ class Terminal(Gtk.VBox):
 
     def key_move_tab_left(self):
         self.emit('move-tab', 'left')
+
+    def key_detach_tab(self):
+        self.emit('detach-tab')
 
     def key_toggle_zoom(self):
         if self.is_zoomed():

--- a/terminatorlib/terminal_popup_menu.py
+++ b/terminatorlib/terminal_popup_menu.py
@@ -221,6 +221,13 @@ class TerminalPopupMenu(object):
                         terminal.emit('tab-new', True, terminal))
                 menu.append(item)
 
+            if isinstance(terminal.get_toplevel().get_child(), Gtk.Notebook):
+                item = self.menu_item(Gtk.MenuItem, 'detach_tab',
+                                                    _('Detach Ta_b'))
+                item.connect('activate', lambda x:
+                        terminal.emit('detach-tab'))
+                menu.append(item)
+
             menu.append(Gtk.SeparatorMenuItem())
 
         item = self.menu_item(Gtk.ImageMenuItem, 'close_term', _('_Close'))

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -588,6 +588,7 @@ class Window(Container, Gtk.Window):
                        'group-tab-toggle': self.group_tab_toggle,
                        'ungroup-tab': self.ungroup_tab,
                        'move-tab': self.move_tab,
+                       'detach-tab': self.detach_tab_to_new_window,
                        'tab-new': [self.tab_new, widget],
                        'navigate': self.navigate_terminal,
                        'rotate-cw': [self.rotate, True],
@@ -1034,6 +1035,21 @@ class Window(Container, Gtk.Window):
             return
         
         notebook.reorder_child(child, page)
+
+    def detach_tab_to_new_window(self, widget):
+        """Handle a request to detach the tab containing widget into a
+        new window"""
+        if self.is_zoomed():
+            self.unzoom()
+
+        maker = Factory()
+        notebook = self.get_child()
+
+        if not maker.isinstance(notebook, 'Notebook'):
+            dbg('not in a notebook, refusing to detach tab')
+            return
+
+        notebook.detach_tab_to_new_window(widget)
 
     def navigate_terminal(self, terminal, direction):
         """Navigate around terminals"""

--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -1037,8 +1037,7 @@ class Window(Container, Gtk.Window):
         notebook.reorder_child(child, page)
 
     def detach_tab_to_new_window(self, widget):
-        """Handle a request to detach the tab containing widget into a
-        new window"""
+        """Detach the tab containing widget into a new window"""
         if self.is_zoomed():
             self.unzoom()
 

--- a/tests/test_prefseditor_keybindings.py
+++ b/tests/test_prefseditor_keybindings.py
@@ -68,17 +68,17 @@ def test_non_empty_default_keybinding_accels_are_distinct():
     "accel_params,expected",
     [
         # 1) 'edit_tab_title' Ctrl+Alt+A
-        (("9", 97, CONTROL_ALT_MOD, 38), False,),
+        (("10", 97, CONTROL_ALT_MOD, 38), False,),
         # 2) 'edit_terminal_title' Ctrl+Alt+A
-        (("10", 97, CONTROL_ALT_MOD, 38), True,),
+        (("11", 97, CONTROL_ALT_MOD, 38), True,),
         # 3) 'edit_window_title' F11
-        (("11", 65480, Gdk.ModifierType(0), 95), True,),
+        (("12", 65480, Gdk.ModifierType(0), 95), True,),
         # 4) 'zoom_in' Shift+Ctrl+Z
-        (("70", 122, CONTROL_SHIFT_MOD, 52), True,),
+        (("71", 122, CONTROL_SHIFT_MOD, 52), True,),
         # 5) 'close_terminal' Ctrl+Alt+{
         (("3", 123, CONTROL_ALT_SHIFT_MOD, 34), False,),
         # 6) 'zoom_in' Shift+Ctrl+B
-        (("70", 98, CONTROL_SHIFT_MOD, 56), False,),
+        (("71", 98, CONTROL_SHIFT_MOD, 56), False,),
     ],
 )
 def test_message_dialog_is_shown_on_duplicate_accel_assignment(
@@ -120,13 +120,13 @@ def test_message_dialog_is_shown_on_duplicate_accel_assignment(
     "accel_params",
     [
         # 1) 'edit_tab_title' Ctrl+Alt+A
-        ("9", 97, CONTROL_ALT_MOD, 38),
-        # 2) 'edit_terminal_title' Ctrl+Alt+A
         ("10", 97, CONTROL_ALT_MOD, 38),
+        # 2) 'edit_terminal_title' Ctrl+Alt+A
+        ("11", 97, CONTROL_ALT_MOD, 38),
         # 3) 'edit_window_title' F11
-        ("11", 65480, Gdk.ModifierType(0), 95),
+        ("12", 65480, Gdk.ModifierType(0), 95),
         # 4) 'zoom_in' Shift+Ctrl+Z
-        ("70", 122, CONTROL_SHIFT_MOD, 52),
+        ("71", 122, CONTROL_SHIFT_MOD, 52),
     ],
 )
 def test_duplicate_accels_not_possible_to_set(accel_params):


### PR DESCRIPTION
# Background

Occasionally I drag a tab out of my terminator window on Gnome/Wayland and drop it, and it gets lost forever (but I think is still running!).

# What

- Fix dragging a tab out of a window crashing the whole app - every window at once (#1022)
- Add an explicit Detach Tab action: `Shift+Ctrl+D` keybinding + right-click menu item (tabs containing splits detach whole)
- Stop a failed tab drag leaving the snapped-back tab label undrawn on Wayland

# Why

The [gdb log attached to #1022](https://github.com/user-attachments/files/22393533/gdb.log) shows the segfault inside GTK's own drag-end handling:

```
#0  gtk_notebook_drag_end (...) at ../gtk/gtk/gtknotebook.c:3743
3743      _gtk_bin_set_child (GTK_BIN (priv->dnd_window), NULL);
```

GTK emits `create-window` in the middle of its drag bookkeeping, and our handler removed the page on the spot. With exactly two tabs, `hoover()` then dissolved the whole notebook, freeing `priv->dnd_window` before GTK's `drag-end` handler dereferences it (hence intermittent: 3+ tabs, no collapse, no crash). One Python process hosts every window, so "all instances crash".

The explicit action matters because on Wayland GTK only emits `create-window` for drops on shell chrome or bare desktop ([GTK#46](https://gitlab.gnome.org/GNOME/gtk/-/issues/46)) - dropping a tab on any window can never detach, and that's not fixable app-side.

# How

- `create_window_detach` now just schedules the detach with `GObject.idle_add`; the page is moved after the drag has fully ended, never inside the emission
- New `detach-tab` terminal signal wired like `move-tab`, driving the keybinding and menu item
- `queue_resize` after a failed tab drag so the restored label repaints ([GTK#3143](https://gitlab.gnome.org/GNOME/gtk/-/issues/3143))
- Verified on GNOME 50.1 Wayland via a nested compositor with injected drags: keyboard/menu/desktop-drop detach all work, drops on app windows snap back safely. Only test change is row indices in `test_prefseditor_keybindings.py` (the new binding sorts before `edit_*`)

Credit where due: Claude did the gdb spelunking and the nested-compositor testing.
