### PR TITLE
Confirm right-click terminal Close menu action

### DIFF
--- a/terminatorlib/terminal_popup_menu.py
+++ b/terminatorlib/terminal_popup_menu.py
@@ -84,6 +84,23 @@ class TerminalPopupMenu(object):
                                 Gtk.AccelFlags.VISIBLE)
         return item
 
+    def close_terminal(self, _menuitem=None):
+        """Close the terminal after applying the normal close confirmation."""
+        terminal = self.terminal
+        container = terminal.get_parent()
+
+        while container and not hasattr(container, 'construct_confirm_close'):
+            container = container.get_parent()
+
+        if container:
+            confirm_close = container.construct_confirm_close(
+                terminal.get_toplevel(), terminal)
+            if confirm_close != Gtk.ResponseType.ACCEPT:
+                dbg('user cancelled request')
+                return
+
+        terminal.close()
+
     def show(self, widget, event=None):
         """Display the context menu"""
         terminal = self.terminal
@@ -224,7 +241,7 @@ class TerminalPopupMenu(object):
             menu.append(Gtk.SeparatorMenuItem())
 
         item = self.menu_item(Gtk.ImageMenuItem, 'close_term', _('_Close'))
-        item.connect('activate', lambda x: terminal.close())
+        item.connect('activate', self.close_terminal)
         menu.append(item)
 
         menu.append(Gtk.SeparatorMenuItem())

--- a/tests/test_terminal_popup_menu.py
+++ b/tests/test_terminal_popup_menu.py
@@ -1,0 +1,98 @@
+"""Tests for terminal context menu actions."""
+
+import os
+import sys
+
+import gi
+
+sys.path.insert(0, os.path.realpath(os.path.join(os.path.dirname(__file__), "..")))
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gtk
+
+from terminatorlib.terminal_popup_menu import TerminalPopupMenu
+
+
+class FakeContainer:
+    """Container recording confirmation requests."""
+
+    def __init__(self, response, parent=None):
+        self.response = response
+        self.parent = parent
+        self.confirmations = []
+
+    def construct_confirm_close(self, window, child):
+        self.confirmations.append((window, child))
+        return self.response
+
+    def get_parent(self):
+        return self.parent
+
+
+class FakeParent:
+    """Intermediate widget without close confirmation behavior."""
+
+    def __init__(self, parent):
+        self.parent = parent
+
+    def get_parent(self):
+        return self.parent
+
+
+class FakeTerminal:
+    """Terminal recording close calls."""
+
+    def __init__(self, parent=None, toplevel=None):
+        self.parent = parent
+        self.toplevel = toplevel
+        self.closed = False
+
+    def get_parent(self):
+        return self.parent
+
+    def get_toplevel(self):
+        return self.toplevel
+
+    def close(self):
+        self.closed = True
+
+
+def popup_for(terminal):
+    popup = TerminalPopupMenu.__new__(TerminalPopupMenu)
+    popup.terminal = terminal
+    return popup
+
+
+def test_close_terminal_closes_after_confirmation_accepts():
+    """Context menu close uses the container confirmation path."""
+    window = object()
+    container = FakeContainer(Gtk.ResponseType.ACCEPT)
+    terminal = FakeTerminal(parent=container, toplevel=window)
+
+    popup_for(terminal).close_terminal()
+
+    assert terminal.closed
+    assert container.confirmations == [(window, terminal)]
+
+
+def test_close_terminal_keeps_terminal_open_when_confirmation_rejects():
+    """A rejected confirmation prevents context menu close."""
+    container = FakeContainer(Gtk.ResponseType.REJECT)
+    terminal = FakeTerminal(parent=container, toplevel=object())
+
+    popup_for(terminal).close_terminal()
+
+    assert not terminal.closed
+    assert container.confirmations == [(terminal.get_toplevel(), terminal)]
+
+
+def test_close_terminal_finds_confirmation_container_above_parent_widget():
+    """Intermediate GTK widgets do not bypass close confirmation."""
+    container = FakeContainer(Gtk.ResponseType.ACCEPT)
+    parent = FakeParent(container)
+    terminal = FakeTerminal(parent=parent, toplevel=object())
+
+    popup_for(terminal).close_terminal()
+
+    assert terminal.closed
+    assert container.confirmations == [(terminal.get_toplevel(), terminal)]


### PR DESCRIPTION
## Summary
- route the terminal right-click -> Close menu action through the existing close confirmation logic
- keep the previous direct close behavior when confirmation is accepted or not required
- add regression tests for accepted, rejected, and nested-parent confirmation paths

## Testing
- .venv/bin/python -m pytest tests/test_terminal_popup_menu.py
- python3 -m py_compile terminatorlib/*.py tests/*.py

Note: running the full tests/ suite in this local environment segfaulted in an existing VTE-heavy preferences/keybindings test while constructing Terminal, before this new test file was reached.