### PR TITLE
Add Apply button to preferences

### DIFF
--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -4539,6 +4539,22 @@ Much of the behavior of Terminator is based on GNOME Terminal, and we are adding
               </packing>
             </child>
             <child>
+              <object class="GtkButton" id="applybutton">
+                <property name="label">gtk-apply</property>
+                <property name="use-action-appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_applybutton_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="okbutton">
                 <property name="label">gtk-close</property>
                 <property name="use-action-appearance">False</property>
@@ -4551,7 +4567,7 @@ Much of the behavior of Terminator is based on GNOME Terminal, and we are adding
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>

--- a/terminatorlib/prefseditor.py
+++ b/terminatorlib/prefseditor.py
@@ -241,11 +241,15 @@ class PrefsEditor:
     def on_destroy_event(self, _widget):
         self.config.base.remove_config_with_suffix('_cur')
 
+    def on_applybutton_clicked(self, _button):
+        """Apply configuration changes without closing the window"""
+        terminator = Terminator()
+        terminator.reconfigure()
+
     def on_closebutton_clicked(self, _button):
         """Close the window"""
         self.config.base.remove_config_with_suffix('_cur')
-        terminator = Terminator()
-        terminator.reconfigure()
+        self.on_applybutton_clicked(_button)
         self.window.destroy()
         self.calling_window.preventHide = False
         del(self)


### PR DESCRIPTION
## Summary

- Add an Apply button to the Preferences window.
- Apply configuration changes without closing Preferences.
- Keep the user on the currently selected page and profile.
- Reuse the same Apply path when closing Preferences.

This makes it easier to adjust settings interactively without repeatedly
closing and reopening the Preferences window.

## Verification

- Python syntax parsing passed.
- Glade XML parsing passed.
- Manually verified that Apply updates open terminals without closing
  Preferences.
- Manually verified that Apply can be used repeatedly.
- Close behavior remains unchanged.

## Notes

The existing Discard Changes behavior is not modified by this pull request.
Its runtime rollback behavior appears to be a separate pre-existing issue.

## AI assistance

Codex assisted with codebase inspection and implementation.