### PR TITLE
Only open a URL on the initial button press

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1114,8 +1114,13 @@ class Terminal(Gtk.VBox):
 
         # Ctrl-click event here.
         if event.button == self.MOUSEBUTTON_LEFT:
-            # Ctrl+leftclick on a URL should open it
-            if self.config["link_single_click"] or event.get_state() & Gdk.ModifierType.CONTROL_MASK == Gdk.ModifierType.CONTROL_MASK:
+            # Ctrl+leftclick on a URL should open it. Only the initial press
+            # counts: GDK reports a double-click as BUTTON_PRESS followed by
+            # _2BUTTON_PRESS, so acting on every event type would open the URL
+            # once per event.
+            if (event.type == Gdk.EventType.BUTTON_PRESS
+                    and (self.config["link_single_click"]
+                         or event.get_state() & Gdk.ModifierType.CONTROL_MASK == Gdk.ModifierType.CONTROL_MASK)):
                 # Check new OSC-8 method first
                 url = self.vte.hyperlink_check_event(event)
                 dbg('url: %s' % url)


### PR DESCRIPTION
## Problem

Ctrl+double-clicking a URL opens it **twice** — the browser gets two tabs for one gesture.

GDK delivers a double-click as `BUTTON_PRESS`, `BUTTON_RELEASE`, `BUTTON_PRESS`, `_2BUTTON_PRESS`. The URL branch of `on_buttonpress` tests only `event.button` and the Ctrl modifier:

```python
if event.button == self.MOUSEBUTTON_LEFT:
    # Ctrl+leftclick on a URL should open it
    if self.config["link_single_click"] or event.get_state() & Gdk.ModifierType.CONTROL_MASK == Gdk.ModifierType.CONTROL_MASK:
```

so both the second `BUTTON_PRESS` and the `_2BUTTON_PRESS` reach `open_url()`. The `_2BUTTON_PRESS` guard near the top of the handler only covers `Gtk.VScrollbar`, not the terminal widget.

Same symptom in two other situations:
- `link_single_click` enabled — an ordinary double-click on a URL opens two tabs
- mouse switch bounce landing inside the double-click interval

## Fix

Gate the URL branch on `event.type == Gdk.EventType.BUTTON_PRESS`.

Later event types fall through to the handler's closing `return False`, so VTE keeps handling double-click word selection and triple-click line selection exactly as before — only the duplicate `open_url()` calls go away.

## Testing

Reproduced and verified on 2.1.3 (Ubuntu noble, GTK3, Wayland session, VTE 7600), with both link paths — OSC-8 hyperlinks via `hyperlink_check_event` and plain URLs via the regex `match_check_event`. Ctrl+double-click gave two browser tabs before the change and one after. Word and line selection unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)