### PR TITLE
Prevent background terminals from flickering the window title

### DIFF
--- a/terminatorlib/window.py
+++ b/terminatorlib/window.py
@@ -1173,9 +1173,17 @@ class WindowTitle(object):
 
     def set_title(self, widget, text):
         """Set the title"""
-        if not self.forced:
-            self.text = text
-            self.update()
+        if self.forced:
+            return
+
+        # Background terminals can keep emitting OSC title changes. Their
+        # pane and tab labels should update, but they must not overwrite the
+        # desktop window title owned by the focused terminal.
+        if widget is not None and not widget.get_vte().is_focus():
+            return
+
+        self.text = text
+        self.update()
 
     def force_title(self, newtext):
         """Force a specific title"""

--- a/tests/test_window_title.py
+++ b/tests/test_window_title.py
@@ -1,0 +1,53 @@
+"""Tests for top-level window title handling."""
+
+import os
+import sys
+
+import gi
+
+sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), "..")))
+gi.require_version("Gtk", "3.0")
+
+from terminatorlib.window import WindowTitle
+
+
+class FakeWindow:
+    """Record titles passed to the native window."""
+
+    def __init__(self):
+        self.titles = []
+
+    def set_title(self, title):
+        self.titles.append(title)
+
+
+class FakeVte:
+    """Expose the focus state used by WindowTitle."""
+
+    def __init__(self, focused):
+        self.focused = focused
+
+    def is_focus(self):
+        return self.focused
+
+
+class FakeTerminal:
+    """Provide the VTE widget associated with a title change."""
+
+    def __init__(self, focused):
+        self.vte = FakeVte(focused)
+
+    def get_vte(self):
+        return self.vte
+
+
+def test_background_terminal_cannot_override_window_title():
+    """Only the terminal owning focus should control the desktop title."""
+    window = FakeWindow()
+    title = WindowTitle(window)
+
+    title.set_title(FakeTerminal(focused=True), "focused terminal")
+    title.set_title(FakeTerminal(focused=False), "background terminal")
+
+    assert title.text == "focused terminal"
+    assert window.titles == ["focused terminal"]


### PR DESCRIPTION
## Summary

- only let the terminal that owns focus within a Terminator window update the desktop window title
- keep background terminals' pane and tab title updates unchanged
- add a regression test for competing foreground/background title signals

## Problem

Every VTE `window-title-changed` signal currently reaches `WindowTitle`, even when it came from an unfocused pane or tab. A background process that emits OSC 0/2 title sequences can therefore overwrite the focused terminal's desktop window title. With frequent title updates, the title visibly flashes between panes.

For example, start this in one pane and then focus another pane:

```sh
while :; do
    printf '\033]0;background-a\007'
    sleep 0.1
    printf '\033]0;background-b\007'
    sleep 0.1
done
```

## Fix

Ignore top-level window title updates from VTE widgets that do not own focus within their GTK window. This check uses `is_focus()` rather than `has_focus()`, so the correct terminal can still update its window title while the entire Terminator window is inactive.

The filtering is done in `WindowTitle`, after pane and tab labels have already been updated, so those labels retain their existing behavior. Forced/custom window titles also retain their existing behavior.

## Tests

- `pytest -q tests/test_window_title.py`
- `python3 -m compileall -q -f terminatorlib tests remotinator terminator`
- real GTK focus check covering focused/background widgets and an inactive top-level window
