### PR TITLE
Add option to span background image across window

### DIFF
--- a/doc/terminator_config.5
+++ b/doc/terminator_config.5
@@ -1135,6 +1135,16 @@ Specify the path to an image that will be used as background.
 This option is ignored unless \fBbackground_type\fP is set to \*(Aqimage\*(Aq.
 .RE
 .sp
+\fBbackground_image_span_window\fP = \fIboolean\fP
+.RS 4
+If set to True, the background image is scaled and aligned relative to the
+entire window, and each terminal draws the corresponding section.
+If set to False, each terminal draws a complete copy of the background image.
+This option is ignored unless \fBbackground_type\fP is set to \*(Aqimage\*(Aq.
+.br
+Default value: \fBFalse\fP
+.RE
+.sp
 \fBbackground_image_mode\fP = \fIstring\fP
 .RS 4
 Specify how the background image will be drawn.

--- a/doc/terminator_config.adoc
+++ b/doc/terminator_config.adoc
@@ -760,6 +760,13 @@ Default value: *solid*
 Specify the path to an image that will be used as background.
 This option is ignored unless *background_type* is set to 'image'.
 
+*background_image_span_window* = _boolean_::
+If set to True, the background image is scaled and aligned relative to the
+entire window, and each terminal draws the corresponding section.
+If set to False, each terminal draws a complete copy of the background image.
+This option is ignored unless *background_type* is set to 'image'. +
+Default value: *False*
+
 *background_image_mode* = _string_::
 Specify how the background image will be drawn.
 'stretch_and_fill' to fill the terminal entirely, without necessarily

--- a/terminatorlib/config.py
+++ b/terminatorlib/config.py
@@ -221,6 +221,7 @@ DEFAULTS = {
                 'background_type'       : 'solid',
                 'background_image'      : '',
                 'background_image_mode' : 'stretch_and_fill',
+                'background_image_span_window': False,
                 'background_image_align_horiz': 'center',
                 'background_image_align_vert' : 'middle',
                 'background_blur'       : False,

--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -3090,6 +3090,22 @@
                                     <property name="position">2</property>
                                   </packing>
                                 </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="background_image_span_window_checkbutton">
+                                    <property name="label" translatable="yes">Span background image across the window</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw-indicator">True</property>
+                                    <signal name="toggled" handler="on_background_image_span_window_checkbutton_toggled" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
                               </object>
                             </child>
                           </object>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -765,6 +765,9 @@ class PrefsEditor:
             # default to stretch_and_fill
             widget.set_active(0)
 
+        widget = guiget('background_image_span_window_checkbutton')
+        widget.set_active(self.config['background_image_span_window'])
+
         widget = guiget('background_image_align_horiz_combobox')
         if self.config['background_image_align_horiz'] == 'center':
             widget.set_active(1)
@@ -1120,6 +1123,10 @@ class PrefsEditor:
         else:
             value = 'stretch_and_fill'
         self.config['background_image_mode'] = value
+        self.config.save()
+
+    def on_background_image_span_window_checkbutton_toggled(self, widget):
+        self.config['background_image_span_window'] = widget.get_active()
         self.config.save()
 
     def on_background_image_align_horiz_changed(self, widget):
@@ -1786,6 +1793,7 @@ class PrefsEditor:
 
         # toggle sensitivity of widgets related to background image
         for element in ('background_image_file',
+                        'background_image_span_window_checkbutton',
                         'background_image_align_horiz_combobox',
                         'background_image_align_vert_combobox',
                         'background_image_mode_combobox'):

--- a/terminatorlib/terminal.py
+++ b/terminatorlib/terminal.py
@@ -1285,7 +1285,16 @@ class Terminal(Gtk.VBox):
         image_align_horiz = self.config['background_image_align_horiz']
         image_align_vert = self.config['background_image_align_vert']
 
-        rect = self.vte.get_allocation()
+        rect = widget.get_allocation()
+        origin_x = 0
+        origin_y = 0
+        if self.config['background_image_span_window']:
+            toplevel = widget.get_toplevel()
+            translated = widget.translate_coordinates(toplevel, 0, 0)
+            if translated:
+                rect = toplevel.get_allocation()
+                origin_x, origin_y = translated
+
         xratio = float(rect.width) / float(self.background_image.get_width())
         yratio = float(rect.height) / float(self.background_image.get_height())
         if image_mode == 'stretch_and_fill':
@@ -1302,17 +1311,19 @@ class Terminal(Gtk.VBox):
             xratio = yratio = 1
         cr.scale(xratio, yratio)
 
-        xoffset = 0
-        yoffset = 0
+        xoffset = -origin_x / xratio
+        yoffset = -origin_y / yratio
         if image_align_horiz == 'center':
-            xoffset = (rect.width / xratio - self.background_image.get_width()) / 2
+            xoffset += (rect.width / xratio -
+                        self.background_image.get_width()) / 2
         elif image_align_horiz == 'right':
-            xoffset = rect.width / xratio - self.background_image.get_width()
+            xoffset += rect.width / xratio - self.background_image.get_width()
 
         if image_align_vert == 'middle':
-            yoffset = (rect.height / yratio - self.background_image.get_height()) / 2
+            yoffset += (rect.height / yratio -
+                        self.background_image.get_height()) / 2
         elif image_align_vert == 'bottom':
-            yoffset = rect.height / yratio - self.background_image.get_height()
+            yoffset += rect.height / yratio - self.background_image.get_height()
 
         cr.set_source_surface(self.background_image, xoffset, yoffset)
         cr.get_source().set_filter(cairo.Filter.FAST)


### PR DESCRIPTION
## Summary

- Add a per-profile option to span a background image across the window.
- Scale and align the image using the top-level window dimensions.
- Have each terminal paint the corresponding window-relative section.
- Preserve the existing per-terminal behavior by default.
- Reuse the existing drawing modes, alignment, and shading settings.

## Motivation

Closes #608.

This is an alternative approach to the draft implementation in #612.
Instead of introducing a window-owned background image, it preserves the
existing per-profile image configuration and aligns each terminal's rendering
in window coordinates. This avoids choosing which terminal profile owns the
window background and does not alter the Window/Notebook/Paned hierarchy.

Related to #635. Builds on the drawing modes introduced by #713.

## Verification

- Python syntax parsing passed.
- Glade XML parsing passed.
- Manually tested with multiple panes, resizing, and fullscreen.
- Full automated test suite: not run.

## AI assistance

Codex assisted with codebase inspection and implementation.