### PR TITLE
Update immediately titlebar background color on D-Bus profile switch

### DIFF
--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -924,7 +924,15 @@ class Terminal(Gtk.VBox):
             elif self.config['scrollbar_position'] == 'right':
                 self.terminalbox.reorder_child(self.vte, 0)
 
-        self.titlebar.update()
+        toplevel = self.get_toplevel()
+        if isinstance(toplevel, Gtk.Window) and toplevel.has_toplevel_focus():
+            focused = self.terminator.get_focussed_terminal()
+            if focused is None:
+                focused = self.terminator.last_focused_term
+            self.titlebar.update(focused or self)
+        else:
+            self.titlebar.update('window-focus-out')
+
         self.vte.queue_draw()
 
     def set_cursor_color(self):


### PR DESCRIPTION
When switching profile at runtime, for example through D-Bus using the command `remotinator switch_profile -p <profile>`, the titlebar color is not updated immediately. The color is only refreshed after the Terminator windows loses and regains focus.

Terminal.reconfigure() calls Titlebar.update() without providing the current focus context, so profile-dependent titlebar colors are not recalculated.

This change determines whether the toplevel window currently has input focus and update the titlebar accordingly.