### PR TITLE
Consume Ctrl+click after opening a URL so it isn't opened twice

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1121,11 +1121,17 @@ class Terminal(Gtk.VBox):
                 dbg('url: %s' % url)
                 if url:
                     self.open_url(url, prepare=False)
+                    # Consume the event: the click we just acted on must not
+                    # also be forwarded to the application underneath. Apps that
+                    # enable mouse reporting and treat Ctrl+click as "open link"
+                    # (e.g. TUIs) would otherwise open the same URL a second time.
+                    return True
                 else:
                     dbg('OSC-8 URL not detected dropping back to regex match')
                     url = self.vte.match_check_event(event)
                     if url[0]:
                         self.open_url(url, prepare=True)
+                        return True
                     else:
                         dbg("No regex match, discard event.")
         elif event.button == self.MOUSEBUTTON_MIDDLE:


### PR DESCRIPTION
## What

On a **Ctrl+click** on a URL, `on_buttonpress` opens the link but never returns `True`, so GTK keeps propagating the `button-press-event`. With mouse reporting enabled, VTE forwards the same click to the foreground application. TUIs that treat Ctrl+click as "open link" (e.g. Claude Code, and comparable vim/tmux mouse setups) then open the **same URL a second time**, producing **two browser tabs** from a single click.

This returns `True` once a URL has actually been opened, so Terminator consumes the click it just handled. Clicks that don't hit a URL still fall through unchanged (selection, etc. are unaffected).

## Why it happens

`terminatorlib/terminal.py`, `on_buttonpress`, `MOUSEBUTTON_LEFT` branch — the two paths that call `open_url()` fall through without stopping the event, so the click reaches both Terminator's URL handler and the application underneath.

## Evidence

Pointing the default `http(s)` handler at a logging wrapper, a single Ctrl+click:

- in a **normal shell** (no mouse reporting): **1** browser launch ✅
- inside a **mouse-reporting TUI**: **2** launches ~0.5s apart — one from Terminator, one from the app ❌

With this change, the mouse-reporting case drops back to a single launch.

Fixes #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)